### PR TITLE
Fix target CI branches

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,9 +2,11 @@ name: Build and test
 
 on:
   pull_request:
+    branches:
+      - ros2
   push:
     branches:
-      - ros2-porting-test
+      - ros2
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This PR changes the target branches for `push` and `pull_request` events to `ros2`