### PR TITLE
Add lint raw vehicle cmd converter

### DIFF
--- a/vehicle/raw_vehicle_cmd_converter/CMakeLists.txt
+++ b/vehicle/raw_vehicle_cmd_converter/CMakeLists.txt
@@ -24,6 +24,11 @@ ament_auto_add_executable(raw_vehicle_cmd_converter_node
 add_dependencies(raw_vehicle_cmd_converter_node accel_map_converter)
 target_link_libraries(raw_vehicle_cmd_converter_node accel_map_converter)
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_auto_package(INSTALL_TO_SHARE
   launch
   data

--- a/vehicle/raw_vehicle_cmd_converter/package.xml
+++ b/vehicle/raw_vehicle_cmd_converter/package.xml
@@ -10,10 +10,12 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-
   <depend>rclcpp</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This adds ament_lint to do lint testing of cpp codes to raw_vehicle_cmd_converter