### PR TITLE
Port autoware_utils

### DIFF
--- a/common/util/autoware_utils/CMakeLists.txt
+++ b/common/util/autoware_utils/CMakeLists.txt
@@ -1,73 +1,34 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(autoware_utils)
 
-add_compile_options(-std=c++14)
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wno-unused-parameter)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  autoware_planning_msgs
-  geometry_msgs
-  tf2
-  tf2_geometry_msgs
-)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
-find_package(Eigen3 REQUIRED)
-
-catkin_package(
-  INCLUDE_DIRS
-    include
-  LIBRARIES
-    autoware_utils
-  CATKIN_DEPENDS
-    autoware_planning_msgs
-    geometry_msgs
-    tf2
-    tf2_geometry_msgs
-)
-
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-)
-
-add_library(autoware_utils
+ament_auto_add_library(autoware_utils
   src/autoware_utils.cpp
 )
 
-target_link_libraries(autoware_utils
-  ${catkin_LIBRARIES}
-)
-
-add_dependencies(autoware_utils
-  ${catkin_EXPORTED_TARGETS}
-)
-
-# Install executables and/or libraries
-install(
-  TARGETS
-    autoware_utils
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-# Install project namespaced headers
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
-
 # Test
-if (CATKIN_ENABLE_TESTING)
-  find_package(rostest REQUIRED)
-
-  add_rostest_gtest(test_autoware_utils test/test_autoware_utils.test
+if(AMENT_ENABLE_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_autoware_utils test/test_autoware_utils.test
     test/src/test_autoware_utils.cpp
     test/src/test_geometry.cpp
     test/src/test_normalization.cpp
     test/src/test_unit_conversion.cpp
   )
-
   target_link_libraries(test_autoware_utils
     autoware_utils
-    ${catkin_LIBRARIES}
   )
 endif ()
+
+ament_auto_package()

--- a/common/util/autoware_utils/include/autoware_utils/geometry.h
+++ b/common/util/autoware_utils/include/autoware_utils/geometry.h
@@ -41,7 +41,7 @@ inline geometry_msgs::msg::Point getPoint(const autoware_planning_msgs::msg::Tra
   return p.pose.position;
 }
 
-inline geometry_msgs::msg::Point rctfeatePoint(const double x, const double y, const double z)
+inline geometry_msgs::msg::Point createPoint(const double x, const double y, const double z)
 {
   geometry_msgs::msg::Point p;
   p.x = x;

--- a/common/util/autoware_utils/include/autoware_utils/geometry.h
+++ b/common/util/autoware_utils/include/autoware_utils/geometry.h
@@ -16,33 +16,34 @@
 
 #pragma once
 
-#include <autoware_planning_msgs/Path.h>
-#include <autoware_planning_msgs/Trajectory.h>
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/Quaternion.h>
+#include <autoware_planning_msgs/msg/path.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2/LinearMath/Quaternion.h>
 
 namespace autoware_utils
 {
-inline geometry_msgs::Point getPoint(const geometry_msgs::Point & p) { return p; }
-inline geometry_msgs::Point getPoint(const geometry_msgs::Pose & p) { return p.position; }
-inline geometry_msgs::Point getPoint(const geometry_msgs::PoseStamped & p)
+inline geometry_msgs::msg::Point getPoint(const geometry_msgs::msg::Point & p) { return p; }
+inline geometry_msgs::msg::Point getPoint(const geometry_msgs::msg::Pose & p) { return p.position; }
+inline geometry_msgs::msg::Point getPoint(const geometry_msgs::msg::PoseStamped & p)
 {
   return p.pose.position;
 }
 
-inline geometry_msgs::Point getPoint(const autoware_planning_msgs::PathPoint & p)
+inline geometry_msgs::msg::Point getPoint(const autoware_planning_msgs::msg::PathPoint & p)
 {
   return p.pose.position;
 }
-inline geometry_msgs::Point getPoint(const autoware_planning_msgs::TrajectoryPoint & p)
+inline geometry_msgs::msg::Point getPoint(const autoware_planning_msgs::msg::TrajectoryPoint & p)
 {
   return p.pose.position;
 }
 
-inline geometry_msgs::Point createPoint(const double x, const double y, const double z)
+inline geometry_msgs::msg::Point rctfeatePoint(const double x, const double y, const double z)
 {
-  geometry_msgs::Point p;
+  geometry_msgs::msg::Point p;
   p.x = x;
   p.y = y;
   p.z = z;

--- a/common/util/autoware_utils/package.xml
+++ b/common/util/autoware_utils/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="kenji.miyake@tier4.jp">Kenji Miyake</maintainer>
   <license>Apache 2</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>autoware_planning_msgs</depend>
   <depend>builtin_interfaces</depend>

--- a/common/util/autoware_utils/package.xml
+++ b/common/util/autoware_utils/package.xml
@@ -7,15 +7,15 @@
   <maintainer email="kenji.miyake@tier4.jp">Kenji Miyake</maintainer>
   <license>Apache 2</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>autoware_planning_msgs</depend>
+  <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
 
-  <test_depend>rostest</test_depend>
-
   <export>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
This package is not in the list of packages to port. However, perhaps this is a good place for time conversion functions, which I need for ndt_scan_matcher.

I changed nothing interesting, I only added one missing header.