### PR TITLE
add apt update command to ci

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install missing dependencies
-      run: rosdep update && DEBIAN_FRONTEND=noninteractive sudo rosdep install --from-paths . --ignore-src --rosdistro foxy -y
+      run: sudo apt update && rosdep update && DEBIAN_FRONTEND=noninteractive sudo rosdep install --from-paths . --ignore-src --rosdistro foxy -y
 
     - name: Build
       run: . /opt/ros/foxy/setup.sh && colcon build --event-handlers console_cohesion+


### PR DESCRIPTION
This adds `apt update` command before running `rosdep install` so that it can find packages.
This should fix the ci error occurring in this PR https://github.com/tier4/Pilot.Auto/pull/11 for example.