### PR TITLE
Port osqp interface to ROS2

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,9 +15,6 @@ jobs:
     - name: Check out repo
       uses: actions/checkout@v2
 
-    - name: Install osqp_vendor
-      run: git clone https://github.com/tier4/osqp_vendor.git
-
     - name: Install missing dependencies
       run: sudo apt update && rosdep update && DEBIAN_FRONTEND=noninteractive sudo rosdep install --from-paths . --ignore-src --rosdistro foxy -y
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,6 +15,9 @@ jobs:
     - name: Check out repo
       uses: actions/checkout@v2
 
+    - name: Install osqp_vendor
+      run: git clone https://github.com/tier4/osqp_vendor.git
+
     - name: Install missing dependencies
       run: sudo apt update && rosdep update && DEBIAN_FRONTEND=noninteractive sudo rosdep install --from-paths . --ignore-src --rosdistro foxy -y
 

--- a/common/math/osqp_interface/CMakeLists.txt
+++ b/common/math/osqp_interface/CMakeLists.txt
@@ -14,6 +14,8 @@ ament_auto_find_build_dependencies()
 
 find_package(Eigen3 REQUIRED)
 
+find_package(osqp_vendor REQUIRED)
+
 find_package(osqp REQUIRED)
 get_target_property(OSQP_INCLUDE_DIR osqp::osqpstatic INTERFACE_INCLUDE_DIRECTORIES)
 

--- a/common/math/osqp_interface/CMakeLists.txt
+++ b/common/math/osqp_interface/CMakeLists.txt
@@ -15,14 +15,23 @@ ament_auto_find_build_dependencies()
 find_package(Eigen3 REQUIRED)
 
 find_package(osqp REQUIRED)
-get_target_property(osqp_INCLUDE_DIR osqp::osqpstatic INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(OSQP_INCLUDE_DIR osqp::osqpstatic INTERFACE_INCLUDE_DIRECTORIES)
 
-include_directories(
-  ${EIGEN3_INCLUDE_DIR}
-  ${osqp_INCLUDE_DIR}
+set(EXTERNAL_INCLUDE_DIRS
+  "${EIGEN3_INCLUDE_DIR}"
+  "${OSQP_INCLUDE_DIR}"
   )
 
-ament_auto_add_library(osqp_interface src/osqp_interface.cpp src/csc_matrix_conv.cpp)
+ament_auto_add_library(osqp_interface
+  src/osqp_interface.cpp
+  src/csc_matrix_conv.cpp
+  include/osqp_interface/osqp_interface.h
+  include/osqp_interface/csc_matrix_conv.h
+  )
 target_link_libraries(osqp_interface osqp::osqpstatic)
+
+target_include_directories(osqp_interface PUBLIC "${EXTERNAL_INCLUDE_DIRS}")
+# needed so clients of this package don't need to worry about includes of this package
+ament_export_include_directories("${EXTERNAL_INCLUDE_DIRS}")
 
 ament_auto_package()

--- a/common/math/osqp_interface/CMakeLists.txt
+++ b/common/math/osqp_interface/CMakeLists.txt
@@ -1,50 +1,28 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(osqp_interface)
 
-add_compile_options(-std=c++14 -Ofast)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  rostest
-  rosunit
-)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Ofast)
+endif()
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 find_package(Eigen3 REQUIRED)
 
 find_package(osqp REQUIRED)
 get_target_property(osqp_INCLUDE_DIR osqp::osqpstatic INTERFACE_INCLUDE_DIRECTORIES)
 
-catkin_package(
-  INCLUDE_DIRS
-    include
-    ${osqp_INCLUDE_DIR}
-  LIBRARIES
-    osqp_interface
-)
-
 include_directories(
-  include
   ${EIGEN3_INCLUDE_DIR}
   ${osqp_INCLUDE_DIR}
-  ${catkin_INCLUDE_DIRS}
-)
+  )
 
-add_library(osqp_interface src/osqp_interface.cpp src/csc_matrix_conv.cpp)
+ament_auto_add_library(osqp_interface src/osqp_interface.cpp src/csc_matrix_conv.cpp)
+target_link_libraries(osqp_interface osqp::osqpstatic)
 
-target_link_libraries(osqp_interface
-  osqp::osqpstatic
-  ${catkin_LIBRARIES}
-)
-
-install(
-  TARGETS
-    osqp_interface
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-## Install project namespaced headers
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
+ament_auto_package()

--- a/common/math/osqp_interface/package.xml
+++ b/common/math/osqp_interface/package.xml
@@ -6,11 +6,11 @@
   <maintainer email="robin.karlsson@tier4.jp">Robin Karlsson</maintainer>
   <license>Apache 2</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  
-  <depend>roscpp</depend>
-  <depend>rostest</depend>
-  <depend>rosunit</depend>
-  
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+
+  <depend>rclcpp</depend>
 </package>

--- a/common/math/osqp_interface/package.xml
+++ b/common/math/osqp_interface/package.xml
@@ -8,6 +8,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>osqp_vendor</depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/vendor/osqp_vendor/.github/workflows/build.yml
+++ b/vendor/osqp_vendor/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: CMake
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#configuring-a-build-matrix
+    runs-on: ubuntu-latest
+
+    container: ros:foxy
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build
+      run: . /opt/ros/foxy/setup.sh && colcon build
+
+    - name: Test
+      run: . /opt/ros/foxy/setup.sh && colcon test

--- a/vendor/osqp_vendor/CMakeLists.txt
+++ b/vendor/osqp_vendor/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.9)
+
+project(osqp_vendor)
+
+find_package(ament_cmake REQUIRED)
+
+macro(build_osqp)
+  set(extra_cmake_args)
+
+  get_property(multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+  if(NOT multi_config AND DEFINED CMAKE_BUILD_TYPE)
+    list(APPEND extra_cmake_args -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+  endif()
+
+  include(ExternalProject)
+  externalproject_add(osqp-v0.6.1.dev0
+    GIT_REPOSITORY https://github.com/oxfordcontrol/osqp.git
+    GIT_TAG v0.6.1.dev0
+    GIT_SHALLOW ON
+    TIMEOUT 60
+    CMAKE_ARGS
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/osqp_install
+      ${extra_cmake_args}
+  )
+
+  # The external project will install to the build folder, but we'll install that on make install.
+  install(
+    DIRECTORY
+      ${CMAKE_CURRENT_BINARY_DIR}/osqp_install/
+    DESTINATION
+      ${CMAKE_INSTALL_PREFIX}
+    PATTERN config.h EXCLUDE
+  )
+endmacro()
+
+build_osqp()
+
+ament_export_libraries(osqp)
+ament_export_dependencies(osqp)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package(CONFIG_EXTRAS osqp_vendor-extras.cmake)

--- a/vendor/osqp_vendor/LICENSE
+++ b/vendor/osqp_vendor/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/osqp_vendor/README.md
+++ b/vendor/osqp_vendor/README.md
@@ -1,0 +1,1 @@
+# osqp_vendor

--- a/vendor/osqp_vendor/README.md
+++ b/vendor/osqp_vendor/README.md
@@ -1,1 +1,3 @@
 # osqp_vendor
+
+`git subtree` added from https://github.com/tier4/osqp_vendor to make `osqp` from https://github.com/oxfordcontrol/osqp available in ROS2.

--- a/vendor/osqp_vendor/osqp_vendor-extras.cmake
+++ b/vendor/osqp_vendor/osqp_vendor-extras.cmake
@@ -1,0 +1,17 @@
+# Copyright 2020 Autoware Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# copied from osqp_vendor/osqp_vendor-extras.cmake
+
+list(APPEND osqp_vendor_TARGETS osqp)

--- a/vendor/osqp_vendor/package.xml
+++ b/vendor/osqp_vendor/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>osqp_vendor</name>
+  <version>0.0.1</version>
+  <description>
+    Wrapper around osqp that ships with a CMake module
+  </description>
+  <maintainer email="esteve.fernandez@autoware.org">Esteve Fernandez</maintainer>
+  <license>Apache License 2.0</license>
+
+  <url type="website">https://github.com/oxfordcontrol/osqp</url>
+  <author email="esteve.fernandez@autoware.org">Esteve Fernandez</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
It doesn't use any ros functionality so the source code is unchanged, only `package.xml` and `CMakeLists.txt` needed to
be modified

To test this locally, eigen and osqp need to be installed in the environment.

    git clone --recursive https://github.com/oxfordcontrol/osqp
    cd osqp
    mkdir build
    cd build/
    cmake ..
    cmake --build .
    sudo cmake --build . --target install

    sudo apt install libeigen3-dev

This package is a dependency of the packages `mpc_follower`, `motion_velocity_optimizer` and `obstacle_avoidance_planner` and so needs to be ported first
