### PR TITLE
set DEBIAN_FRONTEND=noninteractive after sudo

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install missing dependencies
-      run: sudo apt update && rosdep update && DEBIAN_FRONTEND=noninteractive sudo rosdep install --from-paths . --ignore-src --rosdistro foxy -y
+      run: sudo apt update && rosdep update && sudo DEBIAN_FRONTEND=noninteractive rosdep install --from-paths . --ignore-src --rosdistro foxy -y
 
     - name: Build
       run: . /opt/ros/foxy/setup.sh && colcon build --event-handlers console_cohesion+


### PR DESCRIPTION
This should enable the installation of keyboard-configuration in CI which is blocking this PR https://github.com/tier4/Pilot.Auto/pull/11.

`DEBIAN_FRONTEND=noninteractive` should be set after sudo, not before. (https://askubuntu.com/questions/876240/how-to-automate-setting-up-of-keyboard-configuration-package)
