### PR TITLE
ROS2 Porting: geo_pos_conv

### DIFF
--- a/sensing/preprocessor/gnss/geo_pos_conv/CHANGELOG.rst
+++ b/sensing/preprocessor/gnss/geo_pos_conv/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package geo_pos_conv
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.0 (2020-10-03)
+------------------
+* Convert package to ROS2
+
 1.11.0 (2019-03-21)
 -------------------
 * add constructor (`#1913 <https://github.com/CPFL/Autoware/issues/1913>`_)

--- a/sensing/preprocessor/gnss/geo_pos_conv/CMakeLists.txt
+++ b/sensing/preprocessor/gnss/geo_pos_conv/CMakeLists.txt
@@ -29,8 +29,10 @@ target_include_directories(geo_pos_conv
 ament_target_dependencies(geo_pos_conv rclcpp)
 
 ### Install library
-ament_export_interfaces(geo_pos_conv HAS_LIBRARY_TARGET)
+ament_export_targets(geo_pos_conv HAS_LIBRARY_TARGET)
 ament_export_dependencies(rclcpp)
+# ament_export_include_directories(include)
+# ament_export_libraries(geo_pos_conv)
 
 install(
   DIRECTORY include/

--- a/sensing/preprocessor/gnss/geo_pos_conv/CMakeLists.txt
+++ b/sensing/preprocessor/gnss/geo_pos_conv/CMakeLists.txt
@@ -6,7 +6,6 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  # add_compile_options(-Wall -Wextra -Wpedantic)
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
 endif()
 
@@ -31,8 +30,6 @@ ament_target_dependencies(geo_pos_conv rclcpp)
 ### Install library
 ament_export_targets(geo_pos_conv HAS_LIBRARY_TARGET)
 ament_export_dependencies(rclcpp)
-# ament_export_include_directories(include)
-# ament_export_libraries(geo_pos_conv)
 
 install(
   DIRECTORY include/

--- a/sensing/preprocessor/gnss/geo_pos_conv/CMakeLists.txt
+++ b/sensing/preprocessor/gnss/geo_pos_conv/CMakeLists.txt
@@ -1,32 +1,49 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(geo_pos_conv)
 
-find_package(catkin REQUIRED COMPONENTS roscpp)
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
+endif()
 
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES geo_pos_conv
-)
+### Add dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
 
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-)
 
+### Create library
 add_library(geo_pos_conv
   src/geo_pos_conv.cpp
 )
 
-target_link_libraries(geo_pos_conv
-  ${catkin_LIBRARIES}
+target_include_directories(geo_pos_conv
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+ament_target_dependencies(geo_pos_conv rclcpp)
+
+### Install library
+ament_export_interfaces(geo_pos_conv HAS_LIBRARY_TARGET)
+ament_export_dependencies(rclcpp)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
 )
 
-install(TARGETS geo_pos_conv
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+install(
+  TARGETS geo_pos_conv
+  EXPORT geo_pos_conv
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
 )
+
+ament_package()

--- a/sensing/preprocessor/gnss/geo_pos_conv/package.xml
+++ b/sensing/preprocessor/gnss/geo_pos_conv/package.xml
@@ -1,12 +1,23 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>geo_pos_conv</name>
-  <version>0.1.0</version>
-  <description>The geo_pos_conv package</description>
+  <version>2.0.0</version>
+  <description>The ROS2 geo_pos_conv package</description>
   <maintainer email="ryo.watanabe@tier4.jp">Ryo Watanabe</maintainer>
   <maintainer email="tomo@axe.bz">Tomomi HORII</maintainer>
-  <license>Apache 2</license>
+  <!-- ROS2 -->
+  <maintainer email="jilada.eccleston@tier4.jp">Jilada ECCLESTON</maintainer>
+  <license>Apache License 2.0</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <depend>roscpp</depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rclcpp_components</build_depend>
+
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclcpp_components</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/sensing/preprocessor/gnss/geo_pos_conv/package.xml
+++ b/sensing/preprocessor/gnss/geo_pos_conv/package.xml
@@ -11,6 +11,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>
 


### PR DESCRIPTION
# geo_pos_conv

## Summary
The conversion of this package was fairly straightforward because its a library with no executable
* Follow [this convention](https://index.ros.org/doc/ros2/Tutorials/Ament-CMake-Documentation/#building-a-library) for the structuring the `CMakelist.txt`. I am new to ROS2 so please let me know if this has not been executed correctly, or if I have added any redundancy. 
* Update the changelog the increased the release number to 2.0.0.
* Update the package.xml
* There are no code changes required in any of the source files as they are purely C++ with no ROS dependencies.

## Testing
This was a little difficult to test due to the lack of test code however, I was also porting the `gnss_poser` package simultaneously and making sure that the package could be found using CMake. Let me know if there are any other testing practices to test the port, alternatively I can add some simple test code - though really what needs to be tested is that other packages can find and use this library. For now, this branch compiles without issue using Foxy.

## Discussion Points
* The function `conv_xyz2llh` is not implemented, I believe this should really throw some sort of logic_error exception or removed. Not sure if there is any effort to also make these types of superficial changes to the code yet so I have left it as is. 
* There are multiple different licences added to the source code belonging to different entities. Should these be consolidated across packages (maybe I am unaware of any discussion already surrounding this)? 
