### PR TITLE
Port lanelet2 extension

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install missing dependencies
-      run: sudo apt update && rosdep update && sudo DEBIAN_FRONTEND=noninteractive rosdep install --from-paths . --ignore-src --rosdistro foxy -y
+      run: sudo apt update && rosdep update && DEBIAN_FRONTEND=noninteractive rosdep install --from-paths . --ignore-src --rosdistro foxy -y
 
     - name: Build
       run: . /opt/ros/foxy/setup.sh && colcon build --event-handlers console_cohesion+

--- a/map/lanelet2_extension/CMakeLists.txt
+++ b/map/lanelet2_extension/CMakeLists.txt
@@ -49,13 +49,13 @@ target_link_libraries(lanelet2_extension_lib
   ${GeographicLib_LIBRARIES}
 )
 
-ament_auto_add_library(lanelet2_extension_sample src/sample_code.cpp)
+ament_auto_add_executable(lanelet2_extension_sample src/sample_code.cpp)
 add_dependencies(lanelet2_extension_sample lanelet2_extension_lib)
 target_link_libraries(lanelet2_extension_sample
   lanelet2_extension_lib
 )
 
-ament_auto_add_library(autoware_lanelet2_validation src/validation.cpp)
+ament_auto_add_executable(autoware_lanelet2_validation src/validation.cpp)
 add_dependencies(autoware_lanelet2_validation lanelet2_extension_lib)
 target_link_libraries(autoware_lanelet2_validation
   lanelet2_extension_lib

--- a/map/lanelet2_extension/CMakeLists.txt
+++ b/map/lanelet2_extension/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 project(lanelet2_extension)
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
 find_package(PkgConfig)
 find_path(GeographicLib_INCLUDE_DIR GeographicLib/Config.h
   PATH_SUFFIXES GeographicLib
@@ -19,13 +26,6 @@ find_path(PUGIXML_INCLUDE_DIRS
   NAMES pugixml.hpp
   PATH_SUFFIXES pugixml
 )
-
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
 
 include_directories(
   ${GeographicLib_INCLUDE_DIRS}
@@ -46,7 +46,6 @@ ament_auto_add_library(lanelet2_extension_lib SHARED
   lib/visualization.cpp
 )
 target_link_libraries(lanelet2_extension_lib
-  ${catkin_LIBRARIES}
   ${GeographicLib_LIBRARIES}
 )
 
@@ -76,4 +75,4 @@ if(BUILD_TESTING)
   target_link_libraries(utilities-test lanelet2_extension_lib)
 endif()
 
-ament_package()
+ament_auto_package()

--- a/map/lanelet2_extension/CMakeLists.txt
+++ b/map/lanelet2_extension/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(lanelet2_extension)
 
 find_package(PkgConfig)
@@ -20,42 +20,21 @@ find_path(PUGIXML_INCLUDE_DIRS
   PATH_SUFFIXES pugixml
 )
 
-add_compile_options(-std=c++14)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  lanelet2_core
-  lanelet2_io
-  lanelet2_maps
-  lanelet2_projection
-  lanelet2_routing
-  lanelet2_traffic_rules
-  lanelet2_validation
-  autoware_lanelet2_msgs
-  geometry_msgs
-  visualization_msgs
-  roslint
-)
-
-set(ROSLINT_CPP_OPTS "--filter=-build/c++14")
-roslint_cpp()
-
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES lanelet2_extension_lib
-  CATKIN_DEPENDS roscpp lanelet2_core lanelet2_io lanelet2_maps lanelet2_projection lanelet2_routing lanelet2_traffic_rules lanelet2_validation autoware_lanelet2_msgs geometry_msgs visualization_msgs
-)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 include_directories(
-  include
   ${GeographicLib_INCLUDE_DIRS}
-  ${catkin_INCLUDE_DIRS}
   ${PUGIXML_INCLUDE_DIRS}
 )
 
-add_definitions (${GeographicLib_DEFINITIONS})
+add_definitions(${GeographicLib_DEFINITIONS})
 
-add_library( lanelet2_extension_lib
+ament_auto_add_library(lanelet2_extension_lib SHARED
   lib/autoware_osm_parser.cpp
   lib/autoware_traffic_light.cpp
   lib/detection_area.cpp
@@ -66,51 +45,35 @@ add_library( lanelet2_extension_lib
   lib/utilities.cpp
   lib/visualization.cpp
 )
-
-add_dependencies(lanelet2_extension_lib
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
-)
-
 target_link_libraries(lanelet2_extension_lib
   ${catkin_LIBRARIES}
   ${GeographicLib_LIBRARIES}
 )
 
-add_executable(lanelet2_extension_sample src/sample_code.cpp)
-add_dependencies(lanelet2_extension_sample ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+ament_auto_add_library(lanelet2_extension_sample src/sample_code.cpp)
+add_dependencies(lanelet2_extension_sample lanelet2_extension_lib)
 target_link_libraries(lanelet2_extension_sample
-  ${catkin_LIBRARIES}
   lanelet2_extension_lib
 )
 
-add_executable(autoware_lanelet2_validation src/validation.cpp)
-add_dependencies(autoware_lanelet2_validation ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+ament_auto_add_library(autoware_lanelet2_validation src/validation.cpp)
+add_dependencies(autoware_lanelet2_validation lanelet2_extension_lib)
 target_link_libraries(autoware_lanelet2_validation
-  ${catkin_LIBRARIES}
-  ${PUGIXML_LIBRAREIS}
   lanelet2_extension_lib
 )
 
-install(TARGETS lanelet2_extension_lib lanelet2_extension_sample autoware_lanelet2_validation
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
-
-if(CATKIN_ENABLE_TESTING)
-  roslint_add_test()
-  find_package(rostest REQUIRED)
-  add_rostest_gtest(message_conversion-test test/test_message_conversion.test test/src/test_message_conversion.cpp)
-  target_link_libraries(message_conversion-test ${catkin_LIBRARIES} lanelet2_extension_lib)
-  add_rostest_gtest(projector-test test/test_projector.test test/src/test_projector.cpp)
-  target_link_libraries(projector-test ${catkin_LIBRARIES} lanelet2_extension_lib)
-  add_rostest_gtest(query-test test/test_query.test test/src/test_query.cpp)
-  target_link_libraries(query-test ${catkin_LIBRARIES} lanelet2_extension_lib)
-  add_rostest_gtest(regulatory_elements-test test/test_regulatory_elements.test test/src/test_regulatory_elements.cpp)
-  target_link_libraries(regulatory_elements-test ${catkin_LIBRARIES} lanelet2_extension_lib)
-  add_rostest_gtest(utilities-test test/test_utilities.test test/src/test_utilities.cpp)
-  target_link_libraries(utilities-test ${catkin_LIBRARIES} lanelet2_extension_lib)
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(message_conversion-test test/src/test_message_conversion.cpp)
+  target_link_libraries(message_conversion-test lanelet2_extension_lib)
+  ament_add_gtest(projector-test test/src/test_projector.cpp)
+  target_link_libraries(projector-test lanelet2_extension_lib)
+  ament_add_gtest(query-test test/src/test_query.cpp)
+  target_link_libraries(query-test lanelet2_extension_lib)
+  ament_add_gtest(regulatory_elements-test test/src/test_regulatory_elements.cpp)
+  target_link_libraries(regulatory_elements-test lanelet2_extension_lib)
+  ament_add_gtest(utilities-test test/src/test_utilities.cpp)
+  target_link_libraries(utilities-test lanelet2_extension_lib)
 endif()
+
+ament_package()

--- a/map/lanelet2_extension/include/lanelet2_extension/utility/message_conversion.h
+++ b/map/lanelet2_extension/include/lanelet2_extension/utility/message_conversion.h
@@ -19,10 +19,10 @@
 #ifndef LANELET2_EXTENSION_UTILITY_MESSAGE_CONVERSION_H
 #define LANELET2_EXTENSION_UTILITY_MESSAGE_CONVERSION_H
 
-#include <autoware_lanelet2_msgs/MapBin.h>
-#include <geometry_msgs/Point.h>
-#include <geometry_msgs/Point32.h>
-#include <geometry_msgs/Polygon.h>
+#include <autoware_lanelet2_msgs/msg/map_bin.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/point32.hpp>
+#include <geometry_msgs/msg/polygon.hpp>
 #include <lanelet2_core/LaneletMap.h>
 
 #include <lanelet2_routing/RoutingGraph.h>
@@ -40,7 +40,7 @@ namespace conversion
  * @param map [lanelet map data]
  * @param msg [converted ROS message. Only "data" field is filled]
  */
-void toBinMsg(const lanelet::LaneletMapPtr & map, autoware_lanelet2_msgs::MapBin * msg);
+void toBinMsg(const lanelet::LaneletMapPtr & map, autoware_lanelet2_msgs::msg::MapBin * msg);
 
 /**
  * [fromBinMsg converts ROS message into lanelet2 data. Similar implementation
@@ -48,51 +48,51 @@ void toBinMsg(const lanelet::LaneletMapPtr & map, autoware_lanelet2_msgs::MapBin
  * @param msg [ROS message for lanelet map]
  * @param map [Converted lanelet2 data]
  */
-void fromBinMsg(const autoware_lanelet2_msgs::MapBin & msg, lanelet::LaneletMapPtr map);
+void fromBinMsg(const autoware_lanelet2_msgs::msg::MapBin & msg, lanelet::LaneletMapPtr map);
 void fromBinMsg(
-  const autoware_lanelet2_msgs::MapBin & msg, lanelet::LaneletMapPtr map,
+  const autoware_lanelet2_msgs::msg::MapBin & msg, lanelet::LaneletMapPtr map,
   lanelet::traffic_rules::TrafficRulesPtr * traffic_rules,
   lanelet::routing::RoutingGraphPtr * routing_graph);
 
 /**
  * [toGeomMsgPt converts various point types to geometry_msgs point]
- * @param src [input point(geometry_msgs::Point3,
+ * @param src [input point(geometry_msgs::msg::Point3,
  * Eigen::VEctor3d=lanelet::BasicPoint3d, lanelet::Point3d, lanelet::Point2d) ]
  * @param dst [converted geometry_msgs point]
  */
-void toGeomMsgPt(const geometry_msgs::Point32 & src, geometry_msgs::Point * dst);
-void toGeomMsgPt(const Eigen::Vector3d & src, geometry_msgs::Point * dst);
-void toGeomMsgPt(const lanelet::ConstPoint3d & src, geometry_msgs::Point * dst);
-void toGeomMsgPt(const lanelet::ConstPoint2d & src, geometry_msgs::Point * dst);
+void toGeomMsgPt(const geometry_msgs::msg::Point32 & src, geometry_msgs::msg::Point * dst);
+void toGeomMsgPt(const Eigen::Vector3d & src, geometry_msgs::msg::Point * dst);
+void toGeomMsgPt(const lanelet::ConstPoint3d & src, geometry_msgs::msg::Point * dst);
+void toGeomMsgPt(const lanelet::ConstPoint2d & src, geometry_msgs::msg::Point * dst);
 
 /**
  * [toGeomMsgPt converts various point types to geometry_msgs point]
- * @param src [input point(geometry_msgs::Point3,
+ * @param src [input point(geometry_msgs::msg::Point3,
  * Eigen::VEctor3d=lanelet::BasicPoint3d, lanelet::Point3d, lanelet::Point2d) ]
  * @return    [converted geometry_msgs point]
  */
-geometry_msgs::Point toGeomMsgPt(const geometry_msgs::Point32 & src);
-geometry_msgs::Point toGeomMsgPt(const Eigen::Vector3d & src);
-geometry_msgs::Point toGeomMsgPt(const lanelet::ConstPoint3d & src);
-geometry_msgs::Point toGeomMsgPt(const lanelet::ConstPoint2d & src);
+geometry_msgs::msg::Point toGeomMsgPt(const geometry_msgs::msg::Point32 & src);
+geometry_msgs::msg::Point toGeomMsgPt(const Eigen::Vector3d & src);
+geometry_msgs::msg::Point toGeomMsgPt(const lanelet::ConstPoint3d & src);
+geometry_msgs::msg::Point toGeomMsgPt(const lanelet::ConstPoint2d & src);
 
-lanelet::ConstPoint3d toLaneletPoint(const geometry_msgs::Point & src);
-void toLaneletPoint(const geometry_msgs::Point & src, lanelet::ConstPoint3d * dst);
+lanelet::ConstPoint3d toLaneletPoint(const geometry_msgs::msg::Point & src);
+void toLaneletPoint(const geometry_msgs::msg::Point & src, lanelet::ConstPoint3d * dst);
 
 /**
  * [toGeomMsgPoly converts lanelet polygon to geometry_msgs polygon]
  * @param ll_poly   [input polygon]
  * @param geom_poly [converted geometry_msgs point]
  */
-void toGeomMsgPoly(const lanelet::ConstPolygon3d & ll_poly, geometry_msgs::Polygon * geom_poly);
+void toGeomMsgPoly(const lanelet::ConstPolygon3d & ll_poly, geometry_msgs::msg::Polygon * geom_poly);
 
 /**
  * [toGeomMsgPt32 converts Eigen::Vector3d(lanelet:BasicPoint3d to
- * geometry_msgs::Point32)]
+ * geometry_msgs::msg::Point32)]
  * @param src [input point]
  * @param dst [conveted point]
  */
-void toGeomMsgPt32(const Eigen::Vector3d & src, geometry_msgs::Point32 * dst);
+void toGeomMsgPt32(const Eigen::Vector3d & src, geometry_msgs::msg::Point32 * dst);
 
 }  // namespace conversion
 }  // namespace utils

--- a/map/lanelet2_extension/include/lanelet2_extension/utility/query.h
+++ b/map/lanelet2_extension/include/lanelet2_extension/utility/query.h
@@ -23,9 +23,8 @@
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
-#include <geometry_msgs/Point.h>
-#include <geometry_msgs/PolygonStamped.h>
-#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
 #include <lanelet2_extension/regulatory_elements/autoware_traffic_light.h>
 #include <lanelet2_extension/regulatory_elements/detection_area.h>
 
@@ -174,14 +173,14 @@ ConstLanelets getLaneletsWithinRange(
   const lanelet::ConstLanelets & lanelets, const lanelet::BasicPoint2d & search_point,
   const double range);
 ConstLanelets getLaneletsWithinRange(
-  const lanelet::ConstLanelets & lanelets, const geometry_msgs::Point & search_point,
+  const lanelet::ConstLanelets & lanelets, const geometry_msgs::msg::Point & search_point,
   const double range);
 
 ConstLanelets getLaneChangeableNeighbors(
   const routing::RoutingGraphPtr & graph, const ConstLanelet & lanelet);
 ConstLanelets getLaneChangeableNeighbors(
   const routing::RoutingGraphPtr & graph, const ConstLanelets & road_lanelets,
-  const geometry_msgs::Point & search_point);
+  const geometry_msgs::msg::Point & search_point);
 
 ConstLanelets getAllNeighbors(const routing::RoutingGraphPtr & graph, const ConstLanelet & lanelet);
 ConstLanelets getAllNeighborsLeft(
@@ -190,10 +189,10 @@ ConstLanelets getAllNeighborsRight(
   const routing::RoutingGraphPtr & graph, const ConstLanelet & lanelet);
 ConstLanelets getAllNeighbors(
   const routing::RoutingGraphPtr & graph, const ConstLanelets & road_lanelets,
-  const geometry_msgs::Point & search_point);
+  const geometry_msgs::msg::Point & search_point);
 
 bool getClosestLanelet(
-  const ConstLanelets & lanelets, const geometry_msgs::Pose & search_pose,
+  const ConstLanelets & lanelets, const geometry_msgs::msg::Pose & search_pose,
   ConstLanelet * closest_lanelet_ptr);
 
 /**

--- a/map/lanelet2_extension/include/lanelet2_extension/utility/utilities.h
+++ b/map/lanelet2_extension/include/lanelet2_extension/utility/utilities.h
@@ -19,8 +19,8 @@
 #ifndef LANELET2_EXTENSION_UTILITY_UTILITIES_H
 #define LANELET2_EXTENSION_UTILITY_UTILITIES_H
 
-#include <geometry_msgs/Point.h>
-#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
 
 #include <lanelet2_routing/Route.h>
 #include <lanelet2_routing/RoutingGraph.h>
@@ -53,7 +53,7 @@ double getLaneletLength2d(const lanelet::ConstLanelets & lanelet_sequence);
 double getLaneletLength3d(const lanelet::ConstLanelets & lanelet_sequence);
 
 lanelet::ArcCoordinates getArcCoordinates(
-  const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::Pose & pose);
+  const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose);
 
 lanelet::ConstLineString3d getClosestSegment(
   const lanelet::BasicPoint2d & search_pt, const lanelet::ConstLineString3d & linestring);
@@ -61,7 +61,7 @@ lanelet::ConstLineString3d getClosestSegment(
 lanelet::CompoundPolygon3d getPolygonFromArcLength(
   const lanelet::ConstLanelets & lanelets, const double s1, const double s2);
 double getLaneletAngle(
-  const lanelet::ConstLanelet & lanelet, const geometry_msgs::Point & search_point);
+  const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_point);
 
 }  // namespace utils
 }  // namespace lanelet

--- a/map/lanelet2_extension/include/lanelet2_extension/visualization/visualization.h
+++ b/map/lanelet2_extension/include/lanelet2_extension/visualization/visualization.h
@@ -19,8 +19,10 @@
 #ifndef LANELET2_EXTENSION_VISUALIZATION_VISUALIZATION_H
 #define LANELET2_EXTENSION_VISUALIZATION_VISUALIZATION_H
 
-#include <geometry_msgs/PolygonStamped.h>
-#include <visualization_msgs/MarkerArray.h>
+#include <geometry_msgs/msg/polygon.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <rclcpp/rclcpp.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/primitives/Lanelet.h>
@@ -42,7 +44,7 @@ namespace visualization
  * @param triangles [array of polygon message, each containing 3 vertices]
  */
 void lanelet2Triangle(
-  const lanelet::ConstLanelet & ll, std::vector<geometry_msgs::Polygon> * triangles);
+  const lanelet::ConstLanelet & ll, std::vector<geometry_msgs::msg::Polygon> * triangles);
 
 /**
  * [polygon2Triangle converts polygon into vector of triangles]
@@ -50,14 +52,14 @@ void lanelet2Triangle(
  * @param triangles [array of polygon message, each containing 3 vertices]
  */
 void polygon2Triangle(
-  const geometry_msgs::Polygon & polygon, std::vector<geometry_msgs::Polygon> * triangles);
+  const geometry_msgs::msg::Polygon & polygon, std::vector<geometry_msgs::msg::Polygon> * triangles);
 
 /**
  * [lanelet2Polygon converts lanelet into a polygon]
  * @param ll      [input lanelet]
  * @param polygon [polygon message containing shape of the input lanelet.]
  */
-void lanelet2Polygon(const lanelet::ConstLanelet & ll, geometry_msgs::Polygon * polygon);
+void lanelet2Polygon(const lanelet::ConstLanelet & ll, geometry_msgs::msg::Polygon * polygon);
 
 /**
  * [lineString2Marker creates marker to visualize shape of linestring]
@@ -69,8 +71,8 @@ void lanelet2Polygon(const lanelet::ConstLanelet & ll, geometry_msgs::Polygon * 
  * @param lss        [thickness of the marker]
  */
 void lineString2Marker(
-  const lanelet::ConstLineString3d ls, visualization_msgs::Marker * line_strip,
-  const std::string frame_id, const std::string ns, const std_msgs::ColorRGBA c,
+  const lanelet::ConstLineString3d ls, visualization_msgs::msg::Marker * line_strip,
+  const std::string frame_id, const std::string ns, const std_msgs::msg::ColorRGBA c,
   const float lss = 0.1);
 /**
  * [trafficLight2TriangleMarker creates marker to visualize shape of traffic
@@ -82,8 +84,8 @@ void lineString2Marker(
  * @param duration [lifetime of the marker]
  */
 void trafficLight2TriangleMarker(
-  const lanelet::ConstLineString3d ls, visualization_msgs::Marker * marker, const std::string ns,
-  const std_msgs::ColorRGBA cl, const ros::Duration duration = ros::Duration(),
+  const lanelet::ConstLineString3d ls, visualization_msgs::msg::Marker * marker, const std::string ns,
+  const std_msgs::msg::ColorRGBA cl, const rclcpp::Duration duration = rclcpp::Duration(0, 0),
   const double scale = 1.0);
 
 /**
@@ -94,8 +96,8 @@ void trafficLight2TriangleMarker(
  * @param  viz_centerline [flag to visuazlize centerline or not]
  * @return                [created marker array]
  */
-visualization_msgs::MarkerArray laneletsBoundaryAsMarkerArray(
-  const lanelet::ConstLanelets & lanelets, const std_msgs::ColorRGBA c, const bool viz_centerline);
+visualization_msgs::msg::MarkerArray laneletsBoundaryAsMarkerArray(
+  const lanelet::ConstLanelets & lanelets, const std_msgs::msg::ColorRGBA c, const bool viz_centerline);
 /**
  * [laneletsAsTriangleMarkerArray create marker array to visualize shape of the
  * lanelet]
@@ -104,8 +106,8 @@ visualization_msgs::MarkerArray laneletsBoundaryAsMarkerArray(
  * @param  c        [color of the marker]
  * @return          [created marker]
  */
-visualization_msgs::MarkerArray laneletsAsTriangleMarkerArray(
-  const std::string ns, const lanelet::ConstLanelets & lanelets, const std_msgs::ColorRGBA c);
+visualization_msgs::msg::MarkerArray laneletsAsTriangleMarkerArray(
+  const std::string ns, const lanelet::ConstLanelets & lanelets, const std_msgs::msg::ColorRGBA c);
 
 /**
  * [laneletDirectionAsMarkerArray create marker array to visualize direction of
@@ -113,7 +115,7 @@ visualization_msgs::MarkerArray laneletsAsTriangleMarkerArray(
  * @param  lanelets [input lanelets]
  * @return          [created marker array]
  */
-visualization_msgs::MarkerArray laneletDirectionAsMarkerArray(
+visualization_msgs::msg::MarkerArray laneletDirectionAsMarkerArray(
   const lanelet::ConstLanelets lanelets);
 
 /**
@@ -125,9 +127,9 @@ visualization_msgs::MarkerArray laneletDirectionAsMarkerArray(
  * @param  lss          [thickness of the marker]
  * @return              [created marker array]
  */
-visualization_msgs::MarkerArray lineStringsAsMarkerArray(
+visualization_msgs::msg::MarkerArray lineStringsAsMarkerArray(
   const std::vector<lanelet::ConstLineString3d> line_strings, const std::string name_space,
-  const std_msgs::ColorRGBA c, const double lss);
+  const std_msgs::msg::ColorRGBA c, const double lss);
 
 /**
  * [autowareTrafficLightsAsMarkerArray creates marker array to visualize traffic
@@ -137,9 +139,9 @@ visualization_msgs::MarkerArray lineStringsAsMarkerArray(
  * @param  duration     [lifetime of the marker]
  * @return              [created marker array]
  */
-visualization_msgs::MarkerArray autowareTrafficLightsAsMarkerArray(
+visualization_msgs::msg::MarkerArray autowareTrafficLightsAsMarkerArray(
   const std::vector<lanelet::AutowareTrafficLightConstPtr> tl_reg_elems,
-  const std_msgs::ColorRGBA c, const ros::Duration duration = ros::Duration(),
+  const std_msgs::msg::ColorRGBA c, const rclcpp::Duration duration = rclcpp::Duration(0, 0),
   const double scale = 1.0);
 
 /**
@@ -150,9 +152,9 @@ visualization_msgs::MarkerArray autowareTrafficLightsAsMarkerArray(
  * @param  duration     [lifetime of the marker]
  * @return              [created marker array]
  */
-visualization_msgs::MarkerArray trafficLightsAsTriangleMarkerArray(
-  const std::vector<lanelet::TrafficLightConstPtr> tl_reg_elems, const std_msgs::ColorRGBA c,
-  const ros::Duration duration = ros::Duration(), const double scale = 1.0);
+visualization_msgs::msg::MarkerArray trafficLightsAsTriangleMarkerArray(
+  const std::vector<lanelet::TrafficLightConstPtr> tl_reg_elems, const std_msgs::msg::ColorRGBA c,
+  const rclcpp::Duration duration = rclcpp::Duration(0, 0), const double scale = 1.0);
 
 /**
  * [detectionAreasAsMarkerArray creates marker array to visualize detection areas]
@@ -160,14 +162,14 @@ visualization_msgs::MarkerArray trafficLightsAsTriangleMarkerArray(
  * @param  c            [color of the marker]
  * @param  duration     [lifetime of the marker]
  */
-visualization_msgs::MarkerArray detectionAreasAsMarkerArray(
-  const std::vector<lanelet::DetectionAreaConstPtr> & da_reg_elems, const std_msgs::ColorRGBA c,
-  const ros::Duration duration = ros::Duration());
+visualization_msgs::msg::MarkerArray detectionAreasAsMarkerArray(
+  const std::vector<lanelet::DetectionAreaConstPtr> & da_reg_elems, const std_msgs::msg::ColorRGBA c,
+  const rclcpp::Duration duration = rclcpp::Duration(0, 0));
 
-visualization_msgs::MarkerArray parkingLotsAsMarkerArray(
-  const lanelet::ConstPolygons3d & parking_lots, const std_msgs::ColorRGBA & c);
-visualization_msgs::MarkerArray parkingSpacesAsMarkerArray(
-  const lanelet::ConstLineStrings3d & parking_spaces, const std_msgs::ColorRGBA & c);
+visualization_msgs::msg::MarkerArray parkingLotsAsMarkerArray(
+  const lanelet::ConstPolygons3d & parking_lots, const std_msgs::msg::ColorRGBA & c);
+visualization_msgs::msg::MarkerArray parkingSpacesAsMarkerArray(
+  const lanelet::ConstLineStrings3d & parking_spaces, const std_msgs::msg::ColorRGBA & c);
 
 }  // namespace visualization
 }  // namespace lanelet

--- a/map/lanelet2_extension/lib/message_conversion.cpp
+++ b/map/lanelet2_extension/lib/message_conversion.cpp
@@ -23,7 +23,6 @@
 #include <lanelet2_io/io_handlers/OsmHandler.h>
 #include <lanelet2_io/io_handlers/Serialize.h>
 #include <lanelet2_projection/UTM.h>
-#include <ros/ros.h>
 
 #include <lanelet2_extension/projection/mgrs_projector.h>
 #include <lanelet2_extension/utility/message_conversion.h>
@@ -40,10 +39,10 @@ namespace utils
 {
 namespace conversion
 {
-void toBinMsg(const lanelet::LaneletMapPtr & map, autoware_lanelet2_msgs::MapBin * msg)
+void toBinMsg(const lanelet::LaneletMapPtr & map, autoware_lanelet2_msgs::msg::MapBin * msg)
 {
   if (msg == nullptr) {
-    ROS_ERROR_STREAM(__FUNCTION__ << "msg is null pointer!");
+    std::cerr << __FUNCTION__ << "msg is null pointer!";
     return;
   }
 
@@ -59,10 +58,10 @@ void toBinMsg(const lanelet::LaneletMapPtr & map, autoware_lanelet2_msgs::MapBin
   msg->data.assign(data_str.begin(), data_str.end());
 }
 
-void fromBinMsg(const autoware_lanelet2_msgs::MapBin & msg, lanelet::LaneletMapPtr map)
+void fromBinMsg(const autoware_lanelet2_msgs::msg::MapBin & msg, lanelet::LaneletMapPtr map)
 {
   if (!map) {
-    ROS_ERROR_STREAM(__FUNCTION__ << ": map is null pointer!");
+    std::cerr << __FUNCTION__ << ": map is null pointer!";
     return;
   }
 
@@ -80,7 +79,7 @@ void fromBinMsg(const autoware_lanelet2_msgs::MapBin & msg, lanelet::LaneletMapP
 }
 
 void fromBinMsg(
-  const autoware_lanelet2_msgs::MapBin & msg, lanelet::LaneletMapPtr map,
+  const autoware_lanelet2_msgs::msg::MapBin & msg, lanelet::LaneletMapPtr map,
   lanelet::traffic_rules::TrafficRulesPtr * traffic_rules,
   lanelet::routing::RoutingGraphPtr * routing_graph)
 {
@@ -90,40 +89,40 @@ void fromBinMsg(
   *routing_graph = lanelet::routing::RoutingGraph::build(*map, **traffic_rules);
 }
 
-void toGeomMsgPt(const geometry_msgs::Point32 & src, geometry_msgs::Point * dst)
+void toGeomMsgPt(const geometry_msgs::msg::Point32 & src, geometry_msgs::msg::Point * dst)
 {
   if (dst == nullptr) {
-    ROS_ERROR_STREAM(__FUNCTION__ << "pointer is null!");
+    std::cerr << __FUNCTION__ << "pointer is null!";
     return;
   }
   dst->x = src.x;
   dst->y = src.y;
   dst->z = src.z;
 }
-void toGeomMsgPt(const Eigen::Vector3d & src, geometry_msgs::Point * dst)
+void toGeomMsgPt(const Eigen::Vector3d & src, geometry_msgs::msg::Point * dst)
 {
   if (dst == nullptr) {
-    ROS_ERROR_STREAM(__FUNCTION__ << "pointer is null!");
+    std::cerr << __FUNCTION__ << "pointer is null!";
     return;
   }
   dst->x = src.x();
   dst->y = src.y();
   dst->z = src.z();
 }
-void toGeomMsgPt(const lanelet::ConstPoint3d & src, geometry_msgs::Point * dst)
+void toGeomMsgPt(const lanelet::ConstPoint3d & src, geometry_msgs::msg::Point * dst)
 {
   if (dst == nullptr) {
-    ROS_ERROR_STREAM(__FUNCTION__ << "pointer is null!");
+    std::cerr << __FUNCTION__ << "pointer is null!";
     return;
   }
   dst->x = src.x();
   dst->y = src.y();
   dst->z = src.z();
 }
-void toGeomMsgPt(const lanelet::ConstPoint2d & src, geometry_msgs::Point * dst)
+void toGeomMsgPt(const lanelet::ConstPoint2d & src, geometry_msgs::msg::Point * dst)
 {
   if (dst == nullptr) {
-    ROS_ERROR_STREAM(__FUNCTION__ << "pointer is null!");
+    std::cerr << __FUNCTION__ << "pointer is null!" << std::endl;
     return;
   }
   dst->x = src.x();
@@ -131,10 +130,10 @@ void toGeomMsgPt(const lanelet::ConstPoint2d & src, geometry_msgs::Point * dst)
   dst->z = 0;
 }
 
-void toGeomMsgPt32(const Eigen::Vector3d & src, geometry_msgs::Point32 * dst)
+void toGeomMsgPt32(const Eigen::Vector3d & src, geometry_msgs::msg::Point32 * dst)
 {
   if (dst == nullptr) {
-    ROS_ERROR_STREAM(__FUNCTION__ << "pointer is null!");
+    std::cerr << __FUNCTION__ << "pointer is null!" << std::endl;
     return;
   }
   dst->x = src.x();
@@ -142,49 +141,49 @@ void toGeomMsgPt32(const Eigen::Vector3d & src, geometry_msgs::Point32 * dst)
   dst->z = src.z();
 }
 
-geometry_msgs::Point toGeomMsgPt(const geometry_msgs::Point32 & src)
+geometry_msgs::msg::Point toGeomMsgPt(const geometry_msgs::msg::Point32 & src)
 {
-  geometry_msgs::Point dst;
+  geometry_msgs::msg::Point dst;
   toGeomMsgPt(src, &dst);
   return dst;
 }
-geometry_msgs::Point toGeomMsgPt(const Eigen::Vector3d & src)
+geometry_msgs::msg::Point toGeomMsgPt(const Eigen::Vector3d & src)
 {
-  geometry_msgs::Point dst;
+  geometry_msgs::msg::Point dst;
   toGeomMsgPt(src, &dst);
   return dst;
 }
-geometry_msgs::Point toGeomMsgPt(const lanelet::ConstPoint3d & src)
+geometry_msgs::msg::Point toGeomMsgPt(const lanelet::ConstPoint3d & src)
 {
-  geometry_msgs::Point dst;
+  geometry_msgs::msg::Point dst;
   toGeomMsgPt(src, &dst);
   return dst;
 }
-geometry_msgs::Point toGeomMsgPt(const lanelet::ConstPoint2d & src)
+geometry_msgs::msg::Point toGeomMsgPt(const lanelet::ConstPoint2d & src)
 {
-  geometry_msgs::Point dst;
+  geometry_msgs::msg::Point dst;
   toGeomMsgPt(src, &dst);
   return dst;
 }
 
-lanelet::ConstPoint3d toLaneletPoint(const geometry_msgs::Point & src)
+lanelet::ConstPoint3d toLaneletPoint(const geometry_msgs::msg::Point & src)
 {
   lanelet::ConstPoint3d dst;
   toLaneletPoint(src, &dst);
   return dst;
 }
 
-void toLaneletPoint(const geometry_msgs::Point & src, lanelet::ConstPoint3d * dst)
+void toLaneletPoint(const geometry_msgs::msg::Point & src, lanelet::ConstPoint3d * dst)
 {
   *dst = lanelet::Point3d(lanelet::InvalId, src.x, src.y, src.z);
 }
 
-void toGeomMsgPoly(const lanelet::ConstPolygon3d & ll_poly, geometry_msgs::Polygon * geom_poly)
+void toGeomMsgPoly(const lanelet::ConstPolygon3d & ll_poly, geometry_msgs::msg::Polygon * geom_poly)
 {
   geom_poly->points.clear();
   geom_poly->points.reserve(ll_poly.size());
   for (const auto & ll_pt : ll_poly) {
-    geometry_msgs::Point32 geom_pt32;
+    geometry_msgs::msg::Point32 geom_pt32;
     utils::conversion::toGeomMsgPt32(ll_pt.basicPoint(), &geom_pt32);
     geom_poly->points.push_back(geom_pt32);
   }

--- a/map/lanelet2_extension/lib/mgrs_projector.cpp
+++ b/map/lanelet2_extension/lib/mgrs_projector.cpp
@@ -17,11 +17,11 @@
  */
 
 #include <lanelet2_extension/projection/mgrs_projector.h>
-#include <ros/ros.h>
 
 #include <set>
 #include <string>
 #include <vector>
+#include <iostream>
 
 namespace lanelet
 {
@@ -50,7 +50,7 @@ BasicPoint3d MGRSProjector::forward(const GPSPoint & gps, const int precision) c
     GeographicLib::MGRS::Forward(
       zone, northp, utm_point.x(), utm_point.y(), gps.lat, precision, mgrs_code);
   } catch (GeographicLib::GeographicErr err) {
-    ROS_ERROR_STREAM(err.what());
+    std::cerr << err.what() << std::endl;
     return mgrs_point;
   }
 
@@ -60,11 +60,10 @@ BasicPoint3d MGRSProjector::forward(const GPSPoint & gps, const int precision) c
   projected_grid_ = mgrs_code;
 
   if (!prev_projected_grid.empty() && prev_projected_grid != projected_grid_) {
-    ROS_ERROR_STREAM(
-      "Projected MGRS Grid changed from last projection. Projected point "
-      "might be far away from previously projected point."
-      << std::endl
-      << "You may want to use different projector.");
+    std::cerr << "Projected MGRS Grid changed from last projection. Projected point"
+                 "might be far away from previously projected point." 
+              << std::endl
+              << "You may want to use different projector.";
   }
 
   return mgrs_point;
@@ -79,13 +78,8 @@ GPSPoint MGRSProjector::reverse(const BasicPoint3d & mgrs_point) const
   } else if (!projected_grid_.empty()) {
     gps = reverse(mgrs_point, projected_grid_);
   } else {
-    ROS_ERROR_STREAM(
-      "cannot run reverse operation if mgrs code is not set in projector."
-      << std::endl
-      << "use setMGRSCode function "
-         "or explicitly give mgrs "
-         "code as an "
-         "argument.");
+    std::cerr << "cannot run reverse operation if mgrs code is not set in projector." << std::endl
+              << "use setMGRSCode function or explicitly give mgrs code as an argument.";
   }
   return gps;
 }
@@ -105,7 +99,7 @@ GPSPoint MGRSProjector::reverse(
     utm_point.y() += fmod(mgrs_point.y(), pow(10, 5 - prec));
     GeographicLib::UTMUPS::Reverse(zone, northp, utm_point.x(), utm_point.y(), gps.lat, gps.lon);
   } catch (GeographicLib::GeographicErr err) {
-    ROS_ERROR_STREAM("Failed to convert from MGRS to WGS" << err.what());
+    std::cerr << "Failed to convert from MGRS to WGS";
     return gps;
   }
 
@@ -126,7 +120,7 @@ void MGRSProjector::setMGRSCode(const GPSPoint & gps, const int precision)
     GeographicLib::MGRS::Forward(
       zone, northp, utm_point.x(), utm_point.y(), gps.lat, precision, mgrs_code);
   } catch (GeographicLib::GeographicErr err) {
-    ROS_ERROR_STREAM(err.what());
+    std::cerr << err.what() << std::endl;
   }
 
   setMGRSCode(mgrs_code);

--- a/map/lanelet2_extension/lib/query.cpp
+++ b/map/lanelet2_extension/lib/query.cpp
@@ -16,8 +16,6 @@
  * Authors: Simon Thompson, Ryohsuke Mitsudome
  */
 
-#include <ros/ros.h>
-
 #include <Eigen/Eigen>
 
 #include <lanelet2_core/geometry/Lanelet.h>
@@ -57,7 +55,7 @@ lanelet::ConstLanelets query::laneletLayer(const lanelet::LaneletMapConstPtr & l
 {
   lanelet::ConstLanelets lanelets;
   if (!ll_map) {
-    ROS_WARN("No map received!");
+    std::cerr << "No map received!";
     return lanelets;
   }
 
@@ -528,10 +526,10 @@ ConstLanelets query::getLaneletsWithinRange(
 }
 
 ConstLanelets query::getLaneletsWithinRange(
-  const lanelet::ConstLanelets & lanelets, const geometry_msgs::Point & search_point,
+  const lanelet::ConstLanelets & lanelets, const geometry_msgs::msg::Point & search_point,
   const double range)
 {
-  getLaneletsWithinRange(lanelets, lanelet::BasicPoint2d(search_point.x, search_point.y), range);
+  return getLaneletsWithinRange(lanelets, lanelet::BasicPoint2d(search_point.x, search_point.y), range);
 }
 
 ConstLanelets query::getLaneChangeableNeighbors(
@@ -542,7 +540,7 @@ ConstLanelets query::getLaneChangeableNeighbors(
 
 ConstLanelets query::getLaneChangeableNeighbors(
   const routing::RoutingGraphPtr & graph, const ConstLanelets & road_lanelets,
-  const geometry_msgs::Point & search_point)
+  const geometry_msgs::msg::Point & search_point)
 {
   const auto lanelets =
     getLaneletsWithinRange(road_lanelets, search_point, std::numeric_limits<double>::epsilon());
@@ -599,7 +597,7 @@ ConstLanelets query::getAllNeighborsLeft(
 
 ConstLanelets query::getAllNeighbors(
   const routing::RoutingGraphPtr & graph, const ConstLanelets & road_lanelets,
-  const geometry_msgs::Point & search_point)
+  const geometry_msgs::msg::Point & search_point)
 {
   const auto lanelets =
     getLaneletsWithinRange(road_lanelets, search_point, std::numeric_limits<double>::epsilon());
@@ -612,11 +610,11 @@ ConstLanelets query::getAllNeighbors(
 }
 
 bool query::getClosestLanelet(
-  const ConstLanelets & lanelets, const geometry_msgs::Pose & search_pose,
+  const ConstLanelets & lanelets, const geometry_msgs::msg::Pose & search_pose,
   ConstLanelet * closest_lanelet_ptr)
 {
   if (closest_lanelet_ptr == nullptr) {
-    ROS_ERROR("argument closest_lanelet_ptr is null! Failed to find closest lanelet");
+    std::cerr << "argument closest_lanelet_ptr is null! Failed to find closest lanelet" << std::endl;
     return false;
   }
 

--- a/map/lanelet2_extension/lib/utilities.cpp
+++ b/map/lanelet2_extension/lib/utilities.cpp
@@ -61,13 +61,11 @@ void getContactingLanelets(
 {
   if (!lanelet_map) {
     std::cerr << "No lanelet map is set!" << std::endl;
-    ;
     return;
   }
 
   if (contacting_lanelet_ids == nullptr) {
     std::cerr << __FUNCTION__ << " contacting_lanelet_ids is null pointer!" << std::endl;
-    ;
     return;
   }
 
@@ -308,7 +306,6 @@ bool lineStringWithWidthToPolygon(
   if (polygon == nullptr) {
     std::cerr << __func__ << ": polygon is null pointer! Failed to convert to polygon."
               << std::endl;
-    ;
     return false;
   }
   if (linestring.size() != 2) {

--- a/map/lanelet2_extension/lib/utilities.cpp
+++ b/map/lanelet2_extension/lib/utilities.cpp
@@ -27,7 +27,6 @@
 #include <lanelet2_extension/utility/message_conversion.h>
 #include <lanelet2_extension/utility/query.h>
 #include <lanelet2_extension/utility/utilities.h>
-#include <ros/ros.h>
 
 #include <algorithm>
 #include <map>
@@ -61,12 +60,14 @@ void getContactingLanelets(
   const lanelet::BasicPoint2d search_point, std::vector<int> * contacting_lanelet_ids)
 {
   if (!lanelet_map) {
-    ROS_ERROR_STREAM("No lanelet map is set!");
+    std::cerr << "No lanelet map is set!" << std::endl;
+    ;
     return;
   }
 
   if (contacting_lanelet_ids == nullptr) {
-    ROS_ERROR_STREAM(__FUNCTION__ << " contacting_lanelet_ids is null pointer!");
+    std::cerr << __FUNCTION__ << " contacting_lanelet_ids is null pointer!" << std::endl;
+    ;
     return;
   }
 
@@ -275,7 +276,8 @@ lanelet::LineString3d generateFineCenterline(
   return centerline;
 }
 
-void overwriteLaneletsCenterline(lanelet::LaneletMapPtr lanelet_map, const double resolution, const bool force_overwrite)
+void overwriteLaneletsCenterline(
+  lanelet::LaneletMapPtr lanelet_map, const double resolution, const bool force_overwrite)
 {
   for (auto & lanelet_obj : lanelet_map->laneletLayer) {
     if (force_overwrite || !lanelet_obj.hasCustomCenterline()) {
@@ -304,20 +306,20 @@ bool lineStringWithWidthToPolygon(
   const lanelet::ConstLineString3d & linestring, lanelet::ConstPolygon3d * polygon)
 {
   if (polygon == nullptr) {
-    ROS_ERROR_STREAM(__func__ << ": polygon is null pointer! Failed to convert to polygon.");
+    std::cerr << __func__ << ": polygon is null pointer! Failed to convert to polygon."
+              << std::endl;
+    ;
     return false;
   }
   if (linestring.size() != 2) {
-    ROS_ERROR_STREAM(
-      __func__ << ": linestring" << linestring.id() << " must have 2 points! (" << linestring.size()
-               << " != 2)" << std::endl
-               << "Failed to convert to polygon.");
+    std::cerr << __func__ << ": linestring" << linestring.id() << " must have 2 points! ("
+              << linestring.size() << " != 2)" << std::endl
+              << "Failed to convert to polygon.";
     return false;
   }
   if (!linestring.hasAttribute("width")) {
-    ROS_ERROR_STREAM(
-      __func__ << ": linestring" << linestring.id()
-               << " does not have width tag. Failed to convert to polygon.");
+    std::cerr << __func__ << ": linestring" << linestring.id()
+              << " does not have width tag. Failed to convert to polygon.";
     return false;
   }
 
@@ -371,7 +373,7 @@ double getLaneletLength3d(const lanelet::ConstLanelets & lanelet_sequence)
 }
 
 lanelet::ArcCoordinates getArcCoordinates(
-  const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::Pose & pose)
+  const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose)
 {
   lanelet::ConstLanelet closest_lanelet;
   lanelet::utils::query::getClosestLanelet(lanelet_sequence, pose, &closest_lanelet);
@@ -454,7 +456,7 @@ lanelet::CompoundPolygon3d getPolygonFromArcLength(
 }
 
 double getLaneletAngle(
-  const lanelet::ConstLanelet & lanelet, const geometry_msgs::Point & search_point)
+  const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_point)
 {
   lanelet::BasicPoint2d llt_search_point(search_point.x, search_point.y);
   lanelet::ConstLineString3d segment = getClosestSegment(llt_search_point, lanelet.centerline());

--- a/map/lanelet2_extension/lib/visualization.cpp
+++ b/map/lanelet2_extension/lib/visualization.cpp
@@ -16,9 +16,8 @@
  * Authors: Simon Thompson, Ryohsuke Mitsudome
  */
 
-#include <ros/ros.h>
-#include <visualization_msgs/Marker.h>
-#include <visualization_msgs/MarkerArray.h>
+#include <visualization_msgs/msg/marker.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 #include <Eigen/Eigen>
 
@@ -40,11 +39,11 @@ bool exists(const std::unordered_set<T> & set, const T & element)
 }
 
 void adjacentPoints(
-  const int i, const int N, const geometry_msgs::Polygon poly, geometry_msgs::Point32 * p0,
-  geometry_msgs::Point32 * p1, geometry_msgs::Point32 * p2)
+  const int i, const int N, const geometry_msgs::msg::Polygon poly, geometry_msgs::msg::Point32 * p0,
+  geometry_msgs::msg::Point32 * p1, geometry_msgs::msg::Point32 * p2)
 {
   if (p0 == nullptr || p1 == nullptr || p2 == nullptr) {
-    ROS_ERROR_STREAM(__FUNCTION__ << ": either p0, p1, or p2 is null pointer!");
+    std::cerr << __FUNCTION__ << ": either p0, p1, or p2 is null pointer!" << std::endl;
     return;
   }
 
@@ -60,7 +59,7 @@ void adjacentPoints(
     *p2 = poly.points[0];
 }
 
-double hypot(const geometry_msgs::Point32 & p0, const geometry_msgs::Point32 & p1)
+double hypot(const geometry_msgs::msg::Point32 & p0, const geometry_msgs::msg::Point32 & p1)
 {
   return (sqrt(pow((p1.x - p0.x), 2.0) + pow((p1.y - p0.y), 2.0)));
 }
@@ -82,20 +81,20 @@ bool isLaneletAttributeValue(
 }
 
 void lightAsMarker(
-  lanelet::ConstPoint3d p, visualization_msgs::Marker * marker, const std::string ns)
+  lanelet::ConstPoint3d p, visualization_msgs::msg::Marker * marker, const std::string ns)
 {
   if (marker == nullptr) {
-    ROS_ERROR_STREAM(__FUNCTION__ << ": marker is null pointer!");
+    std::cerr << __FUNCTION__ << ": marker is null pointer!" << std::endl;
     return;
   }
 
   marker->header.frame_id = "map";
-  marker->header.stamp = ros::Time();
+  marker->header.stamp = rclcpp::Time();
   marker->frame_locked - true;
   marker->ns = ns;
   marker->id = p.id();
-  marker->lifetime = ros::Duration();
-  marker->type = visualization_msgs::Marker::SPHERE;
+  marker->lifetime = rclcpp::Duration(0, 0);
+  marker->type = visualization_msgs::msg::Marker::SPHERE;
   marker->pose.position.x = p.x();
   marker->pose.position.y = p.y();
   marker->pose.position.z = p.z();
@@ -130,21 +129,21 @@ void lightAsMarker(
 }
 
 void laneletDirectionAsMarker(
-  const lanelet::ConstLanelet ll, visualization_msgs::Marker * marker, const int id,
+  const lanelet::ConstLanelet ll, visualization_msgs::msg::Marker * marker, const int id,
   const std::string ns)
 {
   if (marker == nullptr) {
-    ROS_ERROR_STREAM(__FUNCTION__ << ": marker is null pointer!");
+    std::cerr << __FUNCTION__ << ": marker is null pointer!" << std::endl;
     return;
   }
 
   marker->header.frame_id = "map";
-  marker->header.stamp = ros::Time();
+  marker->header.stamp = rclcpp::Time();
   marker->frame_locked = true;
   marker->ns = ns;
   marker->id = id;
-  marker->type = visualization_msgs::Marker::TRIANGLE_LIST;
-  marker->lifetime = ros::Duration();
+  marker->type = visualization_msgs::msg::Marker::TRIANGLE_LIST;
+  marker->lifetime = rclcpp::Duration(0, 0);
 
   lanelet::BasicPoint3d pt[3];
   pt[0].x() = 0.0;
@@ -180,7 +179,7 @@ void laneletDirectionAsMarker(
   lanelet::Attribute attr = ll.attribute("turn_direction");
   double turn_dir = 0;
 
-  std_msgs::ColorRGBA c;
+  std_msgs::msg::ColorRGBA c;
   c.r = 0.0;
   c.g = 0.0;
   c.b = 1.0;
@@ -214,10 +213,10 @@ void laneletDirectionAsMarker(
 
     for (int i = 0; i < 3; i++) pt_tf[i] = t * pt[i] + pc;
 
-    geometry_msgs::Point gp[3];
+    geometry_msgs::msg::Point gp[3];
 
     for (int i = 0; i < 3; i++) {
-      std_msgs::ColorRGBA cn = c;
+      std_msgs::msg::ColorRGBA cn = c;
 
       gp[i].x = pt_tf[i].x();
       gp[i].y = pt_tf[i].y();
@@ -232,16 +231,16 @@ void laneletDirectionAsMarker(
 // Is angle AOB less than 180?
 // https://qiita.com/fujii-kotaro/items/a411f2a45627ed2f156e
 bool isAcuteAngle(
-  const geometry_msgs::Point32 & a, const geometry_msgs::Point32 & o,
-  const geometry_msgs::Point32 & b)
+  const geometry_msgs::msg::Point32 & a, const geometry_msgs::msg::Point32 & o,
+  const geometry_msgs::msg::Point32 & b)
 {
   return (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x) >= 0;
 }
 
 // https://qiita.com/fujii-kotaro/items/a411f2a45627ed2f156e
 bool isWithinTriangle(
-  const geometry_msgs::Point32 & a, const geometry_msgs::Point32 & b,
-  const geometry_msgs::Point32 & c, const geometry_msgs::Point32 & p)
+  const geometry_msgs::msg::Point32 & a, const geometry_msgs::msg::Point32 & b,
+  const geometry_msgs::msg::Point32 & c, const geometry_msgs::msg::Point32 & p)
 {
   double c1 = (b.x - a.x) * (p.y - b.y) - (b.y - a.y) * (p.x - b.x);
   double c2 = (c.x - b.x) * (p.y - c.y) - (c.y - b.y) * (p.x - c.x);
@@ -250,22 +249,22 @@ bool isWithinTriangle(
   return c1 > 0.0 && c2 > 0.0 && c3 > 0.0 || c1 < 0.0 && c2 < 0.0 && c3 < 0.0;
 }
 
-visualization_msgs::Marker polygonAsMarker(
+visualization_msgs::msg::Marker polygonAsMarker(
   const lanelet::ConstPolygon3d & polygon, const std::string & name_space,
-  const std_msgs::ColorRGBA & color)
+  const std_msgs::msg::ColorRGBA & color)
 {
-  visualization_msgs::Marker marker;
+  visualization_msgs::msg::Marker marker;
   if (polygon.size() < 3) {
     return marker;
   }
 
   marker.header.frame_id = "map";
-  marker.header.stamp = ros::Time();
+  marker.header.stamp = rclcpp::Time();
   marker.frame_locked = true;
   marker.id = polygon.id();
   marker.ns = name_space;
-  marker.type = visualization_msgs::Marker::TRIANGLE_LIST;
-  marker.lifetime = ros::Duration(0);
+  marker.type = visualization_msgs::msg::Marker::TRIANGLE_LIST;
+  marker.lifetime = rclcpp::Duration(0, 0);
   marker.pose.position.x = 0.0;
   marker.pose.position.y = 0.0;
   marker.pose.position.z = 0.0;
@@ -278,16 +277,16 @@ visualization_msgs::Marker polygonAsMarker(
   marker.scale.z = 1.0;
   marker.color = color;
 
-  geometry_msgs::Polygon geom_poly;
+  geometry_msgs::msg::Polygon geom_poly;
   lanelet::utils::conversion::toGeomMsgPoly(polygon, &geom_poly);
 
-  std::vector<geometry_msgs::Polygon> triangles;
+  std::vector<geometry_msgs::msg::Polygon> triangles;
   lanelet::visualization::polygon2Triangle(geom_poly, &triangles);
 
   marker.points.reserve(polygon.size() - 2);
   marker.colors.reserve(polygon.size() - 2);
   for (const auto & tri : triangles) {
-    geometry_msgs::Point geom_pts[3];
+    geometry_msgs::msg::Point geom_pts[3];
     for (int i = 0; i < 3; i++) {
       lanelet::utils::conversion::toGeomMsgPt(tri.points[i], &geom_pts[i]);
       marker.points.push_back(geom_pts[i]);
@@ -302,23 +301,23 @@ visualization_msgs::Marker polygonAsMarker(
 namespace lanelet
 {
 void visualization::lanelet2Triangle(
-  const lanelet::ConstLanelet & ll, std::vector<geometry_msgs::Polygon> * triangles)
+  const lanelet::ConstLanelet & ll, std::vector<geometry_msgs::msg::Polygon> * triangles)
 {
   if (triangles == nullptr) {
-    ROS_ERROR_STREAM(__FUNCTION__ << ": triangles is null pointer!");
+    std::cerr << __FUNCTION__ << ": triangles is null pointer!" << std::endl;
     return;
   }
 
   triangles->clear();
-  geometry_msgs::Polygon ll_poly;
+  geometry_msgs::msg::Polygon ll_poly;
   lanelet2Polygon(ll, &ll_poly);
   polygon2Triangle(ll_poly, triangles);
 }
 
 void visualization::polygon2Triangle(
-  const geometry_msgs::Polygon & polygon, std::vector<geometry_msgs::Polygon> * triangles)
+  const geometry_msgs::msg::Polygon & polygon, std::vector<geometry_msgs::msg::Polygon> * triangles)
 {
-  geometry_msgs::Polygon poly = polygon;
+  geometry_msgs::msg::Polygon poly = polygon;
   // ear clipping: find smallest internal angle in polygon
   int N = poly.points.size();
 
@@ -326,7 +325,7 @@ void visualization::polygon2Triangle(
   std::vector<bool> is_acute_angle;
   is_acute_angle.assign(N, false);
   for (int i = 0; i < N; i++) {
-    geometry_msgs::Point32 p0, p1, p2;
+    geometry_msgs::msg::Point32 p0, p1, p2;
 
     adjacentPoints(i, N, poly, &p0, &p1, &p2);
     is_acute_angle.at(i) = isAcuteAngle(p0, p1, p2);
@@ -339,7 +338,7 @@ void visualization::polygon2Triangle(
     for (int i = 0; i < N; i++) {
       bool theta = is_acute_angle.at(i);
       if (theta == true) {
-        geometry_msgs::Point32 p0, p1, p2;
+        geometry_msgs::msg::Point32 p0, p1, p2;
         adjacentPoints(i, N, poly, &p0, &p1, &p2);
 
         int j_begin = (i + 2) % N;
@@ -359,16 +358,16 @@ void visualization::polygon2Triangle(
       }
     }
     if (clipped_vertex < 0 || clipped_vertex >= N) {
-      ROS_WARN(
-        "Could not find valid vertex for ear clipping triangulation. Triangulation result might be "
-        "invalid");
+      // print in yellow to indicate warning
+      std::cerr << "\033[1;33mCould not find valid vertex for ear clipping triangulation. Triangulation result might be "
+        "invalid\033[0m" << std::endl;
       clipped_vertex = 0;
     }
 
     // create triangle
-    geometry_msgs::Point32 p0, p1, p2;
+    geometry_msgs::msg::Point32 p0, p1, p2;
     adjacentPoints(clipped_vertex, N, poly, &p0, &p1, &p2);
-    geometry_msgs::Polygon triangle;
+    geometry_msgs::msg::Polygon triangle;
     triangle.points.push_back(p0);
     triangle.points.push_back(p1);
     triangle.points.push_back(p2);
@@ -399,10 +398,10 @@ void visualization::polygon2Triangle(
 }
 
 void visualization::lanelet2Polygon(
-  const lanelet::ConstLanelet & ll, geometry_msgs::Polygon * polygon)
+  const lanelet::ConstLanelet & ll, geometry_msgs::msg::Polygon * polygon)
 {
   if (polygon == nullptr) {
-    ROS_ERROR_STREAM(__FUNCTION__ << ": polygon is null pointer!");
+    std::cerr << __FUNCTION__ << ": polygon is null pointer!" << std::endl;
     return;
   }
 
@@ -412,16 +411,16 @@ void visualization::lanelet2Polygon(
   polygon->points.reserve(ll_poly.size());
 
   for (const auto & pt : ll_poly) {
-    geometry_msgs::Point32 pt32;
+    geometry_msgs::msg::Point32 pt32;
     utils::conversion::toGeomMsgPt32(pt.basicPoint(), &pt32);
     polygon->points.push_back(pt32);
   }
 }
 
-visualization_msgs::MarkerArray visualization::laneletDirectionAsMarkerArray(
+visualization_msgs::msg::MarkerArray visualization::laneletDirectionAsMarkerArray(
   const lanelet::ConstLanelets lanelets)
 {
-  visualization_msgs::MarkerArray marker_array;
+  visualization_msgs::msg::MarkerArray marker_array;
   int ll_dir_count = 0;
   for (auto lli = lanelets.begin(); lli != lanelets.end(); lli++) {
     lanelet::ConstLanelet ll = *lli;
@@ -429,7 +428,7 @@ visualization_msgs::MarkerArray visualization::laneletDirectionAsMarkerArray(
     //      bool road_found = false;
     if (ll.hasAttribute(std::string("turn_direction"))) {
       lanelet::Attribute attr = ll.attribute("turn_direction");
-      visualization_msgs::Marker marker;
+      visualization_msgs::msg::Marker marker;
 
       laneletDirectionAsMarker(ll, &marker, ll_dir_count, "lanelet direction");
 
@@ -441,11 +440,11 @@ visualization_msgs::MarkerArray visualization::laneletDirectionAsMarkerArray(
   return (marker_array);
 }
 
-visualization_msgs::MarkerArray visualization::autowareTrafficLightsAsMarkerArray(
+visualization_msgs::msg::MarkerArray visualization::autowareTrafficLightsAsMarkerArray(
   const std::vector<lanelet::AutowareTrafficLightConstPtr> tl_reg_elems,
-  const std_msgs::ColorRGBA c, const ros::Duration duration, const double scale)
+  const std_msgs::msg::ColorRGBA c, const rclcpp::Duration duration, const double scale)
 {
-  visualization_msgs::MarkerArray tl_marker_array;
+  visualization_msgs::msg::MarkerArray tl_marker_array;
 
   int tl_count = 0;
   for (auto tli = tl_reg_elems.begin(); tli != tl_reg_elems.end(); tli++) {
@@ -458,7 +457,7 @@ visualization_msgs::MarkerArray visualization::autowareTrafficLightsAsMarkerArra
       {                        // linestrings
         lanelet::ConstLineString3d ls = static_cast<lanelet::ConstLineString3d>(lsp);
 
-        visualization_msgs::Marker marker;
+        visualization_msgs::msg::Marker marker;
         visualization::trafficLight2TriangleMarker(
           ls, &marker, "traffic_light_triangle", c, duration, scale);
         tl_marker_array.markers.push_back(marker);
@@ -471,7 +470,7 @@ visualization_msgs::MarkerArray visualization::autowareTrafficLightsAsMarkerArra
 
       for (auto pt : l) {
         if (pt.hasAttribute("color")) {
-          visualization_msgs::Marker marker;
+          visualization_msgs::msg::Marker marker;
           lightAsMarker(pt, &marker, "traffic_light");
           tl_marker_array.markers.push_back(marker);
 
@@ -484,23 +483,23 @@ visualization_msgs::MarkerArray visualization::autowareTrafficLightsAsMarkerArra
   return (tl_marker_array);
 }
 
-visualization_msgs::MarkerArray visualization::detectionAreasAsMarkerArray(
-  const std::vector<lanelet::DetectionAreaConstPtr> & da_reg_elems, const std_msgs::ColorRGBA c,
-  const ros::Duration duration)
+visualization_msgs::msg::MarkerArray visualization::detectionAreasAsMarkerArray(
+  const std::vector<lanelet::DetectionAreaConstPtr> & da_reg_elems, const std_msgs::msg::ColorRGBA c,
+  const rclcpp::Duration duration)
 {
-  visualization_msgs::MarkerArray marker_array;
-  visualization_msgs::Marker marker;
+  visualization_msgs::msg::MarkerArray marker_array;
+  visualization_msgs::msg::Marker marker;
 
   if (da_reg_elems.empty()) {
     return marker_array;
   }
 
   marker.header.frame_id = "map";
-  marker.header.stamp = ros::Time();
+  marker.header.stamp = rclcpp::Time();
   marker.frame_locked = true;
   marker.ns = "detection_area";
   marker.id = 0;
-  marker.type = visualization_msgs::Marker::TRIANGLE_LIST;
+  marker.type = visualization_msgs::msg::Marker::TRIANGLE_LIST;
   marker.lifetime = duration;
   marker.pose.position.x = 0.0;  // p.x();
   marker.pose.position.y = 0.0;  // p.y();
@@ -526,14 +525,14 @@ visualization_msgs::MarkerArray visualization::detectionAreasAsMarkerArray(
     // area visualization
     const auto detection_areas = da_reg_elem->detectionAreas();
     for (const auto & detection_area : detection_areas) {
-      geometry_msgs::Polygon geom_poly;
+      geometry_msgs::msg::Polygon geom_poly;
       utils::conversion::toGeomMsgPoly(detection_area, &geom_poly);
 
-      std::vector<geometry_msgs::Polygon> triangles;
+      std::vector<geometry_msgs::msg::Polygon> triangles;
       polygon2Triangle(geom_poly, &triangles);
 
       for (auto tri : triangles) {
-        geometry_msgs::Point tri0[3];
+        geometry_msgs::msg::Point tri0[3];
 
         for (int i = 0; i < 3; i++) {
           utils::conversion::toGeomMsgPt(tri.points[i], &tri0[i]);
@@ -545,8 +544,8 @@ visualization_msgs::MarkerArray visualization::detectionAreasAsMarkerArray(
     marker_array.markers.push_back(marker);
 
     // stop line visualization
-    visualization_msgs::Marker ls_marker;
-    std_msgs::ColorRGBA ls_c;
+    visualization_msgs::msg::Marker ls_marker;
+    std_msgs::msg::ColorRGBA ls_c;
     ls_c.r = 1;
     ls_c.g = 1;
     ls_c.b = 1;
@@ -559,27 +558,27 @@ visualization_msgs::MarkerArray visualization::detectionAreasAsMarkerArray(
   return (marker_array);
 }
 
-visualization_msgs::MarkerArray visualization::parkingLotsAsMarkerArray(
-  const lanelet::ConstPolygons3d & parking_lots, const std_msgs::ColorRGBA & c)
+visualization_msgs::msg::MarkerArray visualization::parkingLotsAsMarkerArray(
+  const lanelet::ConstPolygons3d & parking_lots, const std_msgs::msg::ColorRGBA & c)
 {
-  visualization_msgs::MarkerArray marker_array;
+  visualization_msgs::msg::MarkerArray marker_array;
 
   if (parking_lots.empty()) {
     return marker_array;
   }
 
   for (const auto & polygon : parking_lots) {
-    const visualization_msgs::Marker marker = polygonAsMarker(polygon, "parking_lots", c);
+    const visualization_msgs::msg::Marker marker = polygonAsMarker(polygon, "parking_lots", c);
     if (!marker.points.empty()) {
       marker_array.markers.push_back(marker);
     }
   }
   return marker_array;
 }
-visualization_msgs::MarkerArray visualization::parkingSpacesAsMarkerArray(
-  const lanelet::ConstLineStrings3d & parking_spaces, const std_msgs::ColorRGBA & c)
+visualization_msgs::msg::MarkerArray visualization::parkingSpacesAsMarkerArray(
+  const lanelet::ConstLineStrings3d & parking_spaces, const std_msgs::msg::ColorRGBA & c)
 {
-  visualization_msgs::MarkerArray marker_array;
+  visualization_msgs::msg::MarkerArray marker_array;
 
   if (parking_spaces.empty()) {
     return marker_array;
@@ -588,28 +587,28 @@ visualization_msgs::MarkerArray visualization::parkingSpacesAsMarkerArray(
   for (const auto & linestring : parking_spaces) {
     lanelet::ConstPolygon3d polygon;
     if (utils::lineStringWithWidthToPolygon(linestring, &polygon)) {
-      visualization_msgs::Marker marker = polygonAsMarker(polygon, "parking_space", c);
+      visualization_msgs::msg::Marker marker = polygonAsMarker(polygon, "parking_space", c);
       marker.id = linestring.id();
       if (!marker.points.empty()) {
         marker_array.markers.push_back(marker);
       }
     } else {
-      ROS_ERROR_STREAM("parking space " << linestring.id() << " failed conversion.");
+      std::cerr << "parking space " << linestring.id() << " failed conversion." << std::endl;
     }
   }
   return marker_array;
 }
 
-visualization_msgs::MarkerArray visualization::lineStringsAsMarkerArray(
+visualization_msgs::msg::MarkerArray visualization::lineStringsAsMarkerArray(
   const std::vector<lanelet::ConstLineString3d> line_strings, const std::string name_space,
-  const std_msgs::ColorRGBA c, const double lss)
+  const std_msgs::msg::ColorRGBA c, const double lss)
 {
   std::unordered_set<lanelet::Id> added;
-  visualization_msgs::MarkerArray ls_marker_array;
+  visualization_msgs::msg::MarkerArray ls_marker_array;
   for (auto i = line_strings.begin(); i != line_strings.end(); i++) {
     const lanelet::ConstLineString3d & ls = *i;
     if (!exists(added, ls.id())) {
-      visualization_msgs::Marker ls_marker;
+      visualization_msgs::msg::Marker ls_marker;
       visualization::lineString2Marker(ls, &ls_marker, "map", name_space, c, 0.1);
       ls_marker_array.markers.push_back(ls_marker);
       added.insert(ls.id());
@@ -619,12 +618,12 @@ visualization_msgs::MarkerArray visualization::lineStringsAsMarkerArray(
   return (ls_marker_array);
 }
 
-visualization_msgs::MarkerArray visualization::laneletsBoundaryAsMarkerArray(
-  const lanelet::ConstLanelets & lanelets, const std_msgs::ColorRGBA c, const bool viz_centerline)
+visualization_msgs::msg::MarkerArray visualization::laneletsBoundaryAsMarkerArray(
+  const lanelet::ConstLanelets & lanelets, const std_msgs::msg::ColorRGBA c, const bool viz_centerline)
 {
   double lss = 0.05;  // line string size
   std::unordered_set<lanelet::Id> added;
-  visualization_msgs::MarkerArray marker_array;
+  visualization_msgs::msg::MarkerArray marker_array;
   for (auto li = lanelets.begin(); li != lanelets.end(); li++) {
     lanelet::ConstLanelet lll = *li;
 
@@ -632,7 +631,7 @@ visualization_msgs::MarkerArray visualization::laneletsBoundaryAsMarkerArray(
     lanelet::ConstLineString3d right_ls = lll.rightBound();
     lanelet::ConstLineString3d center_ls = lll.centerline();
 
-    visualization_msgs::Marker left_line_strip, right_line_strip, center_line_strip;
+    visualization_msgs::msg::Marker left_line_strip, right_line_strip, center_line_strip;
     if (!exists(added, left_ls.id())) {
       visualization::lineString2Marker(left_ls, &left_line_strip, "map", "left_lane_bound", c, lss);
       marker_array.markers.push_back(left_line_strip);
@@ -654,16 +653,16 @@ visualization_msgs::MarkerArray visualization::laneletsBoundaryAsMarkerArray(
   return marker_array;
 }
 
-visualization_msgs::MarkerArray visualization::trafficLightsAsTriangleMarkerArray(
-  const std::vector<lanelet::TrafficLightConstPtr> tl_reg_elems, const std_msgs::ColorRGBA c,
-  const ros::Duration duration, const double scale)
+visualization_msgs::msg::MarkerArray visualization::trafficLightsAsTriangleMarkerArray(
+  const std::vector<lanelet::TrafficLightConstPtr> tl_reg_elems, const std_msgs::msg::ColorRGBA c,
+  const rclcpp::Duration duration, const double scale)
 {
   // convert to to an array of linestrings and publish as marker array using
   // exisitng function
 
   int tl_count = 0;
   std::vector<lanelet::ConstLineString3d> line_strings;
-  visualization_msgs::MarkerArray marker_array;
+  visualization_msgs::msg::MarkerArray marker_array;
 
   for (auto tli = tl_reg_elems.begin(); tli != tl_reg_elems.end(); tli++) {
     lanelet::TrafficLightConstPtr tl = *tli;
@@ -675,7 +674,7 @@ visualization_msgs::MarkerArray visualization::trafficLightsAsTriangleMarkerArra
       {                        // linestrings
         lanelet::ConstLineString3d ls = static_cast<lanelet::ConstLineString3d>(lsp);
 
-        visualization_msgs::Marker marker;
+        visualization_msgs::msg::Marker marker;
         visualization::trafficLight2TriangleMarker(
           ls, &marker, "traffic_light_triangle", c, duration, scale);
         marker_array.markers.push_back(marker);
@@ -687,23 +686,23 @@ visualization_msgs::MarkerArray visualization::trafficLightsAsTriangleMarkerArra
   return (marker_array);
 }
 
-visualization_msgs::MarkerArray visualization::laneletsAsTriangleMarkerArray(
-  const std::string ns, const lanelet::ConstLanelets & lanelets, const std_msgs::ColorRGBA c)
+visualization_msgs::msg::MarkerArray visualization::laneletsAsTriangleMarkerArray(
+  const std::string ns, const lanelet::ConstLanelets & lanelets, const std_msgs::msg::ColorRGBA c)
 {
-  visualization_msgs::MarkerArray marker_array;
-  visualization_msgs::Marker marker;
+  visualization_msgs::msg::MarkerArray marker_array;
+  visualization_msgs::msg::Marker marker;
 
   if (lanelets.empty()) {
     return marker_array;
   }
 
   marker.header.frame_id = "map";
-  marker.header.stamp = ros::Time();
+  marker.header.stamp = rclcpp::Time();
   marker.frame_locked = true;
   marker.ns = ns;
   marker.id = 0;
-  marker.type = visualization_msgs::Marker::TRIANGLE_LIST;
-  marker.lifetime = ros::Duration();
+  marker.type = visualization_msgs::msg::Marker::TRIANGLE_LIST;
+  marker.lifetime = rclcpp::Duration(0, 0);
   marker.pose.position.x = 0.0;  // p.x();
   marker.pose.position.y = 0.0;  // p.y();
   marker.pose.position.z = 0.0;  // p.z();
@@ -720,11 +719,11 @@ visualization_msgs::MarkerArray visualization::laneletsAsTriangleMarkerArray(
   marker.color.a = 0.999;
 
   for (auto ll : lanelets) {
-    std::vector<geometry_msgs::Polygon> triangles;
+    std::vector<geometry_msgs::msg::Polygon> triangles;
     lanelet2Triangle(ll, &triangles);
 
     for (auto tri : triangles) {
-      geometry_msgs::Point tri0[3];
+      geometry_msgs::msg::Point tri0[3];
 
       for (int i = 0; i < 3; i++) {
         utils::conversion::toGeomMsgPt(tri.points[i], &tri0[i]);
@@ -742,19 +741,19 @@ visualization_msgs::MarkerArray visualization::laneletsAsTriangleMarkerArray(
 }
 
 void visualization::trafficLight2TriangleMarker(
-  const lanelet::ConstLineString3d ls, visualization_msgs::Marker * marker, const std::string ns,
-  const std_msgs::ColorRGBA cl, const ros::Duration duration, const double scale)
+  const lanelet::ConstLineString3d ls, visualization_msgs::msg::Marker * marker, const std::string ns,
+  const std_msgs::msg::ColorRGBA cl, const rclcpp::Duration duration, const double scale)
 {
   if (marker == nullptr) {
-    ROS_ERROR_STREAM(__FUNCTION__ << ": marker is null pointer!");
+    std::cerr << __FUNCTION__ << ": marker is null pointer!" << std::endl;
     return;
   }
   marker->header.frame_id = "map";
-  marker->header.stamp = ros::Time();
+  marker->header.stamp = rclcpp::Time();
   marker->frame_locked = true;
   marker->ns = ns;
   marker->id = ls.id();
-  marker->type = visualization_msgs::Marker::TRIANGLE_LIST;
+  marker->type = visualization_msgs::msg::Marker::TRIANGLE_LIST;
   marker->lifetime = duration;
 
   marker->pose.position.x = 0.0;  // p.x();
@@ -794,11 +793,11 @@ void visualization::trafficLight2TriangleMarker(
       v[i] = (v[i] - c) * scale + c;
     }
   }
-  geometry_msgs::Point tri0[3];
+  geometry_msgs::msg::Point tri0[3];
   utils::conversion::toGeomMsgPt(v[0], &tri0[0]);
   utils::conversion::toGeomMsgPt(v[1], &tri0[1]);
   utils::conversion::toGeomMsgPt(v[2], &tri0[2]);
-  geometry_msgs::Point tri1[3];
+  geometry_msgs::msg::Point tri1[3];
   utils::conversion::toGeomMsgPt(v[0], &tri1[0]);
   utils::conversion::toGeomMsgPt(v[2], &tri1[1]);
   utils::conversion::toGeomMsgPt(v[3], &tri1[2]);
@@ -814,20 +813,20 @@ void visualization::trafficLight2TriangleMarker(
 }
 
 void visualization::lineString2Marker(
-  const lanelet::ConstLineString3d ls, visualization_msgs::Marker * line_strip,
-  const std::string frame_id, const std::string ns, const std_msgs::ColorRGBA c, const float lss)
+  const lanelet::ConstLineString3d ls, visualization_msgs::msg::Marker * line_strip,
+  const std::string frame_id, const std::string ns, const std_msgs::msg::ColorRGBA c, const float lss)
 {
   if (line_strip == nullptr) {
-    ROS_ERROR_STREAM(__FUNCTION__ << ": line_strip is null pointer!");
+    std::cerr << __FUNCTION__ << ": line_strip is null pointer!" << std::endl;
     return;
   }
 
   line_strip->header.frame_id = frame_id;
-  line_strip->header.stamp = ros::Time();
+  line_strip->header.stamp = rclcpp::Time();
   line_strip->frame_locked = true;
   line_strip->ns = ns;
-  line_strip->action = visualization_msgs::Marker::ADD;
-  line_strip->type = visualization_msgs::Marker::LINE_STRIP;
+  line_strip->action = visualization_msgs::msg::Marker::ADD;
+  line_strip->type = visualization_msgs::msg::Marker::LINE_STRIP;
 
   line_strip->id = ls.id();
   line_strip->pose.orientation.x = 0.0;
@@ -839,7 +838,7 @@ void visualization::lineString2Marker(
 
   // fill out lane line
   for (auto i = ls.begin(); i != ls.end(); i++) {
-    geometry_msgs::Point p;
+    geometry_msgs::msg::Point p;
     p.x = (*i).x();
     p.y = (*i).y();
     p.z = (*i).z();

--- a/map/lanelet2_extension/package.xml
+++ b/map/lanelet2_extension/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>lanelet2_extension</name>
   <version>0.1.0</version>
   <description>The lanelet2_extension pacakge contains libraries to handle Lanelet2 format data.</description>
@@ -8,9 +8,10 @@
 
   <license>Apach 2</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>roscpp</depend>
+  <depend>rclcpp</depend>
   <depend>geographiclib</depend>
   <depend>lanelet2_core</depend>
   <depend>lanelet2_io</depend>
@@ -23,5 +24,10 @@
   <depend>geometry_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>pugixml-dev</depend>
-  <depend>roslint</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/map/lanelet2_extension/src/sample_code.cpp
+++ b/map/lanelet2_extension/src/sample_code.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <lanelet2_extension/projection/mgrs_projector.h>
 #include <lanelet2_extension/regulatory_elements/autoware_traffic_light.h>
@@ -112,13 +112,9 @@ void usingAutowareTrafficLight(const std::string map_file_path)
 
 int main(int argc, char * argv[])
 {
-  ros::init(argc, argv, "lanelet2_extension_example");
-  ros::NodeHandle nh;
-  ros::NodeHandle pnh("~");
-
-  std::string map_file_path;
-  pnh.param("map_file", map_file_path, map_file_path);
-
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("sample_code");
+  const std::string map_file_path = node->declare_parameter("map_file", "");
   loadingAutowareOSMFile(map_file_path);
   usingMGRSProjector();
   usingAutowareTrafficLight(map_file_path);

--- a/map/lanelet2_extension/src/validation.cpp
+++ b/map/lanelet2_extension/src/validation.cpp
@@ -29,7 +29,7 @@
 #include <iostream>
 #include <string>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <pugixml.hpp>
 
@@ -59,7 +59,7 @@ void validateElevationTag(const std::string filename)
   pugi::xml_document doc;
   auto result = doc.load_file(filename.c_str());
   if (!result) {
-    ROS_FATAL_STREAM(result.description());
+    std::cerr << result.description() << std::endl;
     exit(1);
   }
 
@@ -68,7 +68,7 @@ void validateElevationTag(const std::string filename)
        node = node.next_sibling(keyword::Node)) {
     const auto id = node.attribute(keyword::Id).as_llong(lanelet::InvalId);
     if (!node.find_child_by_attribute(keyword::Tag, keyword::Key, keyword::Elevation)) {
-      ROS_ERROR_STREAM("failed to find elevation tag for node: " << id);
+      std::cerr << "failed to find elevation tag for node: " << id << std::endl;
     }
   }
 }
@@ -76,7 +76,7 @@ void validateElevationTag(const std::string filename)
 void validateTrafficLight(const lanelet::LaneletMapPtr lanelet_map)
 {
   if (!lanelet_map) {
-    ROS_FATAL_STREAM("Missing map. Are you sure you set correct path for map?");
+    std::cerr << "Missing map. Are you sure you set correct path for map?" << std::endl;
     exit(1);
   }
 
@@ -86,28 +86,29 @@ void validateTrafficLight(const lanelet::LaneletMapPtr lanelet_map)
     if (autoware_traffic_lights.empty()) continue;
     for (auto light : autoware_traffic_lights) {
       if (light->lightBulbs().size() == 0) {
-        ROS_WARN_STREAM(
-          "regulatory element traffic light "
-          << light->id()
-          << " is missing optional light_bulb member. You won't "
-             "be able to use region_tlr node with this map");
+        std::cerr << "regulatory element traffic light " << light->id()
+                  << " is missing optional light_bulb member. You won't be able to use region_tlr "
+                     "node with this map"
+                  << std::endl;
+        ;
       }
       for (auto light_string : light->lightBulbs()) {
         if (!light_string.hasAttribute("traffic_light_id")) {
-          ROS_ERROR_STREAM(
-            "light_bulb " << light_string.id() << " is missing traffic_light_id tag");
+          std::cerr << "light_bulb " << light_string.id() << " is missing traffic_light_id tag"
+                    << std::endl;
         }
       }
       for (auto base_string_or_poly : light->trafficLights()) {
         if (!base_string_or_poly.isLineString()) {
-          ROS_ERROR_STREAM(
-            "traffic_light " << base_string_or_poly.id()
-                             << " is polygon, and only linestring class is currently supported for "
-                                "traffic lights");
+          std::cerr
+            << "traffic_light " << base_string_or_poly.id()
+            << " is polygon, and only linestring class is currently supported for traffic lights"
+            << std::endl;
         }
         auto base_string = static_cast<lanelet::LineString3d>(base_string_or_poly);
         if (!base_string.hasAttribute("height")) {
-          ROS_ERROR_STREAM("traffic_light " << base_string.id() << " is missing height tag");
+          std::cerr << "traffic_light " << base_string.id() << " is missing height tag"
+                    << std::endl;
         }
       }
     }
@@ -117,7 +118,7 @@ void validateTrafficLight(const lanelet::LaneletMapPtr lanelet_map)
 void validateTurnDirection(const lanelet::LaneletMapPtr lanelet_map)
 {
   if (!lanelet_map) {
-    ROS_FATAL_STREAM("Missing map. Are you sure you set correct path for map?");
+    std::cerr << "Missing map. Are you sure you set correct path for map?" << std::endl;
     exit(1);
   }
 
@@ -135,28 +136,26 @@ void validateTurnDirection(const lanelet::LaneletMapPtr lanelet_map)
     const auto conflicting_lanelets_or_areas = vehicle_graph->conflicting(lanelet);
     if (conflicting_lanelets_or_areas.size() == 0) continue;
     if (!lanelet.hasAttribute("turn_direction")) {
-      ROS_ERROR_STREAM(
-        "lanelet " << lanelet.id()
-                   << " seems to be intersecting other lanelet, but does "
-                      "not have turn_direction tagging.");
+      std::cerr
+        << "lanelet " << lanelet.id()
+        << " seems to be intersecting other lanelet, but does not have turn_direction tagging."
+        << std::endl;
     }
   }
 }
 
 int main(int argc, char * argv[])
 {
-  ros::init(argc, argv, "autoware_lanelet_valdiation");
-  ros::NodeHandle node;
-  ros::NodeHandle private_rosnode("~");
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("sample_code");
 
-  if (!private_rosnode.hasParam("map_file")) {
-    ROS_FATAL_STREAM("failed find map_file parameter! No file to load");
+  if (!node->has_parameter("map_file")) {
+    std::cerr << "failed find map_file parameter! No file to load" << std::endl;
     printUsage();
     return 1;
   }
 
-  std::string map_path = "";
-  private_rosnode.getParam("map_file", map_path);
+  const std::string map_path = node->get_parameter("map_file").as_string();
 
   lanelet::LaneletMapPtr lanelet_map;
   lanelet::ErrorMessages errors;

--- a/map/lanelet2_extension/src/validation.cpp
+++ b/map/lanelet2_extension/src/validation.cpp
@@ -49,7 +49,7 @@ void printUsage()
 {
   std::cout << "Usage:" << std::endl
             << "ros2 run lanelet2_extension autoware_lanelet2_validation"
-               "_map_file:=<path to osm file>"
+               " --ros-args -p map_file:=<path to osm file>"
             << std::endl;
 }
 }  // namespace
@@ -149,13 +149,14 @@ int main(int argc, char * argv[])
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("sample_code");
 
-  if (!node->has_parameter("map_file")) {
+  std::string map_path;
+  try {
+    std::string map_path = node->declare_parameter("map_file").get<std::string>();
+  } catch (...) {
     std::cerr << "failed find map_file parameter! No file to load" << std::endl;
     printUsage();
     return 1;
   }
-
-  const std::string map_path = node->get_parameter("map_file").as_string();
 
   lanelet::LaneletMapPtr lanelet_map;
   lanelet::ErrorMessages errors;

--- a/map/lanelet2_extension/src/validation.cpp
+++ b/map/lanelet2_extension/src/validation.cpp
@@ -48,7 +48,7 @@ constexpr const char * Elevation = "ele";
 void printUsage()
 {
   std::cout << "Usage:" << std::endl
-            << "rosrun lanelet2_extension autoware_lanelet2_validation"
+            << "ros2 run lanelet2_extension autoware_lanelet2_validation"
                "_map_file:=<path to osm file>"
             << std::endl;
 }

--- a/map/lanelet2_extension/src/validation.cpp
+++ b/map/lanelet2_extension/src/validation.cpp
@@ -151,13 +151,12 @@ int main(int argc, char * argv[])
 
   std::string map_path;
   try {
-    std::string map_path = node->declare_parameter("map_file").get<std::string>();
+    map_path = node->declare_parameter("map_file").get<std::string>();
   } catch (...) {
     std::cerr << "failed find map_file parameter! No file to load" << std::endl;
     printUsage();
     return 1;
   }
-
   lanelet::LaneletMapPtr lanelet_map;
   lanelet::ErrorMessages errors;
   lanelet::projection::MGRSProjector projector;

--- a/map/lanelet2_extension/test/src/test_message_conversion.cpp
+++ b/map/lanelet2_extension/test/src/test_message_conversion.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #include <math.h>
-#include <ros/ros.h>
 
 #include <gtest/gtest.h>
 
@@ -56,7 +55,7 @@ private:
 
 TEST_F(TestSuite, BinMsgConversion)
 {
-  autoware_lanelet2_msgs::MapBin bin_msg;
+  autoware_lanelet2_msgs::msg::MapBin bin_msg;
   lanelet::LaneletMapPtr regenerated_map(new lanelet::LaneletMap);
 
   lanelet::utils::conversion::toBinMsg(single_lanelet_map_ptr, &bin_msg);
@@ -76,27 +75,27 @@ TEST_F(TestSuite, ToGeomMsgPt)
 {
   Point3d lanelet_pt(getId(), -0.1, 0.2, 3.0);
 
-  geometry_msgs::Point32 geom_pt32;
+  geometry_msgs::msg::Point32 geom_pt32;
   geom_pt32.x = -0.1;
   geom_pt32.y = 0.2;
   geom_pt32.z = 3.0;
 
-  geometry_msgs::Point geom_pt;
+  geometry_msgs::msg::Point geom_pt;
   toGeomMsgPt(geom_pt32, &geom_pt);
   ASSERT_FLOAT_EQ(geom_pt32.x, geom_pt.x)
-    << " converted value is different from original geometry_msgs::Point";
+    << " converted value is different from original geometry_msgs::msg::Point";
   ASSERT_FLOAT_EQ(geom_pt32.y, geom_pt.y)
-    << " converted value is different from original geometry_msgs::Point";
+    << " converted value is different from original geometry_msgs::msg::Point";
   ASSERT_FLOAT_EQ(geom_pt32.z, geom_pt.z)
-    << " converted value is different from original geometry_msgs::Point";
+    << " converted value is different from original geometry_msgs::msg::Point";
 
   geom_pt = toGeomMsgPt(geom_pt32);
   ASSERT_FLOAT_EQ(geom_pt32.x, geom_pt.x)
-    << " converted value is different from original geometry_msgs::Point";
+    << " converted value is different from original geometry_msgs::msg::Point";
   ASSERT_FLOAT_EQ(geom_pt32.y, geom_pt.y)
-    << " converted value is different from original geometry_msgs::Point";
+    << " converted value is different from original geometry_msgs::msg::Point";
   ASSERT_FLOAT_EQ(geom_pt32.z, geom_pt.z)
-    << " converted value is different from original geometry_msgs::Point";
+    << " converted value is different from original geometry_msgs::msg::Point";
 
   toGeomMsgPt(lanelet_pt.basicPoint(), &geom_pt);
   ASSERT_DOUBLE_EQ(lanelet_pt.basicPoint().x(), geom_pt.x)
@@ -158,6 +157,5 @@ TEST_F(TestSuite, ToGeomMsgPt)
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  ros::init(argc, argv, "TestNode");
   return RUN_ALL_TESTS();
 }

--- a/map/lanelet2_extension/test/src/test_projector.cpp
+++ b/map/lanelet2_extension/test/src/test_projector.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include <ros/ros.h>
-
 #include <gtest/gtest.h>
 #include <math.h>
 
@@ -82,6 +80,5 @@ TEST(TestSuite, ReverseProjection)
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  ros::init(argc, argv, "TestNode");
   return RUN_ALL_TESTS();
 }

--- a/map/lanelet2_extension/test/src/test_query.cpp
+++ b/map/lanelet2_extension/test/src/test_query.cpp
@@ -17,7 +17,6 @@
 #include <gtest/gtest.h>
 #include <lanelet2_extension/utility/query.h>
 #include <math.h>
-#include <ros/ros.h>
 
 using lanelet::Lanelet;
 using lanelet::LineString3d;
@@ -129,6 +128,5 @@ TEST_F(TestSuite, QueryStopLine)
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  ros::init(argc, argv, "TestNode");
   return RUN_ALL_TESTS();
 }

--- a/map/lanelet2_extension/test/src/test_regulatory_elements.cpp
+++ b/map/lanelet2_extension/test/src/test_regulatory_elements.cpp
@@ -15,7 +15,6 @@
  */
 
 #include <gtest/gtest.h>
-#include <ros/ros.h>
 
 #include <lanelet2_core/Attribute.h>
 #include <lanelet2_core/LaneletMap.h>
@@ -124,6 +123,5 @@ TEST(TestSuite, TrafficLightWorksAsExpected)
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  ros::init(argc, argv, "TestNode");
   return RUN_ALL_TESTS();
 }

--- a/map/lanelet2_extension/test/src/test_utilities.cpp
+++ b/map/lanelet2_extension/test/src/test_utilities.cpp
@@ -18,7 +18,6 @@
 #include <lanelet2_extension/utility/utilities.h>
 #include <lanelet2_routing/RoutingGraphContainer.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
-#include <ros/ros.h>
 #include <map>
 
 using lanelet::Lanelet;
@@ -29,7 +28,8 @@ using lanelet::utils::getId;
 class TestSuite : public ::testing::Test
 {
 public:
-  TestSuite() : sample_map_ptr(new lanelet::LaneletMap())
+  TestSuite()
+  : sample_map_ptr(new lanelet::LaneletMap())
   {  // NOLINT
     // create sample lanelets
     Point3d p1, p2, p3, p4, p5, p6, p7, p8, p9, p10;
@@ -106,6 +106,5 @@ TEST_F(TestSuite, OverwriteLaneletsCenterline)
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  ros::init(argc, argv, "TestNode");
   return RUN_ALL_TESTS();
 }

--- a/map/lanelet2_extension/test/test_message_conversion.test
+++ b/map/lanelet2_extension/test/test_message_conversion.test
@@ -1,5 +1,0 @@
-<launch>
-
-  <test test-name="test-message_conversion" pkg="lanelet2_extension" type="message_conversion-test" name="test"/>
-
-</launch>

--- a/map/lanelet2_extension/test/test_projector.test
+++ b/map/lanelet2_extension/test/test_projector.test
@@ -1,5 +1,0 @@
-<launch>
-
-  <test test-name="test-projector" pkg="lanelet2_extension" type="projector-test" name="test"/>
-
-</launch>

--- a/map/lanelet2_extension/test/test_query.test
+++ b/map/lanelet2_extension/test/test_query.test
@@ -1,5 +1,0 @@
-<launch>
-
-  <test test-name="test-query" pkg="lanelet2_extension" type="query-test" name="test"/>
-
-</launch>

--- a/map/lanelet2_extension/test/test_regulatory_elements.test
+++ b/map/lanelet2_extension/test/test_regulatory_elements.test
@@ -1,5 +1,0 @@
-<launch>
-
-  <test test-name="test-regulatory_elements" pkg="lanelet2_extension" type="regulatory_elements-test" name="test"/>
-
-</launch>

--- a/map/lanelet2_extension/test/test_utilities.test
+++ b/map/lanelet2_extension/test/test_utilities.test
@@ -1,5 +1,0 @@
-<launch>
-
-  <test test-name="test-utilities" pkg="lanelet2_extension" type="utilities-test" name="test"/>
-
-</launch>


### PR DESCRIPTION
This ports lanelet2_extension package to ROS2.

In order to make use of the library easier, I changed ROS loggers (ROS_INFO, ROS_WARN, ROS_ERROR) into standard messages. This is because the functions in the library can be called from anywhere in the source code, which might have bad access to rclcpp::logger(). The drawback is that the messages will not be recorded in the ros logging file anymore, but it will still show up in the terminal screen.

I also changed CI to remove `sudo` from `rosdep` commands since it was somehow failing to find `ros-foxy-lanelet2-*`  packages. 