### PR TITLE
ROS2 Porting: gyro_odometer

### DIFF
--- a/localization/twist_estimator/gyro_odometer/CMakeLists.txt
+++ b/localization/twist_estimator/gyro_odometer/CMakeLists.txt
@@ -1,44 +1,65 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(gyro_odometer)
 
-add_compile_options(-std=c++14)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  tf2
-  tf2_ros
-  tf2_geometry_msgs
-  std_msgs
-  geometry_msgs
-  sensor_msgs
-)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+# find_package(roscpp REQUIRED)
+# find_package(tf2 REQUIRED)
+# find_package(tf2_ros REQUIRED)
+# find_package(tf2_geometry_msgs REQUIRED)
+# find_package(std_msgs REQUIRED)
+# find_package(geometry_msgs REQUIRED)
+# find_package(sensor_msgs REQUIRED)
 
-catkin_package(
-  INCLUDE_DIRS include
-)
+# catkin_package(
+#   INCLUDE_DIRS include
+# )
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+set(GRYO_ODOMETER_SRC
+  src/gyro_odometer_core.cpp)
 
-add_executable(gyro_odometer
-        src/gyro_odometer_node.cpp
-        src/gyro_odometer_core.cpp
-)
+set(GRYO_ODOMETER_HEADERS
+  include/gyro_odometer/gyro_odometer_core.h)
 
-add_dependencies(gyro_odometer ${${PROJECT_NAME}_EXPORTED_TARGETS}
-                                  ${catkin_EXPORTED_TARGETS}
-)
+ament_auto_add_library(${PROJECT_NAME} 
+  src/gyro_odometer_node.cpp
+  ${GRYO_ODOMETER_SRC}
+  ${GRYO_ODOMETER_HEADERS}
+ )
 
-target_link_libraries(gyro_odometer ${catkin_LIBRARIES})
+# include_directories(include ${catkin_INCLUDE_DIRS})
 
-install(TARGETS
-            gyro_odometer
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-        )
+# add_executable(gyro_odometer
+#         src/gyro_odometer_node.cpp
+#         src/gyro_odometer_core.cpp
+# )
 
-install(
-  DIRECTORY
-    launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# add_dependencies(gyro_odometer ${${PROJECT_NAME}_EXPORTED_TARGETS}
+#                                   ${catkin_EXPORTED_TARGETS}
+# )
+
+# target_link_libraries(gyro_odometer ${catkin_LIBRARIES})
+
+# install(TARGETS
+#             gyro_odometer
+#         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+#         )
+
+# install(
+#   DIRECTORY
+#     launch
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+ament_auto_package(
+  INSTALL_TO_SHARE
 )

--- a/localization/twist_estimator/gyro_odometer/CMakeLists.txt
+++ b/localization/twist_estimator/gyro_odometer/CMakeLists.txt
@@ -10,17 +10,6 @@ endif()
 
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
-# find_package(roscpp REQUIRED)
-# find_package(tf2 REQUIRED)
-# find_package(tf2_ros REQUIRED)
-# find_package(tf2_geometry_msgs REQUIRED)
-# find_package(std_msgs REQUIRED)
-# find_package(geometry_msgs REQUIRED)
-# find_package(sensor_msgs REQUIRED)
-
-# catkin_package(
-#   INCLUDE_DIRS include
-# )
 
 set(GRYO_ODOMETER_SRC
   src/gyro_odometer_core.cpp)
@@ -28,38 +17,12 @@ set(GRYO_ODOMETER_SRC
 set(GRYO_ODOMETER_HEADERS
   include/gyro_odometer/gyro_odometer_core.h)
 
-ament_auto_add_library(${PROJECT_NAME} 
+ament_auto_add_executable(${PROJECT_NAME}
   src/gyro_odometer_node.cpp
   ${GRYO_ODOMETER_SRC}
   ${GRYO_ODOMETER_HEADERS}
  )
 
-# include_directories(include ${catkin_INCLUDE_DIRS})
-
-# add_executable(gyro_odometer
-#         src/gyro_odometer_node.cpp
-#         src/gyro_odometer_core.cpp
-# )
-
-# add_dependencies(gyro_odometer ${${PROJECT_NAME}_EXPORTED_TARGETS}
-#                                   ${catkin_EXPORTED_TARGETS}
-# )
-
-# target_link_libraries(gyro_odometer ${catkin_LIBRARIES})
-
-# install(TARGETS
-#             gyro_odometer
-#         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-#         )
-
-# install(
-#   DIRECTORY
-#     launch
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-ament_auto_package(
-  INSTALL_TO_SHARE
+ament_auto_package(INSTALL_TO_SHARE
+  launch
 )

--- a/localization/twist_estimator/gyro_odometer/include/gyro_odometer/gyro_odometer_core.h
+++ b/localization/twist_estimator/gyro_odometer/include/gyro_odometer/gyro_odometer_core.h
@@ -41,16 +41,13 @@ private:
     const std::string & target_frame, const std::string & source_frame,
     const geometry_msgs::msg::TransformStamped::SharedPtr transform_stamped_ptr);
 
-  // ros::NodeHandle nh_;
-  // ros::NodeHandle private_nh_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr vehicle_twist_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
 
-  // ros::Subscriber vehicle_twist_sub_;
-  // ros::Subscriber imu_sub_;
-
-  // ros::Publisher twist_pub_;
-  // ros::Publisher twist_with_covariance_pub_;
-  // ros::Publisher linear_x_pub_;
-  // ros::Publisher angular_z_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr twist_with_covariance_pub_;
+  // rclcpp::Publisher<std_msgs::Float32>::SharedPtr linear_x_pub_;
+  // rclcpp::Publisher<std_msgs::Float32>::SharedPtr angular_z_pub_;
 
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;

--- a/localization/twist_estimator/gyro_odometer/include/gyro_odometer/gyro_odometer_core.h
+++ b/localization/twist_estimator/gyro_odometer/include/gyro_odometer/gyro_odometer_core.h
@@ -14,47 +14,49 @@
  * limitations under the License.
  */
 
-#pragma once
+#ifndef GYRO_ODOMETER_GYRO_ODOMETER_CORE_H_
 
-#include <ros/ros.h>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <std_msgs/msg/float32.hpp>
 
 #include <tf2/transform_datatypes.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/transform_listener.h>
 
-#include <std_msgs/Float32.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include <geometry_msgs/TwistStamped.h>
-#include <geometry_msgs/TwistWithCovarianceStamped.h>
-#include <sensor_msgs/Imu.h>
 
-class GyroOdometer
+class GyroOdometer : public rclcpp::Node
 {
 public:
-  GyroOdometer(ros::NodeHandle nh, ros::NodeHandle private_nh);
+  GyroOdometer();
   ~GyroOdometer();
 
 private:
-  void callbackTwist(const geometry_msgs::TwistStamped::ConstPtr & twist_msg_ptr);
-  void callbackImu(const sensor_msgs::Imu::ConstPtr & imu_msg_ptr);
+  void callbackTwist(const geometry_msgs::msg::TwistStamped::ConstSharedPtr twist_msg_ptr);
+  void callbackImu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg_ptr);
   bool getTransform(
     const std::string & target_frame, const std::string & source_frame,
-    const geometry_msgs::TransformStamped::Ptr & transform_stamped_ptr);
+    const geometry_msgs::msg::TransformStamped::SharedPtr transform_stamped_ptr);
 
-  ros::NodeHandle nh_;
-  ros::NodeHandle private_nh_;
+  // ros::NodeHandle nh_;
+  // ros::NodeHandle private_nh_;
 
-  ros::Subscriber vehicle_twist_sub_;
-  ros::Subscriber imu_sub_;
+  // ros::Subscriber vehicle_twist_sub_;
+  // ros::Subscriber imu_sub_;
 
-  ros::Publisher twist_pub_;
-  ros::Publisher twist_with_covariance_pub_;
-  ros::Publisher linear_x_pub_;
-  ros::Publisher angular_z_pub_;
+  // ros::Publisher twist_pub_;
+  // ros::Publisher twist_with_covariance_pub_;
+  // ros::Publisher linear_x_pub_;
+  // ros::Publisher angular_z_pub_;
 
-  tf2_ros::Buffer tf2_buffer_;
-  tf2_ros::TransformListener tf2_listener_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
   std::string output_frame_;
-  geometry_msgs::TwistStamped::ConstPtr twist_msg_ptr_;
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr twist_msg_ptr_;
 };
+
+#endif

--- a/localization/twist_estimator/gyro_odometer/include/gyro_odometer/gyro_odometer_core.h
+++ b/localization/twist_estimator/gyro_odometer/include/gyro_odometer/gyro_odometer_core.h
@@ -15,6 +15,7 @@
  */
 
 #ifndef GYRO_ODOMETER_GYRO_ODOMETER_CORE_H_
+#define GYRO_ODOMETER_GYRO_ODOMETER_CORE_H_
 
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
@@ -49,8 +50,8 @@ private:
   // rclcpp::Publisher<std_msgs::Float32>::SharedPtr linear_x_pub_;
   // rclcpp::Publisher<std_msgs::Float32>::SharedPtr angular_z_pub_;
 
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
 
   std::string output_frame_;
   geometry_msgs::msg::TwistStamped::ConstSharedPtr twist_msg_ptr_;

--- a/localization/twist_estimator/gyro_odometer/launch/gyro_odometer.launch.xml
+++ b/localization/twist_estimator/gyro_odometer/launch/gyro_odometer.launch.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <launch>
   <arg name="input_vehicle_twist_topic" default="/vehicle/status/twist" doc="" />
   <arg name="input_imu_topic" default="/sensing/imu/imu_data" doc="" />

--- a/localization/twist_estimator/gyro_odometer/launch/gyro_odometer.launch.xml
+++ b/localization/twist_estimator/gyro_odometer/launch/gyro_odometer.launch.xml
@@ -1,5 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <launch>
-
   <arg name="input_vehicle_twist_topic" default="/vehicle/status/twist" doc="" />
   <arg name="input_imu_topic" default="/sensing/imu/imu_data" doc="" />
 
@@ -8,14 +8,13 @@
 
   <arg name="output_frame" default="base_link" doc="" />
 
-  <node pkg="gyro_odometer" type="gyro_odometer" name="gyro_odometer" output="log">
-    <remap from="vehicle/twist" to="$(arg input_vehicle_twist_topic)" />
-    <remap from="imu" to="$(arg input_imu_topic)" />
+  <node pkg="gyro_odometer" exec="gyro_odometer" name="gyro_odometer" output="screen">
+    <remap from="vehicle/twist" to="$(var input_vehicle_twist_topic)" />
+    <remap from="imu" to="$(var input_imu_topic)" />
 
-    <remap from="twist" to="$(arg output_twist_topic)" />
-    <remap from="twist_with_covariance" to="$(arg output_twist_with_covariance_topic)" />
+    <remap from="twist" to="$(var output_twist_topic)" />
+    <remap from="twist_with_covariance" to="$(var output_twist_with_covariance_topic)" />
 
-    <param name="output_frame" value="$(arg output_frame)" />
+    <param name="output_frame" value="$(var output_frame)" />
   </node>
-
 </launch>

--- a/localization/twist_estimator/gyro_odometer/package.xml
+++ b/localization/twist_estimator/gyro_odometer/package.xml
@@ -1,28 +1,24 @@
-<?xml version="1.0"?>
-<package>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
     <name>gyro_odometer</name>
     <version>0.1.0</version>
-    <description>The gyro_odometer package</description>
+    <description>The gyro_odometer package as a ROS2 node</description>
     <maintainer email="yamato.ando@gmail.com">Yamato Ando</maintainer>
-    <license>Apache 2</license>
-    <buildtool_depend>catkin</buildtool_depend>
+    <license>Apache License 2.0</license>
 
-    <build_depend>roscpp</build_depend>
-    <build_depend>tf2</build_depend>
-    <build_depend>tf2_ros</build_depend>
-    <build_depend>tf2_geometry_msgs</build_depend>
-    <build_depend>std_msgs</build_depend>
-    <build_depend>geometry_msgs</build_depend>
-    <build_depend>sensor_msgs</build_depend>
+    <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-    <run_depend>roscpp</run_depend>
-    <run_depend>tf2</run_depend>
-    <run_depend>tf2_ros</run_depend>
-    <run_depend>tf2_geometry_msgs</run_depend>
-    <run_depend>std_msgs</run_depend>
-    <run_depend>geometry_msgs</run_depend>
-    <run_depend>sensor_msgs</run_depend>
+    <depend>tf2</depend>
+    <depend>tf2_ros</depend>
+    <depend>tf2_geometry_msgs</depend>
+    <depend>std_msgs</depend>
+    <depend>geometry_msgs</depend>
+    <depend>sensor_msgs</depend>
+
+    <exec_depend>rclcpp</exec_depend>
+    <exec_depend>rclcpp_components</exec_depend>
 
     <export>
+        <build_type>ament_cmake</build_type>
     </export>
 </package>

--- a/localization/twist_estimator/gyro_odometer/src/gyro_odometer_core.cpp
+++ b/localization/twist_estimator/gyro_odometer/src/gyro_odometer_core.cpp
@@ -16,21 +16,25 @@
 
 #include "gyro_odometer/gyro_odometer_core.h"
 
-#include <cmath>
-
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
-GyroOdometer::GyroOdometer(ros::NodeHandle nh, ros::NodeHandle private_nh)
-: nh_(nh), private_nh_(private_nh), output_frame_("base_link"), tf2_listener_(tf2_buffer_)
+#include <cmath>
+
+GyroOdometer::GyroOdometer()
+: Node("map_tf_generator"), 
+  output_frame_("base_link")
 {
-  private_nh_.getParam("output_frame", output_frame_);
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  tf_buffer_ = std::make_shared<tf2_ros::Buffer>(clock);
+  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+  // private_nh_.getParam("output_frame", output_frame_);
 
-  vehicle_twist_sub_ = nh_.subscribe("vehicle/twist", 100, &GyroOdometer::callbackTwist, this);
-  imu_sub_ = nh_.subscribe("imu", 100, &GyroOdometer::callbackImu, this);
+  // vehicle_twist_sub_ = nh_.subscribe("vehicle/twist", 100, &GyroOdometer::callbackTwist, this);
+  // imu_sub_ = nh_.subscribe("imu", 100, &GyroOdometer::callbackImu, this);
 
-  twist_pub_ = nh_.advertise<geometry_msgs::TwistStamped>("twist", 10);
-  twist_with_covariance_pub_ =
-    nh_.advertise<geometry_msgs::TwistWithCovarianceStamped>("twist_with_covariance", 10);
+  // twist_pub_ = nh_.advertise<geometry_msgs::TwistStamped>("twist", 10);
+  // twist_with_covariance_pub_ =
+  //   nh_.advertise<geometry_msgs::TwistWithCovarianceStamped>("twist_with_covariance", 10);
   // linear_x_pub_ = nh_.advertise<std_msgs::Float32>("linear_x", 10);
   // angular_z_pub_ = nh_.advertise<std_msgs::Float32>("angular_z", 10);
 
@@ -39,26 +43,26 @@ GyroOdometer::GyroOdometer(ros::NodeHandle nh, ros::NodeHandle private_nh)
 
 GyroOdometer::~GyroOdometer() {}
 
-void GyroOdometer::callbackTwist(const geometry_msgs::TwistStamped::ConstPtr & twist_msg_ptr)
+void GyroOdometer::callbackTwist(const geometry_msgs::msg::TwistStamped::ConstSharedPtr twist_msg_ptr)
 {
   // TODO trans from twist_msg_ptr->header to base_frame
   twist_msg_ptr_ = twist_msg_ptr;
 }
 
-void GyroOdometer::callbackImu(const sensor_msgs::Imu::ConstPtr & imu_msg_ptr)
+void GyroOdometer::callbackImu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg_ptr)
 {
   if (twist_msg_ptr_ == nullptr) {
     return;
   }
 
-  geometry_msgs::TransformStamped::Ptr tf_base2imu_ptr(new geometry_msgs::TransformStamped);
+  geometry_msgs::msg::TransformStamped::SharedPtr tf_base2imu_ptr = std::make_shared<geometry_msgs::msg::TransformStamped>();
   getTransform(output_frame_, imu_msg_ptr->header.frame_id, tf_base2imu_ptr);
 
-  geometry_msgs::Vector3Stamped angular_velocity;
+  geometry_msgs::msg::Vector3Stamped angular_velocity;
   angular_velocity.header = imu_msg_ptr->header;
   angular_velocity.vector = imu_msg_ptr->angular_velocity;
 
-  geometry_msgs::Vector3Stamped transed_angular_velocity;
+  geometry_msgs::msg::Vector3Stamped transed_angular_velocity;
   transed_angular_velocity.header = tf_base2imu_ptr->header;
 
   tf2::doTransform(angular_velocity, transed_angular_velocity, *tf_base2imu_ptr);
@@ -71,14 +75,14 @@ void GyroOdometer::callbackImu(const sensor_msgs::Imu::ConstPtr & imu_msg_ptr)
   }
 
   // TODO move code
-  geometry_msgs::TwistStamped twist;
+  geometry_msgs::msg::TwistStamped twist;
   twist.header.stamp = imu_msg_ptr->header.stamp;
   twist.header.frame_id = output_frame_;
   twist.twist.linear = twist_msg_ptr_->twist.linear;
   twist.twist.angular.z = transed_angular_velocity.vector.z;  // TODO yaw_rate only
-  twist_pub_.publish(twist);
+  // twist_pub_.publish(twist);
 
-  geometry_msgs::TwistWithCovarianceStamped twist_with_covariance;
+  geometry_msgs::msg::TwistWithCovarianceStamped twist_with_covariance;
   twist_with_covariance.header.stamp = imu_msg_ptr->header.stamp;
   twist_with_covariance.header.frame_id = output_frame_;
   twist_with_covariance.twist.twist.linear = twist_msg_ptr_->twist.linear;
@@ -91,15 +95,15 @@ void GyroOdometer::callbackImu(const sensor_msgs::Imu::ConstPtr & imu_msg_ptr)
   twist_with_covariance.twist.covariance[0 * 6 + 5] = vx_covariance * wz_covariance;
   twist_with_covariance.twist.covariance[5 * 6 + 0] = wz_covariance * vx_covariance;
   twist_with_covariance.twist.covariance[5 * 6 + 5] = wz_covariance * wz_covariance;
-  twist_with_covariance_pub_.publish(twist_with_covariance);
+  // twist_with_covariance_pub_.publish(twist_with_covariance);
 }
 
 bool GyroOdometer::getTransform(
   const std::string & target_frame, const std::string & source_frame,
-  const geometry_msgs::TransformStamped::Ptr & transform_stamped_ptr)
+  const geometry_msgs::msg::TransformStamped::SharedPtr transform_stamped_ptr)
 {
   if (target_frame == source_frame) {
-    transform_stamped_ptr->header.stamp = ros::Time::now();
+    transform_stamped_ptr->header.stamp = this->get_clock()->now();
     transform_stamped_ptr->header.frame_id = target_frame;
     transform_stamped_ptr->child_frame_id = source_frame;
     transform_stamped_ptr->transform.translation.x = 0.0;
@@ -114,12 +118,12 @@ bool GyroOdometer::getTransform(
 
   try {
     *transform_stamped_ptr =
-      tf2_buffer_.lookupTransform(target_frame, source_frame, ros::Time(0), ros::Duration(1.0));
+      tf_buffer_->lookupTransform(target_frame, source_frame, tf2::TimePointZero);
   } catch (tf2::TransformException & ex) {
-    ROS_WARN("%s", ex.what());
-    ROS_ERROR("Please publish TF %s to %s", target_frame.c_str(), source_frame.c_str());
+    RCLCPP_WARN(this->get_logger(), "%s", ex.what());
+    RCLCPP_ERROR(this->get_logger(), "Please publish TF %s to %s", target_frame.c_str(), source_frame.c_str());
 
-    transform_stamped_ptr->header.stamp = ros::Time::now();
+    transform_stamped_ptr->header.stamp = this->get_clock()->now();
     transform_stamped_ptr->header.frame_id = target_frame;
     transform_stamped_ptr->child_frame_id = source_frame;
     transform_stamped_ptr->transform.translation.x = 0.0;

--- a/localization/twist_estimator/gyro_odometer/src/gyro_odometer_node.cpp
+++ b/localization/twist_estimator/gyro_odometer/src/gyro_odometer_node.cpp
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include "gyro_odometer/gyro_odometer_core.h"
 
 int main(int argc, char ** argv)
 {
-  ros::init(argc, argv, "gyro_odometer");
-  ros::NodeHandle nh;
-  ros::NodeHandle private_nh("~");
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<GyroOdometer>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
 
-  GyroOdometer node(nh, private_nh);
-
-  ros::spin();
   return 0;
 }


### PR DESCRIPTION
# gyro_odometer

## Summary

Port `gyro_odometer` package. This package was straightforward with not many dependencies.

## Testing

1. Using the ADE environment in foxy, compile the package
```
colcon build
. install/setup.bash
```
2. Launch the package
```
ros2 launch gyro_odometer gyro_odometer.launch.xml
```