### PR TITLE
Message definition for ndt_scan_matcher debug topics

### DIFF
--- a/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher_msgs/CMakeLists.txt
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher_msgs/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.5)
+project(ndt_scan_matcher_msgs)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/DebugInfo.msg"
+)
+
+ament_package()

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher_msgs/msg/DebugInfo.msg
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher_msgs/msg/DebugInfo.msg
@@ -1,0 +1,6 @@
+int32 iteration_num
+float64 exe_time_ms
+float64 transform_probability
+float64 initial_to_result_distance
+float64 initial_to_result_distance_old
+float64 initial_to_result_distance_new

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher_msgs/package.xml
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher_msgs/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+    <name>ndt_scan_matcher_msgs</name>
+    <version>0.1.0</version>
+    <description>The ndt_scan_matcher_msgs package</description>
+    <maintainer email="yamato.ando@gmail.com">Yamato Ando</maintainer>
+    <license>Apache 2</license>
+    <buildtool_depend>ament_cmake_auto</buildtool_depend>
+    <buildtool_depend>rosidl_default_generators</buildtool_depend>
+    <exec_depend>rosidl_default_runtime</exec_depend>
+    <member_of_group>rosidl_interface_packages</member_of_group>
+    <export>
+        <build_type>ament_cmake</build_type> 
+    </export>
+</package>

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher_msgs/package.xml
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher_msgs/package.xml
@@ -6,7 +6,7 @@
     <description>The ndt_scan_matcher_msgs package</description>
     <maintainer email="yamato.ando@gmail.com">Yamato Ando</maintainer>
     <license>Apache 2</license>
-    <buildtool_depend>ament_cmake_auto</buildtool_depend>
+    <buildtool_depend>ament_cmake</buildtool_depend>
     <buildtool_depend>rosidl_default_generators</buildtool_depend>
     <exec_depend>rosidl_default_runtime</exec_depend>
     <member_of_group>rosidl_interface_packages</member_of_group>


### PR DESCRIPTION
* There are a [couple of `Float32` publishers](https://github.com/tier4/Pilot.Auto/blob/0f3dee10dd4c22fddbee44662bd520e5a6d87ef7/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp#L114-L122) in `ndt_scan_matcher` that are apparently for debugging; there are no corresponding subscribers in the code base.
* They all publish at the same time, so they can be made into one message instead of individual messages. This package defines that message type.
* When I compiled this with `ament_cmake_auto`, the message wasn't found by the `ndt_scan_matcher` package, so I used `ament_cmake` as in the other message packages.
