### PR TITLE
port map_tf_generator

### DIFF
--- a/map/map_tf_generator/CMakeLists.txt
+++ b/map/map_tf_generator/CMakeLists.txt
@@ -5,6 +5,9 @@ project(map_tf_generator)
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
+endif()
 
 ### Dependencies
 find_package(ament_cmake REQUIRED)

--- a/map/map_tf_generator/CMakeLists.txt
+++ b/map/map_tf_generator/CMakeLists.txt
@@ -9,44 +9,18 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
 endif()
 
-### Dependencies
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(tf2 REQUIRED)
-find_package(tf2_ros REQUIRED)
+### ROS Dependencies
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
+### non-ROS Dependencies
 find_package(PCL REQUIRED)
-find_package(pcl_conversions REQUIRED)
-
-# Add path of include dir
-include_directories(include)
 
 # Generate exe file
-add_executable(map_tf_generator nodes/map_tf_generator.cpp)
+ament_auto_add_executable(map_tf_generator nodes/map_tf_generator.cpp)
+target_link_libraries(map_tf_generator ${PCL_LIBRARIES})
 
-# Add dependencies. use target_link_libaries() before Crystal
-set(MAP_TF_GENERATOR_DEPENDENCIES
-  rclcpp
-  std_msgs
-  tf2
-  tf2_ros
-  PCL
-  pcl_conversions
+## Install
+ament_auto_package(INSTALL_TO_SHARE
+  launch
 )
-ament_target_dependencies(map_tf_generator ${MAP_TF_GENERATOR_DEPENDENCIES})
-
-## Install executables and/or libraries
-install(TARGETS map_tf_generator
-  ARCHIVE DESTINATION lib/${PROJECT_NAME}
-  LIBRARY DESTINATION lib/${PROJECT_NAME}
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
-)
-
-## Install project namespaced headers
-install(DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}
-)
-
-# set at the end of cmakelists
-ament_package()

--- a/map/map_tf_generator/CMakeLists.txt
+++ b/map/map_tf_generator/CMakeLists.txt
@@ -1,37 +1,49 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(map_tf_generator)
 
-add_compile_options(-std=c++14)
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
+### Dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+
+find_package(PCL REQUIRED)
+find_package(pcl_conversions REQUIRED)
+
+# Add path of include dir
+include_directories(include)
+
+# Generate exe file
+add_executable(map_tf_generator nodes/map_tf_generator.cpp)
+
+# Add dependencies. use target_link_libaries() before Crystal
+set(MAP_TF_GENERATOR_DEPENDENCIES
+  rclcpp
   std_msgs
-  pcl_ros
   tf2
   tf2_ros
+  PCL
+  pcl_conversions
 )
+ament_target_dependencies(map_tf_generator ${MAP_TF_GENERATOR_DEPENDENCIES})
 
-catkin_package()
-
-include_directories(
-  ${catkin_INCLUDE_DIRS}
-)
-
-add_executable(
-  map_tf_generator nodes/map_tf_generator.cpp
-)
-
-target_link_libraries(
-  map_tf_generator ${catkin_LIBRARIES}
-)
-
+## Install executables and/or libraries
 install(TARGETS map_tf_generator
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-
-install(
-  DIRECTORY
-    launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  ARCHIVE DESTINATION lib/${PROJECT_NAME}
+  LIBRARY DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
+
+## Install project namespaced headers
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+# set at the end of cmakelists
+ament_package()

--- a/map/map_tf_generator/launch/map_tf_generator.launch.xml
+++ b/map/map_tf_generator/launch/map_tf_generator.launch.xml
@@ -4,10 +4,10 @@
   <arg name="map_frame" default="map" />
   <arg name="viewer_frame" default="viewer" />
 
-  <node pkg="map_tf_generator" type="map_tf_generator" name="map_tf_generator">
-    <remap from="pointcloud_map" to="$(arg input_map_points_topic)" />
+  <node pkg="map_tf_generator" exec="map_tf_generator" name="map_tf_generator">
+    <remap from="pointcloud_map" to="$(var input_map_points_topic)" />
 
-    <param name="map_frame" value="$(arg map_frame)" />
-    <param name="viewer_frame" value="$(arg viewer_frame)" />
+    <param name="map_frame" value="$(var map_frame)" />
+    <param name="viewer_frame" value="$(var viewer_frame)" />
   </node>
 </launch>

--- a/map/map_tf_generator/nodes/map_tf_generator.cpp
+++ b/map/map_tf_generator/nodes/map_tf_generator.cpp
@@ -13,65 +13,84 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
-#include <pcl_ros/point_cloud.h>
-#include <ros/ros.h>
-#include <sensor_msgs/PointCloud2.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_ros/static_transform_broadcaster.h>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include <pcl_conversions/pcl_conversions.h>
 
 typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
-std::string map_frame_ = "map";
-std::string viewer_frame_ = "viewer";
 
-void Callback(const PointCloud::ConstPtr & clouds)
+class MapTFGenerator : public rclcpp::Node
 {
-  const unsigned int sum = clouds->points.size();
-  double coordinate[3] = {0, 0, 0};
-  for (int i = 0; i < sum; i++) {
-    coordinate[0] += clouds->points[i].x;
-    coordinate[1] += clouds->points[i].y;
-    coordinate[2] += clouds->points[i].z;
+public:
+  MapTFGenerator() : Node("map_tf_generator")
+  {
+    map_frame_ = declare_parameter("map_frame", "map");
+    viewer_frame_ = declare_parameter("viewer_frame", "viewer");
+
+    sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
+      "pointcloud_map", rclcpp::QoS{1},
+      std::bind(&MapTFGenerator::Callback, this, std::placeholders::_1));
+
+    static_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(
+      std::shared_ptr<rclcpp::Node>(this, [](auto) {}));
   }
-  coordinate[0] = coordinate[0] / sum;
-  coordinate[1] = coordinate[1] / sum;
-  coordinate[2] = coordinate[2] / sum;
 
-  geometry_msgs::TransformStamped static_transformStamped;
-  static_transformStamped.header.stamp = ros::Time::now();
-  static_transformStamped.header.frame_id = map_frame_;
-  static_transformStamped.child_frame_id = viewer_frame_;
-  static_transformStamped.transform.translation.x = coordinate[0];
-  static_transformStamped.transform.translation.y = coordinate[1];
-  static_transformStamped.transform.translation.z = coordinate[2];
-  tf2::Quaternion quat;
-  quat.setRPY(0, 0, 0);
-  static_transformStamped.transform.rotation.x = quat.x();
-  static_transformStamped.transform.rotation.y = quat.y();
-  static_transformStamped.transform.rotation.z = quat.z();
-  static_transformStamped.transform.rotation.w = quat.w();
+private:
+  std::string map_frame_;
+  std::string viewer_frame_;
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_;
 
-  static tf2_ros::StaticTransformBroadcaster static_broadcaster;
-  static_broadcaster.sendTransform(static_transformStamped);
+  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_broadcaster_;
 
-  ROS_INFO_STREAM(
-    "broadcast static tf. map_frame:" << map_frame_ << ", viewer_frame:" << viewer_frame_
-                                      << ", x:" << coordinate[0] << ", y:" << coordinate[1]
-                                      << ", z:" << coordinate[2]);
-}
+  void Callback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr clouds_ros)
+  {
+    PointCloud * clouds;
+    pcl::fromROSMsg<pcl::PointXYZ>(*clouds_ros, *clouds);
+
+    const unsigned int sum = clouds->points.size();
+    double coordinate[3] = {0, 0, 0};
+    for (int i = 0; i < sum; i++) {
+      coordinate[0] += clouds->points[i].x;
+      coordinate[1] += clouds->points[i].y;
+      coordinate[2] += clouds->points[i].z;
+    }
+    coordinate[0] = coordinate[0] / sum;
+    coordinate[1] = coordinate[1] / sum;
+    coordinate[2] = coordinate[2] / sum;
+
+    geometry_msgs::msg::TransformStamped static_transformStamped;
+    static_transformStamped.header.stamp = get_clock()->now();
+    static_transformStamped.header.frame_id = map_frame_;
+    static_transformStamped.child_frame_id = viewer_frame_;
+    static_transformStamped.transform.translation.x = coordinate[0];
+    static_transformStamped.transform.translation.y = coordinate[1];
+    static_transformStamped.transform.translation.z = coordinate[2];
+    tf2::Quaternion quat;
+    quat.setRPY(0, 0, 0);
+    static_transformStamped.transform.rotation.x = quat.x();
+    static_transformStamped.transform.rotation.y = quat.y();
+    static_transformStamped.transform.rotation.z = quat.z();
+    static_transformStamped.transform.rotation.w = quat.w();
+
+    static_broadcaster_->sendTransform(static_transformStamped);
+
+    RCLCPP_INFO_STREAM(
+      get_logger(), "broadcast static tf. map_frame:"
+                      << map_frame_ << ", viewer_frame:" << viewer_frame_ << ", x:" << coordinate[0]
+                      << ", y:" << coordinate[1] << ", z:" << coordinate[2]);
+  }
+};
 
 int main(int argc, char ** argv)
 {
-  ros::init(argc, argv, "map_tf_generator");
-  ros::NodeHandle nh;
-  ros::NodeHandle nh_private("~");
-
-  nh_private.getParam("map_frame", map_frame_);
-  nh_private.getParam("viewer_frame", viewer_frame_);
-
-  ros::Subscriber sub = nh.subscribe<PointCloud>("pointcloud_map", 1, &Callback);
-
-  ros::spin();
-
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<MapTFGenerator>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
   return 0;
 };

--- a/map/map_tf_generator/nodes/map_tf_generator.cpp
+++ b/map/map_tf_generator/nodes/map_tf_generator.cpp
@@ -36,8 +36,7 @@ public:
       "pointcloud_map", rclcpp::QoS{1},
       std::bind(&MapTFGenerator::Callback, this, std::placeholders::_1));
 
-    static_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(
-      std::shared_ptr<rclcpp::Node>(this, [](auto) {}));
+    static_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
   }
 
 private:
@@ -49,15 +48,15 @@ private:
 
   void Callback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr clouds_ros)
   {
-    PointCloud * clouds;
-    pcl::fromROSMsg<pcl::PointXYZ>(*clouds_ros, *clouds);
+    PointCloud clouds;
+    pcl::fromROSMsg<pcl::PointXYZ>(*clouds_ros, clouds);
 
-    const unsigned int sum = clouds->points.size();
+    const unsigned int sum = clouds.points.size();
     double coordinate[3] = {0, 0, 0};
     for (int i = 0; i < sum; i++) {
-      coordinate[0] += clouds->points[i].x;
-      coordinate[1] += clouds->points[i].y;
-      coordinate[2] += clouds->points[i].z;
+      coordinate[0] += clouds.points[i].x;
+      coordinate[1] += clouds.points[i].y;
+      coordinate[2] += clouds.points[i].z;
     }
     coordinate[0] = coordinate[0] / sum;
     coordinate[1] = coordinate[1] / sum;
@@ -93,4 +92,4 @@ int main(int argc, char ** argv)
   rclcpp::spin(node);
   rclcpp::shutdown();
   return 0;
-};
+}

--- a/map/map_tf_generator/package.xml
+++ b/map/map_tf_generator/package.xml
@@ -1,17 +1,19 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>map_tf_generator</name>
   <version>0.1.0</version>
-  <description>The map_tf_generator package</description>
+  <description>map_tf_generator package as a ROS 2 node</description>
   <maintainer email="azumi.suzuki@tier4.jp">azumi-suzuki</maintainer>
-  <license>Apache 2</license>
+  <license>Apache License 2.0</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
-
-  <depend>roscpp</depend>
+  <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-
-  <exec_depend>pcl_ros</exec_depend>
+  <depend>pcl_conversions</depend>
+  
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/map/map_tf_generator/package.xml
+++ b/map/map_tf_generator/package.xml
@@ -7,11 +7,14 @@
   <maintainer email="azumi.suzuki@tier4.jp">azumi-suzuki</maintainer>
   <license>Apache License 2.0</license>
 
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>pcl_conversions</depend>
+  <depend>libpcl-all-dev</depend>
   
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
 - `pcl` to `PCL`
 - add msg conversion for pcl, which was not used in the original code since the raw pcl class can be used for a ROS1 subscriver.
 - add `pcl_conversion` for `pcl::fromROSMsg<pcl::PointXYZ>()`.

You need to run rosdep before build for `pcl_conversions`.

```
rosdep update
rosdep install --from-paths src -i -y --rosdistro=$ROS_DISTRO
```
