### PR TITLE
Update ci to use repos file

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,6 +15,18 @@ jobs:
     - name: Check out repo
       uses: actions/checkout@v2
 
+    - name: get repos file  
+      uses: wei/wget@v1
+      with: 
+        args: https://raw.githubusercontent.com/tier4/AutowareArchitectureProposal/ros2/autoware.proj.repos
+
+    - name: Clone other packages
+      run: mkdir dependency_ws && vcs import dependency_ws < autoware.proj.repos
+
+      ## We remove pilot.auto since it is already cloned from in actions/checkout@v2
+    - name: Remove pilot.auto from dependency_ws
+      run: rm -r dependency_ws/autoware/pilot.auto
+
     - name: Install missing dependencies
       run: sudo apt update && rosdep update && DEBIAN_FRONTEND=noninteractive rosdep install --from-paths . --ignore-src --rosdistro foxy -y
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,17 +15,8 @@ jobs:
     - name: Check out repo
       uses: actions/checkout@v2
 
-    - name: get repos file  
-      uses: wei/wget@v1
-      with: 
-        args: https://raw.githubusercontent.com/tier4/AutowareArchitectureProposal/ros2/autoware.proj.repos
-
-    - name: Clone other packages
-      run: mkdir dependency_ws && vcs import dependency_ws < autoware.proj.repos
-
-      ## We remove pilot.auto since it is already cloned from in actions/checkout@v2
-    - name: Remove pilot.auto from dependency_ws
-      run: rm -r dependency_ws/autoware/pilot.auto
+    - name: Clone dependency packages
+      run: mkdir dependency_ws && vcs import dependency_ws < build_depends.repos
 
     - name: Install missing dependencies
       run: sudo apt update && rosdep update && DEBIAN_FRONTEND=noninteractive rosdep install --from-paths . --ignore-src --rosdistro foxy -y

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -1,0 +1,9 @@
+repositories:
+  vendor/osqp:
+    type: git
+    url: https://github.com/tier4/osqp_vendor.git
+    version: 0.0.1
+  vendor/ublox:
+    type: git
+    url: https://github.com/tier4/ublox.git
+    version: foxy-devel


### PR DESCRIPTION
This modifies CI to use autoware.proj.repos file from AutowareArchitectureProposal to clone any external dependencies.