### PR TITLE
Port ndt_omp to ROS2

### DIFF
--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 
 include_directories(
   include
+  ${PCL_COMMON_INCLUDE_DIRS}
 )
 
 add_library(ndt_omp
@@ -52,13 +53,13 @@ add_executable(align
   apps/align.cpp
 )
 
-target_link_libraries(align
-  rclcpp
+# get_target_property(FRED_PCL_LINK_LIBRARIES PCL::pcl LINK_INTERFACE_LIBRARIES)
+
+# ament_target_dependencies can't depend on targets, i.e. ndt_omp
+target_link_libraries(align PUBLIC
   ndt_omp
-  PCL
+  ${PCL_LIBRARIES}
 )
-
-
 
 install(TARGETS ndt_omp
   DESTINATION lib/${PROJECT_NAME}
@@ -66,7 +67,7 @@ install(TARGETS ndt_omp
 
 ## Install project namespaced headers
 install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION share/${PROJECT_NAME}
+  DESTINATION install/${PROJECT_NAME}
 )
 
 ament_package()

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
@@ -1,16 +1,14 @@
 cmake_minimum_required(VERSION 3.5)
 project(ndt_omp)
 
-# -mavx causes a lot of errors!!
-add_definitions(-std=c++14 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
-set(CMAKE_CXX_FLAGS "-std=c++14 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2")
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 # warn performance issue of ndt_omp which is NOT built in release mode
-# string(TOUPPER ${CMAKE_BUILD_TYPE} uppercase_CMAKE_BUILD_TYPE)
-# if (NOT (${uppercase_CMAKE_BUILD_TYPE} STREQUAL "RELEASE"))
-#   message(WARNING
-#     "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} may cause a serious performance degradation. Please configure with -DCMAKE_BUILD_TYPE=Release.")
-# endif()
+if (NOT ("${CMAKE_BUILD_TYPE}" STREQUAL "Release"))
+  message(WARNING "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} may cause a serious performance degradation. Please configure with -DCMAKE_BUILD_TYPE=Release.")
+endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_auto REQUIRED)
@@ -38,8 +36,12 @@ target_include_directories(ndt_omp
 )
 
 # pcl 1.7 causes a segfault without -O2 (or -O3) flag
-target_compile_options(ndt_omp PUBLIC
-  $<$<CONFIG:Debug>:-O2 -g>
+target_compile_options(ndt_omp
+  PUBLIC
+    $<$<CONFIG:Debug>:-O2 -g>
+  PRIVATE
+    # -mavx causes a lot of errors!!
+    -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2
 )
 
 set(NDT_OMP_DEPENDENCIES

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
@@ -54,6 +54,6 @@ add_executable(align
   apps/align.cpp
 )
 
-ament_target_dependencies(ndt_omp ${NDT_OMP_DEPENDENCIES}) 
+target_link_libraries(align ndt_omp ${PCL_LIBRARIES})
 
 ament_auto_package()

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(ndt_omp)
 
 # -mavx causes a lot of errors!!
@@ -6,28 +6,20 @@ add_definitions(-std=c++14 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
 set(CMAKE_CXX_FLAGS "-std=c++14 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2")
 
 # warn performance issue of ndt_omp which is NOT built in release mode
-string(TOUPPER ${CMAKE_BUILD_TYPE} uppercase_CMAKE_BUILD_TYPE)
-if (NOT (${uppercase_CMAKE_BUILD_TYPE} STREQUAL "RELEASE"))
-  message(WARNING
-    "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} may cause a serious performance degradation. Please configure with -DCMAKE_BUILD_TYPE=Release.")
-endif()
+# string(TOUPPER ${CMAKE_BUILD_TYPE} uppercase_CMAKE_BUILD_TYPE)
+# if (NOT (${uppercase_CMAKE_BUILD_TYPE} STREQUAL "RELEASE"))
+#   message(WARNING
+#     "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} may cause a serious performance degradation. Please configure with -DCMAKE_BUILD_TYPE=Release.")
+# endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  pcl_ros
-)
-
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(PCL REQUIRED)
 find_package(OpenMP)
 if (OPENMP_FOUND)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif()
-
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES ndt_omp
-  CATKIN_DEPENDS
-)
 
 ###########
 ## Build ##
@@ -35,7 +27,6 @@ catkin_package(
 
 include_directories(
   include
-  ${catkin_INCLUDE_DIRS}
 )
 
 add_library(ndt_omp
@@ -43,28 +34,39 @@ add_library(ndt_omp
   src/ndt_omp/ndt_omp.cpp
 )
 
-add_executable(align
-  apps/align.cpp
+set(NDT_OMP_DEPENDENCIES
+  PCL
+  OpenMP
 )
-add_dependencies(align
-  ndt_omp
-)
+
 # pcl 1.7 causes a segfault without -O2 (or -O3) flag
 target_compile_options(ndt_omp PUBLIC
   $<$<CONFIG:Debug>:-O2 -g>
 )
-target_link_libraries(align
-  ${catkin_LIBRARIES}
-  ndt_omp
+
+ament_target_dependencies(ndt_omp ${NDT_OMP_DEPENDENCIES}) 
+ament_export_dependencies(${NDT_OMP_DEPENDENCIES})
+
+
+add_executable(align
+  apps/align.cpp
 )
 
+target_link_libraries(align
+  rclcpp
+  ndt_omp
+  PCL
+)
+
+
+
 install(TARGETS ndt_omp
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 ## Install project namespaced headers
 install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  DESTINATION share/${PROJECT_NAME}
 )
+
+ament_package()

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
@@ -34,14 +34,14 @@ add_library(ndt_omp
   src/ndt_omp/ndt_omp.cpp
 )
 
-set(NDT_OMP_DEPENDENCIES
-  PCL
-  OpenMP
-)
-
 # pcl 1.7 causes a segfault without -O2 (or -O3) flag
 target_compile_options(ndt_omp PUBLIC
   $<$<CONFIG:Debug>:-O2 -g>
+)
+
+set(NDT_OMP_DEPENDENCIES
+  PCL
+  OpenMP
 )
 
 ament_target_dependencies(ndt_omp ${NDT_OMP_DEPENDENCIES}) 
@@ -51,8 +51,6 @@ ament_export_dependencies(${NDT_OMP_DEPENDENCIES})
 add_executable(align
   apps/align.cpp
 )
-
-# get_target_property(FRED_PCL_LINK_LIBRARIES PCL::pcl LINK_INTERFACE_LIBRARIES)
 
 # ament_target_dependencies can't depend on targets, i.e. ndt_omp
 target_link_libraries(align PUBLIC

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
@@ -13,8 +13,10 @@ set(CMAKE_CXX_FLAGS "-std=c++14 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2")
 # endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
 find_package(PCL REQUIRED)
 find_package(OpenMP)
+
 if (OPENMP_FOUND)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
@@ -24,14 +26,15 @@ endif()
 ## Build ##
 ###########
 
-include_directories(
-  include
-  ${PCL_COMMON_INCLUDE_DIRS}
-)
-
 add_library(ndt_omp
   src/ndt_omp/voxel_grid_covariance_omp.cpp
   src/ndt_omp/ndt_omp.cpp
+)
+
+target_include_directories(ndt_omp
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include> 
 )
 
 # pcl 1.7 causes a segfault without -O2 (or -O3) flag
@@ -45,26 +48,12 @@ set(NDT_OMP_DEPENDENCIES
 )
 
 ament_target_dependencies(ndt_omp ${NDT_OMP_DEPENDENCIES}) 
-ament_export_dependencies(${NDT_OMP_DEPENDENCIES})
 
 
 add_executable(align
   apps/align.cpp
 )
 
-# ament_target_dependencies can't depend on targets, i.e. ndt_omp
-target_link_libraries(align PUBLIC
-  ndt_omp
-  ${PCL_LIBRARIES}
-)
+ament_target_dependencies(ndt_omp ${NDT_OMP_DEPENDENCIES}) 
 
-install(TARGETS ndt_omp
-  DESTINATION lib/${PROJECT_NAME}
-)
-
-## Install project namespaced headers
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION install/${PROJECT_NAME}
-)
-
-ament_package()
+ament_auto_package()

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
@@ -13,7 +13,6 @@ set(CMAKE_CXX_FLAGS "-std=c++14 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2")
 # endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
 find_package(PCL REQUIRED)
 find_package(OpenMP)
 if (OPENMP_FOUND)

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
@@ -5,10 +5,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
-# warn performance issue of ndt_omp which is NOT built in release mode
-if (NOT ("${CMAKE_BUILD_TYPE}" STREQUAL "Release"))
-  message(WARNING "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} may cause a serious performance degradation. Please configure with -DCMAKE_BUILD_TYPE=Release.")
-endif()
+set(CMAKE_BUILD_TYPE "Release")
 
 find_package(ament_cmake REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common filters kdtree registration io)
@@ -34,10 +31,7 @@ target_include_directories(ndt_omp
     $<INSTALL_INTERFACE:include> 
 )
 
-# pcl 1.7 causes a segfault without -O2 (or -O3) flag
 target_compile_options(ndt_omp
-  PUBLIC
-    $<$<CONFIG:Debug>:-O2 -g>
   PRIVATE
     # -mavx causes a lot of errors!!
     -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
@@ -11,8 +11,7 @@ if (NOT ("${CMAKE_BUILD_TYPE}" STREQUAL "Release"))
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_auto REQUIRED)
-find_package(PCL REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common filters kdtree registration io)
 find_package(OpenMP)
 
 if (OPENMP_FOUND)
@@ -50,12 +49,39 @@ set(NDT_OMP_DEPENDENCIES
 )
 
 ament_target_dependencies(ndt_omp ${NDT_OMP_DEPENDENCIES}) 
-
+ament_export_targets(export_ndt_omp HAS_LIBRARY_TARGET)
 
 add_executable(align
   apps/align.cpp
 )
 
-target_link_libraries(align ndt_omp ${PCL_LIBRARIES})
+# Strangely, for an executable, ament_target_dependencies(align ${NDT_OMP_DEPENDENCIES})
+# gives a linker error from PCL
+ament_target_dependencies(align PUBLIC OpenMP)
+# So we include PCL manually
+target_include_directories(align PUBLIC ${PCL_INCLUDE_DIRS})
+target_link_libraries(align PUBLIC ${PCL_LIBRARIES})
+target_compile_definitions(align PUBLIC ${PCL_DEFINITIONS})
+target_link_directories(align PUBLIC ${PCL_LIBRARY_DIRS})
+# Also link ndt_omp separately because ament_target_dependencies doesn't support
+# depending on a library target from the same package
+target_link_libraries(align PUBLIC ndt_omp)
 
-ament_auto_package()
+ament_export_dependencies(${NDT_OMP_DEPENDENCIES})
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(
+  TARGETS ndt_omp
+  EXPORT export_ndt_omp
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
+ament_package()
+

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
@@ -1,8 +1,12 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.9)
 project(ndt_omp)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wno-unused-parameter)
 endif()
 
 set(CMAKE_BUILD_TYPE "Release")
@@ -10,11 +14,6 @@ set(CMAKE_BUILD_TYPE "Release")
 find_package(ament_cmake REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common filters kdtree registration io)
 find_package(OpenMP)
-
-if (OPENMP_FOUND)
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-endif()
 
 ###########
 ## Build ##
@@ -31,37 +30,68 @@ target_include_directories(ndt_omp
     $<INSTALL_INTERFACE:include> 
 )
 
-target_compile_options(ndt_omp
-  PRIVATE
-    # -mavx causes a lot of errors!!
-    -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2
-)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(ndt_omp
+    PRIVATE
+      # -mavx causes a lot of errors!!
+      -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2
+  )
+endif()
 
 set(NDT_OMP_DEPENDENCIES
   PCL
   OpenMP
 )
 
-ament_target_dependencies(ndt_omp ${NDT_OMP_DEPENDENCIES}) 
-ament_export_targets(export_ndt_omp HAS_LIBRARY_TARGET)
 
+# Naively, I'd want to do something like:
+# ament_target_dependencies(ndt_omp PUBLIC ${NDT_OMP_DEPENDENCIES})
+# But there are several problems with that. For one, you'll have a hundred
+# errors like "undefined reference to `pcl::something::Something`". That's
+# because it only links `libpcl_common.so` for whatever reason, but we also
+# want `libpcl_io.so` etc. So we do this PCL thing manually:
+target_compile_definitions(ndt_omp PUBLIC ${PCL_DEFINITIONS})
+target_include_directories(ndt_omp PUBLIC ${PCL_INCLUDE_DIRS})
+target_link_libraries(ndt_omp PUBLIC ${PCL_LIBRARIES})
+target_link_directories(ndt_omp PUBLIC ${PCL_LIBRARY_DIRS})
+
+# As for OpenMP, the recommended format is the following, which is not
+# supported by `ament_target_dependencies()` either.
+if(OpenMP_CXX_FOUND)
+  target_link_libraries(ndt_omp PUBLIC OpenMP::OpenMP_CXX)
+else()
+  message(WARNING "OpenMP not found")
+endif()
+# See https://cliutils.gitlab.io/modern-cmake/chapters/packages/OpenMP.html
+# but it doesn't matter anyway because at the time of writing, omp.h is in
+# /usr/lib/gcc/x86_64-linux-gnu/9/include/ which is one of the default
+# include directories, and libgomp.so is in /usr/lib/x86_64-linux-gnu/,
+# which is one of the default linker search paths.
+
+ament_export_targets(export_ndt_omp HAS_LIBRARY_TARGET)
+ament_export_dependencies(${NDT_OMP_DEPENDENCIES})
+
+
+# Same story for the executable
 add_executable(align
   apps/align.cpp
 )
 
-# Strangely, for an executable, ament_target_dependencies(align ${NDT_OMP_DEPENDENCIES})
-# gives a linker error from PCL
-ament_target_dependencies(align PUBLIC OpenMP)
-# So we include PCL manually
-target_include_directories(align PUBLIC ${PCL_INCLUDE_DIRS})
-target_link_libraries(align PUBLIC ${PCL_LIBRARIES})
-target_compile_definitions(align PUBLIC ${PCL_DEFINITIONS})
-target_link_directories(align PUBLIC ${PCL_LIBRARY_DIRS})
-# Also link ndt_omp separately because ament_target_dependencies doesn't support
-# depending on a library target from the same package
-target_link_libraries(align PUBLIC ndt_omp)
+target_compile_definitions(align PRIVATE ${PCL_DEFINITIONS})
+target_include_directories(align PRIVATE ${PCL_INCLUDE_DIRS})
+target_link_libraries(align PRIVATE ${PCL_LIBRARIES})
+target_link_directories(align PRIVATE ${PCL_LIBRARY_DIRS})
+if(OpenMP_CXX_FOUND)
+  target_link_libraries(align PRIVATE OpenMP::OpenMP_CXX)
+else()
+  message(WARNING "OpenMP not found")
+endif()
 
-ament_export_dependencies(${NDT_OMP_DEPENDENCIES})
+# Again, no chance for `ament_target_dependencies()` since you can't depend on
+# a local library target: "ament_target_dependencies() the passed package name
+# 'ndt_omp' was not found" – so we need to add ndt_omp with
+# `target_link_libraries(align PUBLIC ndt_omp)` instead.
+target_link_libraries(align PRIVATE ndt_omp)
 
 install(
   DIRECTORY include/

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/apps/align.cpp
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/apps/align.cpp
@@ -31,7 +31,6 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/registration/ndt.h>
-#include <ros/ros.h>
 #include <iostream>
 
 #include <ndt_omp/ndt_omp.h>
@@ -45,17 +44,16 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr align(
   registration->setInputTarget(target_cloud);
   registration->setInputSource(source_cloud);
   pcl::PointCloud<pcl::PointXYZ>::Ptr aligned(new pcl::PointCloud<pcl::PointXYZ>());
-
-  auto t1 = ros::WallTime::now();
+  auto t1 = std::chrono::steady_clock::now();
   registration->align(*aligned);
-  auto t2 = ros::WallTime::now();
-  std::cout << "single : " << (t2 - t1).toSec() * 1000 << "[msec]" << std::endl;
+  auto t2 = std::chrono::steady_clock::now();
+  std::cout << "single : " << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count() << "[msec]" << std::endl;
 
   for (int i = 0; i < 10; i++) {
     registration->align(*aligned);
   }
-  auto t3 = ros::WallTime::now();
-  std::cout << "10times: " << (t3 - t2).toSec() * 1000 << "[msec]" << std::endl;
+  auto t3 = std::chrono::steady_clock::now();
+  std::cout << "10times: " << std::chrono::duration_cast<std::chrono::milliseconds>(t3 - t2).count() << "[msec]" << std::endl;
   std::cout << "fitness: " << registration->getFitnessScore() << std::endl << std::endl;
 
   return aligned;
@@ -96,8 +94,6 @@ int main(int argc, char ** argv)
   voxelgrid.setInputCloud(source_cloud);
   voxelgrid.filter(*downsampled);
   source_cloud = downsampled;
-
-  ros::Time::init();
 
   // benchmark
   std::cout << "--- pcl::NDT ---" << std::endl;

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/apps/align.cpp
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/apps/align.cpp
@@ -26,12 +26,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * 
 */
+#include <iostream>
+#include <omp.h>
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/registration/ndt.h>
-#include <iostream>
 
 #include <ndt_omp/ndt_omp.h>
 

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/package.xml
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/package.xml
@@ -14,7 +14,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>pcl_ros</depend>
-  <depend>rclcpp</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/package.xml
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/package.xml
@@ -13,7 +13,7 @@
   <license>BSD</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <depend>pcl_ros</depend>
+  <depend>libpcl-all-dev</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/package.xml
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?> 
+<package format="3">
   <name>ndt_omp</name>
   <version>0.1.0</version>
   <description>OpenMP boosted NDT and GICP algorithms</description>
@@ -11,12 +12,11 @@
 
   <license>BSD</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>pcl_ros</build_depend>
-  <build_depend>roscpp</build_depend>
-  <run_depend>pcl_ros</run_depend>
-  <run_depend>roscpp</run_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>pcl_ros</depend>
+  <depend>rclcpp</depend>
 
   <export>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
* Removed ROS as a dependency, it was just used for its wall timer
* Replaced `pcl_ros` by `PCL`
* See comments for CMake questions
* There is a large number of warnings from using deprecated `pcl` functions. Maybe this already has been fixed in the newest version of https://github.com/koide3/ndt_omp?