### PR TITLE
ported pose2twist from ROS1 to ROS2

### DIFF
--- a/localization/twist_estimator/pose2twist/CMakeLists.txt
+++ b/localization/twist_estimator/pose2twist/CMakeLists.txt
@@ -1,43 +1,53 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(pose2twist)
 
-add_compile_options(-std=c++14)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  tf2_geometry_msgs
-  std_msgs
-  geometry_msgs
-)
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
 
-catkin_package(
-  INCLUDE_DIRS include
-)
-
-include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_executable(pose2twist
   src/pose2twist_node.cpp
   src/pose2twist_core.cpp
 )
 
-add_dependencies(pose2twist
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+ament_target_dependencies(pose2twist rclcpp 
+  tf2_geometry_msgs 
+  std_msgs geometry_msgs
 )
-
-target_link_libraries(pose2twist ${catkin_LIBRARIES})
 
 install(
   TARGETS
-    pose2twist
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  pose2twist
+  ARCHIVE DESTINATION lib/${PROJECT_NAME}
+  LIBRARY DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+include_directories(
+  include
 )
 
 install(
-  DIRECTORY
-    launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
 )
+install(
+  DIRECTORY include/${PROJECT_NAME}
+  DESTINATION include
+)
+
+ament_export_include_directories(include)
+ament_export_dependencies(std_msgs)
+ament_export_dependencies(tf2_geometry_msgs)
+ament_export_dependencies(geometry_msgs)
+ament_package()

--- a/localization/twist_estimator/pose2twist/CMakeLists.txt
+++ b/localization/twist_estimator/pose2twist/CMakeLists.txt
@@ -4,50 +4,16 @@ project(pose2twist)
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
 
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(geometry_msgs REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
-
-add_executable(pose2twist
+ament_auto_add_executable(pose2twist
   src/pose2twist_node.cpp
   src/pose2twist_core.cpp
 )
 
-ament_target_dependencies(pose2twist rclcpp 
-  tf2_geometry_msgs 
-  std_msgs geometry_msgs
+ament_auto_package(
+  INSTALL_TO_SHARE
+  launch
 )
-
-install(
-  TARGETS
-  pose2twist
-  ARCHIVE DESTINATION lib/${PROJECT_NAME}
-  LIBRARY DESTINATION lib/${PROJECT_NAME}
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
-)
-
-include_directories(
-  include
-)
-
-install(
-  DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}
-)
-install(
-  DIRECTORY include/${PROJECT_NAME}
-  DESTINATION include
-)
-
-ament_export_include_directories(include)
-ament_export_dependencies(std_msgs)
-ament_export_dependencies(tf2_geometry_msgs)
-ament_export_dependencies(geometry_msgs)
-ament_package()

--- a/localization/twist_estimator/pose2twist/include/pose2twist/pose2twist_core.h
+++ b/localization/twist_estimator/pose2twist/include/pose2twist/pose2twist_core.h
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-#pragma once
+#ifndef POSE2TWIST_CORE_H
+#define POSE2TWIST_CORE_H
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -39,3 +40,5 @@ private:
   rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr angular_z_pub_;
 
 };
+
+#endif

--- a/localization/twist_estimator/pose2twist/include/pose2twist/pose2twist_core.h
+++ b/localization/twist_estimator/pose2twist/include/pose2twist/pose2twist_core.h
@@ -27,7 +27,7 @@ class Pose2Twist : public rclcpp::Node
 {
 public:
   Pose2Twist();
-  ~Pose2Twist();
+  ~Pose2Twist() = default;
 
 private:
   void callbackPose(geometry_msgs::msg::PoseStamped::SharedPtr pose_msg_ptr);

--- a/localization/twist_estimator/pose2twist/include/pose2twist/pose2twist_core.h
+++ b/localization/twist_estimator/pose2twist/include/pose2twist/pose2twist_core.h
@@ -16,28 +16,26 @@
 
 #pragma once
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include <std_msgs/Float32.h>
+#include <std_msgs/msg/float32.hpp>
 
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/TwistStamped.h>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 
-class Pose2Twist
+class Pose2Twist : public rclcpp::Node
 {
 public:
-  Pose2Twist(ros::NodeHandle nh, ros::NodeHandle private_nh);
+  Pose2Twist();
   ~Pose2Twist();
 
 private:
-  void callbackPose(const geometry_msgs::PoseStamped::ConstPtr & pose_msg_ptr);
+  void callbackPose(geometry_msgs::msg::PoseStamped::SharedPtr pose_msg_ptr);
 
-  ros::NodeHandle nh_;
-  ros::NodeHandle private_nh_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr pose_sub_;
 
-  ros::Subscriber pose_sub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_pub_;
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr linear_x_pub_;
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr angular_z_pub_;
 
-  ros::Publisher twist_pub_;
-  ros::Publisher linear_x_pub_;
-  ros::Publisher angular_z_pub_;
 };

--- a/localization/twist_estimator/pose2twist/launch/pose2twist.launch.xml
+++ b/localization/twist_estimator/pose2twist/launch/pose2twist.launch.xml
@@ -3,9 +3,9 @@
   <arg name="input_pose_topic" default="/localization/pose_estimator/pose" doc="" />
   <arg name="output_twist_topic" default="/estimate_twist" doc="" />
 
-  <node pkg="pose2twist" type="pose2twist" name="pose2twist" output="log">
-    <remap from="pose" to="$(arg input_pose_topic)" />
-    <remap from="twist" to="$(arg output_twist_topic)" />
+  <node pkg="pose2twist" exec="pose2twist" name="pose2twist" output="log">
+    <remap from="pose" to="$(var input_pose_topic)" />
+    <remap from="twist" to="$(var output_twist_topic)" />
   </node>
 
 </launch>

--- a/localization/twist_estimator/pose2twist/package.xml
+++ b/localization/twist_estimator/pose2twist/package.xml
@@ -5,10 +5,6 @@
     <description>The pose2twist package</description>
     <maintainer email="yamato.ando@gmail.com">Yamato Ando</maintainer>
     <license>Apache 2.0</license>
-
-    <export>
-      <build_type>ament_cmake</build_type>
-    </export>
     
     <buildtool_depend>ament_cmake</buildtool_depend>
 
@@ -17,4 +13,7 @@
     <depend>std_msgs</depend>
     <depend>tf2_geometry_msgs</depend>
 
+    <export>
+      <build_type>ament_cmake</build_type>
+    </export>
 </package>

--- a/localization/twist_estimator/pose2twist/package.xml
+++ b/localization/twist_estimator/pose2twist/package.xml
@@ -5,12 +5,16 @@
     <description>The pose2twist package</description>
     <maintainer email="yamato.ando@gmail.com">Yamato Ando</maintainer>
     <license>Apache 2.0</license>
-    <buildtool_depend>ament_cmake</buildtool_depend>
-    <depend>rclcpp</depend>
-    <depend>tf2_geometry_msgs</depend>
-    <depend>std_msgs</depend>
-    <depend>geometry_msgs</depend>
+
     <export>
       <build_type>ament_cmake</build_type>
     </export>
+    
+    <buildtool_depend>ament_cmake</buildtool_depend>
+
+    <depend>geometry_msgs</depend>
+    <depend>rclcpp</depend>
+    <depend>std_msgs</depend>
+    <depend>tf2_geometry_msgs</depend>
+
 </package>

--- a/localization/twist_estimator/pose2twist/package.xml
+++ b/localization/twist_estimator/pose2twist/package.xml
@@ -1,22 +1,16 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
     <name>pose2twist</name>
     <version>0.1.0</version>
     <description>The pose2twist package</description>
     <maintainer email="yamato.ando@gmail.com">Yamato Ando</maintainer>
-    <license>Apache 2</license>
-    <buildtool_depend>catkin</buildtool_depend>
-
-    <build_depend>roscpp</build_depend>
-    <build_depend>tf2_geometry_msgs</build_depend>
-    <build_depend>std_msgs</build_depend>
-    <build_depend>geometry_msgs</build_depend>
-
-    <run_depend>roscpp</run_depend>
-    <run_depend>tf2_geometry_msgs</run_depend>
-    <run_depend>std_msgs</run_depend>
-    <run_depend>geometry_msgs</run_depend>
-
+    <license>Apache 2.0</license>
+    <buildtool_depend>ament_cmake</buildtool_depend>
+    <depend>rclcpp</depend>
+    <depend>tf2_geometry_msgs</depend>
+    <depend>std_msgs</depend>
+    <depend>geometry_msgs</depend>
     <export>
+      <build_type>ament_cmake</build_type>
     </export>
 </package>

--- a/localization/twist_estimator/pose2twist/src/pose2twist_core.cpp
+++ b/localization/twist_estimator/pose2twist/src/pose2twist_core.cpp
@@ -17,17 +17,25 @@
 #include "pose2twist/pose2twist_core.h"
 
 #include <cmath>
+#include <cstddef>
+#include <functional>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
-Pose2Twist::Pose2Twist(ros::NodeHandle nh, ros::NodeHandle private_nh)
-: nh_(nh), private_nh_(private_nh)
+Pose2Twist::Pose2Twist() : Node("pose2twist_core")
 {
-  pose_sub_ = nh_.subscribe("pose", 100, &Pose2Twist::callbackPose, this);
+  using std::placeholders::_1;
 
-  twist_pub_ = nh_.advertise<geometry_msgs::TwistStamped>("twist", 10);
-  linear_x_pub_ = nh_.advertise<std_msgs::Float32>("linear_x", 10);
-  angular_z_pub_ = nh_.advertise<std_msgs::Float32>("angular_z", 10);
+  static constexpr std::size_t queue_size = 1;
+  rclcpp::QoS durable_qos(queue_size);
+  durable_qos.transient_local();
+
+  pose_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>("pose", queue_size, std::bind(&Pose2Twist::callbackPose, this, _1));
+
+
+  twist_pub_ = create_publisher<geometry_msgs::msg::TwistStamped>("twist", durable_qos);
+  linear_x_pub_ = create_publisher<std_msgs::msg::Float32>("linear_x", durable_qos);
+  angular_z_pub_ = create_publisher<std_msgs::msg::Float32>("angular_z", durable_qos);
 }
 
 Pose2Twist::~Pose2Twist() {}
@@ -44,42 +52,42 @@ double calcDiffForRadian(const double lhs_rad, const double rhs_rad)
 }
 
 // x: roll, y: pitch, z: yaw
-geometry_msgs::Vector3 getRPY(const geometry_msgs::Pose & pose)
+geometry_msgs::msg::Vector3 getRPY(geometry_msgs::msg::Pose::SharedPtr pose)
 {
-  geometry_msgs::Vector3 rpy;
-  tf2::Quaternion q(pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
+  geometry_msgs::msg::Vector3 rpy;
+  tf2::Quaternion q(pose->orientation.x, pose->orientation.y, pose->orientation.z, pose->orientation.w);
   tf2::Matrix3x3(q).getRPY(rpy.x, rpy.y, rpy.z);
   return rpy;
 }
 
-geometry_msgs::Vector3 getRPY(const geometry_msgs::PoseStamped & pose) { return getRPY(pose.pose); }
+geometry_msgs::msg::Vector3 getRPY(geometry_msgs::msg::PoseStamped::SharedPtr pose) { return getRPY(pose); }
 
-geometry_msgs::TwistStamped calcTwist(
-  const geometry_msgs::PoseStamped & pose_a, const geometry_msgs::PoseStamped & pose_b)
+geometry_msgs::msg::TwistStamped calcTwist(
+  geometry_msgs::msg::PoseStamped::SharedPtr pose_a, geometry_msgs::msg::PoseStamped::SharedPtr pose_b)
 {
-  const double dt = (pose_b.header.stamp - pose_a.header.stamp).toSec();
+  const double dt = (pose_b->header.stamp.sec - pose_a->header.stamp.sec);
 
   if (dt == 0) {
-    geometry_msgs::TwistStamped twist;
-    twist.header = pose_b.header;
+    geometry_msgs::msg::TwistStamped twist;
+    twist.header = pose_b->header;
     return twist;
   }
 
   const auto pose_a_rpy = getRPY(pose_a);
   const auto pose_b_rpy = getRPY(pose_b);
 
-  geometry_msgs::Vector3 diff_xyz;
-  geometry_msgs::Vector3 diff_rpy;
+  geometry_msgs::msg::Vector3 diff_xyz;
+  geometry_msgs::msg::Vector3 diff_rpy;
 
-  diff_xyz.x = pose_b.pose.position.x - pose_a.pose.position.x;
-  diff_xyz.y = pose_b.pose.position.y - pose_a.pose.position.y;
-  diff_xyz.z = pose_b.pose.position.z - pose_a.pose.position.z;
+  diff_xyz.x = pose_b->pose.position.x - pose_a->pose.position.x;
+  diff_xyz.y = pose_b->pose.position.y - pose_a->pose.position.y;
+  diff_xyz.z = pose_b->pose.position.z - pose_a->pose.position.z;
   diff_rpy.x = calcDiffForRadian(pose_b_rpy.x, pose_a_rpy.x);
   diff_rpy.y = calcDiffForRadian(pose_b_rpy.y, pose_a_rpy.y);
   diff_rpy.z = calcDiffForRadian(pose_b_rpy.z, pose_a_rpy.z);
 
-  geometry_msgs::TwistStamped twist;
-  twist.header = pose_b.header;
+  geometry_msgs::msg::TwistStamped twist;
+  twist.header = pose_b->header;
   twist.twist.linear.x =
     std::sqrt(std::pow(diff_xyz.x, 2.0) + std::pow(diff_xyz.y, 2.0) + std::pow(diff_xyz.z, 2.0)) /
     dt;
@@ -92,24 +100,24 @@ geometry_msgs::TwistStamped calcTwist(
   return twist;
 }
 
-void Pose2Twist::callbackPose(const geometry_msgs::PoseStamped::ConstPtr & pose_msg_ptr)
+void Pose2Twist::callbackPose(geometry_msgs::msg::PoseStamped::SharedPtr pose_msg_ptr)
 {
   // TODO check time stamp diff
   // TODO check suddenly move
   // TODO apply low pass filter
 
-  geometry_msgs::PoseStamped current_pose_msg = *pose_msg_ptr;
-  static geometry_msgs::PoseStamped prev_pose_msg = current_pose_msg;
-  geometry_msgs::TwistStamped twist_msg = calcTwist(prev_pose_msg, current_pose_msg);
+  geometry_msgs::msg::PoseStamped::SharedPtr current_pose_msg = pose_msg_ptr;
+  static geometry_msgs::msg::PoseStamped::SharedPtr prev_pose_msg = current_pose_msg;
+  geometry_msgs::msg::TwistStamped twist_msg = calcTwist(prev_pose_msg, current_pose_msg);
   prev_pose_msg = current_pose_msg;
   twist_msg.header.frame_id = "base_link";
-  twist_pub_.publish(twist_msg);
+  twist_pub_->publish(twist_msg);
 
-  std_msgs::Float32 linear_x_msg;
+  std_msgs::msg::Float32 linear_x_msg;
   linear_x_msg.data = twist_msg.twist.linear.x;
-  linear_x_pub_.publish(linear_x_msg);
+  linear_x_pub_->publish(linear_x_msg);
 
-  std_msgs::Float32 angular_z_msg;
+  std_msgs::msg::Float32 angular_z_msg;
   angular_z_msg.data = twist_msg.twist.angular.z;
-  angular_z_pub_.publish(angular_z_msg);
+  angular_z_pub_->publish(angular_z_msg);
 }

--- a/localization/twist_estimator/pose2twist/src/pose2twist_core.cpp
+++ b/localization/twist_estimator/pose2twist/src/pose2twist_core.cpp
@@ -38,8 +38,6 @@ Pose2Twist::Pose2Twist() : Node("pose2twist_core")
   angular_z_pub_ = create_publisher<std_msgs::msg::Float32>("angular_z", durable_qos);
 }
 
-Pose2Twist::~Pose2Twist() {}
-
 double calcDiffForRadian(const double lhs_rad, const double rhs_rad)
 {
   double diff_rad = lhs_rad - rhs_rad;

--- a/localization/twist_estimator/pose2twist/src/pose2twist_node.cpp
+++ b/localization/twist_estimator/pose2twist/src/pose2twist_node.cpp
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include "pose2twist/pose2twist_core.h"
 
 int main(int argc, char ** argv)
 {
-  ros::init(argc, argv, "pose2twist");
-  ros::NodeHandle nh;
-  ros::NodeHandle private_nh("~");
+  rclcpp::init(argc, argv);
 
-  Pose2Twist node(nh, private_nh);
+  rclcpp::spin(std::make_shared<Pose2Twist>());
+  rclcpp::shutdown();
 
-  ros::spin();
   return 0;
 }


### PR DESCRIPTION
This PR ports pose2twist from ROS1 to ROS2

Changes and notes I made during the port.

The naming of header files are all small letter in Ros2:
`<std_msgs/Float32.h> to <std_msgs/msg/float32.hpp>`
`geometry_msgs/PoseStamped.h to geometry_msgs/msg/pose_stamped.hpp`