### PR TITLE
Port shift decider to ros2

### DIFF
--- a/control/shift_decider/CMakeLists.txt
+++ b/control/shift_decider/CMakeLists.txt
@@ -1,40 +1,16 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(shift_decider)
 
-add_compile_options(-std=c++14)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
-find_package(
-  catkin REQUIRED COMPONENTS
-    autoware_control_msgs
-    autoware_vehicle_msgs
-    roscpp
-)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
-catkin_package(
-  INCLUDE_DIRS include
-  CATKIN_DEPENDS
-    autoware_control_msgs
-    autoware_vehicle_msgs
-    roscpp
-)
+ament_auto_add_executable(shift_decider src/shift_decider.cpp src/main.cpp)
 
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-)
-
-add_executable(shift_decider src/shift_decider.cpp src/main.cpp)
-target_link_libraries(shift_decider ${catkin_LIBRARIES})
-add_dependencies(shift_decider ${catkin_EXPORTED_TARGETS})
-
-install(
-  TARGETS shift_decider
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-install(
-  DIRECTORY launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+ament_auto_package(
+  INSTALL_TO_SHARE
+  launch
+  )

--- a/control/shift_decider/include/shift_decider/shift_decider.h
+++ b/control/shift_decider/include/shift_decider/shift_decider.h
@@ -17,31 +17,29 @@
 #ifndef CONTROL_SHIFT_DECIDER_INCLUDE_SHIFT_DECIDER_NODE_HPP_
 #define CONTROL_SHIFT_DECIDER_INCLUDE_SHIFT_DECIDER_NODE_HPP_
 
+#include <autoware_control_msgs/msg/control_command_stamped.hpp>
+#include <autoware_vehicle_msgs/msg/shift_stamped.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+
 #include <memory>
 
-#include <ros/ros.h>
-
-#include <autoware_control_msgs/ControlCommandStamped.h>
-#include <autoware_vehicle_msgs/ShiftStamped.h>
-
-class ShiftDecider
+class ShiftDecider : public rclcpp::Node
 {
 public:
   ShiftDecider();
 
 private:
-  void onTimer(const ros::TimerEvent & e);
-  void onControlCmd(const autoware_control_msgs::ControlCommandStamped::ConstPtr msg);
+  void onTimer();
+  void onControlCmd(autoware_control_msgs::msg::ControlCommandStamped::SharedPtr msg);
   void updateCurrentShiftCmd();
 
-  ros::NodeHandle nh_{""};
-  ros::NodeHandle pnh_{"~"};
-  ros::Publisher pub_shift_cmd_;
-  ros::Subscriber sub_control_cmd_;
-  ros::Timer timer_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::ShiftStamped>::SharedPtr pub_shift_cmd_;
+  rclcpp::Subscription<autoware_control_msgs::msg::ControlCommandStamped>::SharedPtr sub_control_cmd_;
+  rclcpp::TimerBase::SharedPtr timer_;
 
-  autoware_control_msgs::ControlCommandStamped::ConstPtr control_cmd_;
-  autoware_vehicle_msgs::ShiftStamped shift_cmd_;
+  autoware_control_msgs::msg::ControlCommandStamped::SharedPtr control_cmd_;
+  autoware_vehicle_msgs::msg::ShiftStamped shift_cmd_;
 };
 
 #endif  // CONTROL_SHIFT_DECIDER_INCLUDE_SHIFT_DECIDER_NODE_HPP_

--- a/control/shift_decider/include/shift_decider/shift_decider.h
+++ b/control/shift_decider/include/shift_decider/shift_decider.h
@@ -33,9 +33,11 @@ private:
   void onTimer();
   void onControlCmd(autoware_control_msgs::msg::ControlCommandStamped::SharedPtr msg);
   void updateCurrentShiftCmd();
+  void initTimer(double period_s);
 
   rclcpp::Publisher<autoware_vehicle_msgs::msg::ShiftStamped>::SharedPtr pub_shift_cmd_;
-  rclcpp::Subscription<autoware_control_msgs::msg::ControlCommandStamped>::SharedPtr sub_control_cmd_;
+  rclcpp::Subscription<autoware_control_msgs::msg::ControlCommandStamped>::SharedPtr
+    sub_control_cmd_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   autoware_control_msgs::msg::ControlCommandStamped::SharedPtr control_cmd_;

--- a/control/shift_decider/launch/shift_decider.launch
+++ b/control/shift_decider/launch/shift_decider.launch
@@ -1,6 +1,0 @@
-<launch>
-  <node pkg="shift_decider" type="shift_decider" name="shift_decider" output="screen">
-    <remap from="~input/control_cmd" to="/control/trajectory_follower/control_cmd" />
-    <remap from="~output/shift_cmd" to="/control/shift_decider/shift_cmd" />
-  </node>
-</launch>

--- a/control/shift_decider/launch/shift_decider.launch.xml
+++ b/control/shift_decider/launch/shift_decider.launch.xml
@@ -1,0 +1,6 @@
+<launch>
+  <node pkg="shift_decider" exec="shift_decider" name="shift_decider" output="screen">
+    <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd" />
+    <remap from="output/shift_cmd" to="/control/shift_decider/shift_cmd" />
+  </node>
+</launch>

--- a/control/shift_decider/package.xml
+++ b/control/shift_decider/package.xml
@@ -7,9 +7,13 @@
   <author email="horibe.takamasa@gmail.com">Takamasa Horibe</author>
   <license>Apache 2</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+  <build_type>ament_cmake</build_type>
+  </export>
 
   <depend>autoware_control_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
-  <depend>roscpp</depend>
+  <depend>rclcpp</depend>
 </package>

--- a/control/shift_decider/src/main.cpp
+++ b/control/shift_decider/src/main.cpp
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-#include <ros/ros.h>
 
 #include <shift_decider/shift_decider.h>
 
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+
 int main(int argc, char ** argv)
 {
-  ros::init(argc, argv, "shift_decider");
+  rclcpp::init(argc, argv);
 
-  ShiftDecider obj;
-  ros::spin();
+  rclcpp::spin(std::make_shared<ShiftDecider>());
+  rclcpp::shutdown();
 
   return 0;
 }

--- a/control/shift_decider/src/main.cpp
+++ b/control/shift_decider/src/main.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 #include <shift_decider/shift_decider.h>
 
 #include <rclcpp/rclcpp.hpp>


### PR DESCRIPTION
I ported the code similar in a similar fashion to what @nnmm did with the `vehicle_cmd_gate` and took the review comments given on that [PR](https://github.com/tier4/autoware.iv.universe/pull/3). The PR currently suffers from the same limitation that a jump in sim time would be treated differently than in the previous version. Before implementing a hack, we should agree on a common solution and then implement it in all packages to be ported.

The first commit of this PR is the previous ROS1 version of the code.
 
The node builds and runs fine with 

    ros2 launch shift_decider shift_decider.launch.xml

@nnmm @dejanpan @mitsudome-r 