### PR TITLE
Port osqp-interface to ros2

### DIFF
--- a/common/math/osqp_interface/CMakeLists.txt
+++ b/common/math/osqp_interface/CMakeLists.txt
@@ -1,50 +1,39 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(osqp_interface)
 
-add_compile_options(-std=c++14 -Ofast)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  rostest
-  rosunit
-)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Ofast)
+endif()
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 find_package(Eigen3 REQUIRED)
 
+find_package(osqp_vendor REQUIRED)
+
 find_package(osqp REQUIRED)
-get_target_property(osqp_INCLUDE_DIR osqp::osqpstatic INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(OSQP_INCLUDE_DIR osqp::osqpstatic INTERFACE_INCLUDE_DIRECTORIES)
 
-catkin_package(
-  INCLUDE_DIRS
-    include
-    ${osqp_INCLUDE_DIR}
-  LIBRARIES
-    osqp_interface
-)
+set(EXTERNAL_INCLUDE_DIRS
+  "${EIGEN3_INCLUDE_DIR}"
+  "${OSQP_INCLUDE_DIR}"
+  )
 
-include_directories(
-  include
-  ${EIGEN3_INCLUDE_DIR}
-  ${osqp_INCLUDE_DIR}
-  ${catkin_INCLUDE_DIRS}
-)
+ament_auto_add_library(osqp_interface
+  src/osqp_interface.cpp
+  src/csc_matrix_conv.cpp
+  include/osqp_interface/osqp_interface.h
+  include/osqp_interface/csc_matrix_conv.h
+  )
+target_link_libraries(osqp_interface osqp::osqpstatic)
 
-add_library(osqp_interface src/osqp_interface.cpp src/csc_matrix_conv.cpp)
+target_include_directories(osqp_interface PUBLIC "${EXTERNAL_INCLUDE_DIRS}")
+# needed so clients of this package don't need to worry about includes of this package
+ament_export_include_directories("${EXTERNAL_INCLUDE_DIRS}")
 
-target_link_libraries(osqp_interface
-  osqp::osqpstatic
-  ${catkin_LIBRARIES}
-)
-
-install(
-  TARGETS
-    osqp_interface
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-## Install project namespaced headers
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
+ament_auto_package()

--- a/common/math/osqp_interface/package.xml
+++ b/common/math/osqp_interface/package.xml
@@ -6,11 +6,13 @@
   <maintainer email="robin.karlsson@tier4.jp">Robin Karlsson</maintainer>
   <license>Apache 2</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  
-  <depend>roscpp</depend>
-  <depend>rostest</depend>
-  <depend>rosunit</depend>
-  
+  <depend>osqp_vendor</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+
+  <depend>rclcpp</depend>
 </package>


### PR DESCRIPTION
It doesn't use any ros functionality so the source code is unchanged, only `package.xml` and `CMakeLists.txt` needed to
be modified. But osqp is added through a vendor package created at https://github.com/tier4/osqp_vendor

To test this locally, eigen needs to be installed in the environment with

    sudo apt install libeigen3-dev

This PR requires PR https://github.com/tier4/Pilot.Auto/pull/35 to be merged first and replaces https://github.com/tier4/Pilot.Auto/pull/14 as it introduces the same changes but with a streamlines history

