### PR TITLE
Port lane change planner

### DIFF
--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/CMakeLists.txt
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/CMakeLists.txt
@@ -1,31 +1,24 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(lane_change_planner)
 
-add_compile_options(-std=c++14)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wno-unused-parameter)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  autoware_perception_msgs
-  autoware_planning_msgs
-  geometry_msgs
-  lanelet2_extension
-  roscpp
-  sensor_msgs
-  tf2
-  tf2_geometry_msgs
-  tf2_ros
-)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 find_package(OpenCV REQUIRED)
 
-catkin_package()
-
 include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
 )
 
-add_executable(lane_change_planner
+ament_auto_add_executable(lane_change_planner
   src/lane_change_planner_node.cpp
   src/lane_changer.cpp
   src/data_manager.cpp
@@ -42,16 +35,9 @@ add_executable(lane_change_planner
   src/state/stopping_lane_change.cpp
   src/state/common_functions.cpp
 )
-add_dependencies(lane_change_planner ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(lane_change_planner
-  ${catkin_LIBRARIES}
   ${OpenCV_LIBRARIES}
 )
 
-install(
-  TARGETS
-    lane_change_planner
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+ament_auto_package(
 )

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.h
@@ -45,13 +45,15 @@ namespace lane_change_planner
 class SelfPoseLinstener
 {
 public:
-  SelfPoseLinstener();
+  SelfPoseLinstener(const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr & clock);
   bool getSelfPose(geometry_msgs::msg::PoseStamped & self_pose);
   bool isSelfPoseReady();
 
 private:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
+  rclcpp::Logger logger_;
+  rclcpp::Clock::SharedPtr clock_;
 };
 
 struct BoolStamped
@@ -77,13 +79,16 @@ private:
   LaneChangerParameters parameters_;
   bool is_parameter_set_;
 
+  rclcpp::Logger logger_;
+  rclcpp::Clock::SharedPtr clock_;
+
   /*
    * SelfPoseLinstener
    */
   std::shared_ptr<SelfPoseLinstener> self_pose_listener_ptr_;
 
 public:
-  DataManager();
+  DataManager(const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr & clock);
   ~DataManager() = default;
 
   // callbacks
@@ -101,6 +106,8 @@ public:
   LaneChangerParameters getLaneChangerParameters();
   bool getLaneChangeApproval();
   bool getForceLaneChangeSignal();
+  rclcpp::Logger & getLogger();
+  rclcpp::Clock::SharedPtr getClock();
 
   bool isDataReady();
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.h
@@ -50,7 +50,7 @@ public:
   bool isSelfPoseReady();
 
 private:
-  tf2_ros::Buffer tf_buffer_;
+  tf2::BufferCore tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
   rclcpp::Logger logger_;
   rclcpp::Clock::SharedPtr clock_;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.h
@@ -60,7 +60,7 @@ struct BoolStamped
 {
   explicit BoolStamped(bool in_data) : data(in_data) {}
   bool data = false;
-  ros::Time stamp;
+  rclcpp::Time stamp;
 };
 
 class DataManager

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.h
@@ -18,18 +18,18 @@
 #define LANE_CHANGE_PLANNER_DATA_MANAGER_H
 
 // ROS
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/TwistStamped.h>
-#include <ros/ros.h>
-#include <sensor_msgs/PointCloud2.h>
-#include <std_msgs/Bool.h>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <std_msgs/msg/bool.hpp>
 #include <tf2_ros/transform_listener.h>
 
 // Autoware
-#include <autoware_lanelet2_msgs/MapBin.h>
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <autoware_planning_msgs/PathWithLaneId.h>
-#include <autoware_planning_msgs/Route.h>
+#include <autoware_lanelet2_msgs/msg/map_bin.hpp>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <autoware_planning_msgs/msg/route.hpp>
 #include <lane_change_planner/parameters.h>
 
 // lanelet
@@ -46,7 +46,7 @@ class SelfPoseLinstener
 {
 public:
   SelfPoseLinstener();
-  bool getSelfPose(geometry_msgs::PoseStamped & self_pose);
+  bool getSelfPose(geometry_msgs::msg::PoseStamped & self_pose);
   bool isSelfPoseReady();
 
 private:
@@ -67,11 +67,11 @@ private:
   /*
    * Cache
    */
-  autoware_perception_msgs::DynamicObjectArray::ConstPtr perception_ptr_;
-  geometry_msgs::TwistStamped::ConstPtr vehicle_velocity_ptr_;
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr perception_ptr_;
+  geometry_msgs::msg::TwistStamped::ConstPtr vehicle_velocity_ptr_;
   BoolStamped lane_change_approval_;
   BoolStamped force_lane_change_;
-  geometry_msgs::PoseStamped self_pose_;
+  geometry_msgs::msg::PoseStamped self_pose_;
 
   // ROS parameters
   LaneChangerParameters parameters_;
@@ -88,16 +88,16 @@ public:
 
   // callbacks
   void perceptionCallback(
-    const autoware_perception_msgs::DynamicObjectArray::ConstPtr & input_perception_msg);
-  void velocityCallback(const geometry_msgs::TwistStamped::ConstPtr & input_twist_msg);
+    const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr & input_perception_msg);
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstPtr & input_twist_msg);
   void setLaneChangerParameters(const LaneChangerParameters & parameters);
-  void laneChangeApprovalCallback(const std_msgs::Bool & input_approval_msg);
-  void forceLaneChangeSignalCallback(const std_msgs::Bool & input_approval_msg);
+  void laneChangeApprovalCallback(const std_msgs::msg::Bool & input_approval_msg);
+  void forceLaneChangeSignalCallback(const std_msgs::msg::Bool & input_approval_msg);
 
   // getters
-  autoware_perception_msgs::DynamicObjectArray::ConstPtr getDynamicObjects();
-  geometry_msgs::PoseStamped getCurrentSelfPose();
-  geometry_msgs::TwistStamped::ConstPtr getCurrentSelfVelocity();
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr getDynamicObjects();
+  geometry_msgs::msg::PoseStamped getCurrentSelfPose();
+  geometry_msgs::msg::TwistStamped::ConstPtr getCurrentSelfVelocity();
   LaneChangerParameters getLaneChangerParameters();
   bool getLaneChangeApproval();
   bool getForceLaneChangeSignal();

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.h
@@ -69,8 +69,8 @@ private:
   /*
    * Cache
    */
-  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr perception_ptr_;
-  geometry_msgs::msg::TwistStamped::ConstPtr vehicle_velocity_ptr_;
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr perception_ptr_;
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr vehicle_velocity_ptr_;
   BoolStamped lane_change_approval_;
   BoolStamped force_lane_change_;
   geometry_msgs::msg::PoseStamped self_pose_;
@@ -93,16 +93,16 @@ public:
 
   // callbacks
   void perceptionCallback(
-    const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr & input_perception_msg);
-  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstPtr & input_twist_msg);
+    const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr input_perception_msg);
+  void velocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr input_twist_msg);
   void setLaneChangerParameters(const LaneChangerParameters & parameters);
-  void laneChangeApprovalCallback(const std_msgs::msg::Bool & input_approval_msg);
-  void forceLaneChangeSignalCallback(const std_msgs::msg::Bool & input_approval_msg);
+  void laneChangeApprovalCallback(const std_msgs::msg::Bool::ConstSharedPtr input_approval_msg);
+  void forceLaneChangeSignalCallback(const std_msgs::msg::Bool::ConstSharedPtr input_approval_msg);
 
   // getters
-  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr getDynamicObjects();
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr getDynamicObjects();
   geometry_msgs::msg::PoseStamped getCurrentSelfPose();
-  geometry_msgs::msg::TwistStamped::ConstPtr getCurrentSelfVelocity();
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr getCurrentSelfVelocity();
   LaneChangerParameters getLaneChangerParameters();
   bool getLaneChangeApproval();
   bool getForceLaneChangeSignal();

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/lane_changer.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/lane_changer.h
@@ -18,16 +18,16 @@
 #define LANE_CHANGE_PLANNER_LANE_CHANGER_H
 
 // ROS
-#include <ros/ros.h>
-#include <std_msgs/Bool.h>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/bool.hpp>
 #include <tf2_ros/transform_listener.h>
 
 // Autoware
-#include <autoware_lanelet2_msgs/MapBin.h>
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <autoware_planning_msgs/PathWithLaneId.h>
-#include <autoware_planning_msgs/Route.h>
-#include <autoware_planning_msgs/StopReasonArray.h>
+#include <autoware_lanelet2_msgs/msg/map_bin.hpp>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <autoware_planning_msgs/msg/route.hpp>
+#include <autoware_planning_msgs/msg/stop_reason_array.hpp>
 
 #include <lane_change_planner/data_manager.h>
 #include <lane_change_planner/route_handler.h>
@@ -74,10 +74,10 @@ private:
 
   void run(const ros::TimerEvent & event);
   void publishDebugMarkers();
-  void publishDrivableArea(const autoware_planning_msgs::PathWithLaneId & path);
-  autoware_planning_msgs::StopReasonArray makeStopReasonArray(
+  void publishDrivableArea(const autoware_planning_msgs::msg::PathWithLaneId & path);
+  autoware_planning_msgs::msg::StopReasonArray makeStopReasonArray(
     const DebugData & debug_data, const State & state);
-  std::vector<autoware_planning_msgs::StopReason> makeEmptyStopReasons();
+  std::vector<autoware_planning_msgs::msg::StopReason> makeEmptyStopReasons();
   void waitForData();
 
 public:

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/lane_changer.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/lane_changer.h
@@ -47,7 +47,7 @@ namespace lane_change_planner
 class LaneChanger : rclcpp::Node
 {
 private:
-  ros::Timer timer_;
+  rclcpp::TimerBase::SharedPtr timer_;
 
   rclcpp::Publisher<autoware_planning_msgs::msg::PathWithLaneId>::SharedPtr path_publisher_;
   rclcpp::Publisher<autoware_planning_msgs::msg::Path>::SharedPtr candidate_path_publisher_;
@@ -71,7 +71,7 @@ private:
   std::shared_ptr<RouteHandler> route_handler_ptr_;
   // PathExtender path_extender_;
 
-  void run(const ros::TimerEvent & event);
+  void run();
   void publishDebugMarkers();
   void publishDrivableArea(const autoware_planning_msgs::msg::PathWithLaneId & path);
   autoware_planning_msgs::msg::StopReasonArray makeStopReasonArray(

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/lane_changer.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/lane_changer.h
@@ -44,7 +44,7 @@
 
 namespace lane_change_planner
 {
-class LaneChanger : rclcpp::Node
+class LaneChanger : public rclcpp::Node
 {
 private:
   rclcpp::TimerBase::SharedPtr timer_;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/lane_changer.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/lane_changer.h
@@ -42,7 +42,7 @@
 
 namespace lane_change_planner
 {
-class LaneChanger
+class LaneChanger : rclcpp::Node
 {
 private:
   ros::Timer timer_;
@@ -54,8 +54,6 @@ private:
   ros::Publisher drivable_area_publisher_;
   ros::Publisher lane_change_ready_publisher_;
   ros::Publisher lane_change_available_publisher_;
-
-  ros::NodeHandle pnh_;
 
   ros::Subscriber points_subscriber_;
   ros::Subscriber perception_subscriber_;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/lane_changer.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/lane_changer.h
@@ -21,11 +21,13 @@
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <tf2_ros/transform_listener.h>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 // Autoware
 #include <autoware_lanelet2_msgs/msg/map_bin.hpp>
 #include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
 #include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <autoware_planning_msgs/msg/path.hpp>
 #include <autoware_planning_msgs/msg/route.hpp>
 #include <autoware_planning_msgs/msg/stop_reason_array.hpp>
 
@@ -47,23 +49,22 @@ class LaneChanger : rclcpp::Node
 private:
   ros::Timer timer_;
 
-  ros::Publisher path_publisher_;
-  ros::Publisher candidate_path_publisher_;
-  ros::Publisher path_marker_publisher_;
-  ros::Publisher stop_reason_publisher_;
-  ros::Publisher drivable_area_publisher_;
-  ros::Publisher lane_change_ready_publisher_;
-  ros::Publisher lane_change_available_publisher_;
+  rclcpp::Publisher<autoware_planning_msgs::msg::PathWithLaneId>::SharedPtr path_publisher_;
+  rclcpp::Publisher<autoware_planning_msgs::msg::Path>::SharedPtr candidate_path_publisher_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr path_marker_publisher_;
+  rclcpp::Publisher<autoware_planning_msgs::msg::StopReasonArray>::SharedPtr stop_reason_publisher_;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr drivable_area_publisher_;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr lane_change_ready_publisher_;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr lane_change_available_publisher_;
 
-  ros::Subscriber points_subscriber_;
-  ros::Subscriber perception_subscriber_;
-  ros::Subscriber velocity_subscriber_;
-  ros::Subscriber lane_change_approval_subscriber_;
-  ros::Subscriber force_lane_change_subscriber_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::DynamicObjectArray>::SharedPtr perception_subscriber_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr velocity_subscriber_;
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr lane_change_approval_subscriber_;
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr force_lane_change_subscriber_;
 
-  ros::Subscriber vector_map_subscriber_;
-  ros::Subscriber route_subscriber_;
-  ros::Subscriber route_init_subscriber_;
+  rclcpp::Subscription<autoware_lanelet2_msgs::msg::MapBin>::SharedPtr vector_map_subscriber_;
+  rclcpp::Subscription<autoware_planning_msgs::msg::Route>::SharedPtr route_subscriber_;
+  rclcpp::Subscription<autoware_planning_msgs::msg::Route>::SharedPtr route_init_subscriber_;
 
   std::shared_ptr<DataManager> data_manager_ptr_;
   std::shared_ptr<StateMachine> state_machine_ptr_;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/route_handler.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/route_handler.h
@@ -83,8 +83,8 @@ public:
     const lanelet::routing::RoutingGraphPtr & routing_graph, const lanelet::routing::Route & route);
   bool isHandlerReady();
 
-  void mapCallback(const autoware_lanelet2_msgs::msg::MapBin & map_msg);
-  void routeCallback(const autoware_planning_msgs::msg::Route & route_msg);
+  void mapCallback(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr map_msg);
+  void routeCallback(const autoware_planning_msgs::msg::Route::ConstSharedPtr route_msg);
 
   bool getPreviousLaneletWithinRoute(
     const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * prev_lanelet) const;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/route_handler.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/route_handler.h
@@ -18,10 +18,10 @@
 #define LANE_CHANGE_PLANNER_ROUTE_HANDLER_H
 
 // Autoware
-#include <autoware_lanelet2_msgs/MapBin.h>
-#include <autoware_planning_msgs/PathWithLaneId.h>
-#include <autoware_planning_msgs/Route.h>
-#include <geometry_msgs/PoseStamped.h>
+#include <autoware_lanelet2_msgs/msg/map_bin.hpp>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <autoware_planning_msgs/msg/route.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <lanelet2_extension/utility/query.h>
 // lanelet
 #include <lanelet2_routing/Route.h>
@@ -40,7 +40,7 @@ enum class LaneChangeDirection { NONE, LEFT, RIGHT };
 
 struct LaneChangePath
 {
-  autoware_planning_msgs::PathWithLaneId path;
+  autoware_planning_msgs::msg::PathWithLaneId path;
   double acceleration = 0.0;
   double preparation_length = 0.0;
   double lane_change_length = 0.0;
@@ -57,7 +57,7 @@ private:
   lanelet::routing::RoutingGraphPtr routing_graph_ptr_;
   lanelet::traffic_rules::TrafficRulesPtr traffic_rules_ptr_;
   std::shared_ptr<const lanelet::routing::RoutingGraphContainer> overall_graphs_ptr_;
-  autoware_planning_msgs::Route route_msg_;
+  autoware_planning_msgs::msg::Route route_msg_;
 
   bool is_map_msg_ready_;
   bool is_route_msg_ready_;
@@ -78,8 +78,8 @@ public:
     const lanelet::routing::RoutingGraphPtr & routing_graph, const lanelet::routing::Route & route);
   bool isHandlerReady();
 
-  void mapCallback(const autoware_lanelet2_msgs::MapBin & map_msg);
-  void routeCallback(const autoware_planning_msgs::Route & route_msg);
+  void mapCallback(const autoware_lanelet2_msgs::msg::MapBin & map_msg);
+  void routeCallback(const autoware_planning_msgs::msg::Route & route_msg);
 
   bool getPreviousLaneletWithinRoute(
     const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * prev_lanelet) const;
@@ -91,20 +91,20 @@ public:
     const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * left_lanelet);
 
   bool getClosestLaneletWithinRoute(
-    const geometry_msgs::Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const;
+    const geometry_msgs::msg::Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const;
   bool getGoalLanelet(lanelet::ConstLanelet * goal_lanelet) const;
-  geometry_msgs::Pose getGoalPose() const;
+  geometry_msgs::msg::Pose getGoalPose() const;
   lanelet::Id getGoalLaneId() const;
   lanelet::ConstLanelets getLaneletsFromIds(const std::vector<uint64_t> ids) const;
 
   bool isDeadEndLanelet(const lanelet::ConstLanelet & lanelet) const;
   bool isInTargetLane(
-    const geometry_msgs::PoseStamped & pose, const lanelet::ConstLanelets & target) const;
+    const geometry_msgs::msg::PoseStamped & pose, const lanelet::ConstLanelets & target) const;
   bool isInGoalRouteSection(const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstLanelets getRouteLanelets() const;
   lanelet::ConstLanelets getLaneletSequence(const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstLanelets getLaneletSequence(
-    const lanelet::ConstLanelet & lanelet, const geometry_msgs::Pose & current_pose,
+    const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Pose & current_pose,
     const double backward_distance, const double forward_distance) const;
   lanelet::ConstLanelets getLaneletSequenceUpTo(
     const lanelet::ConstLanelet & lanelet,
@@ -114,33 +114,33 @@ public:
     const double min_length = std::numeric_limits<double>::max()) const;
   lanelet::ConstLanelets getPreviousLaneletSequence(
     const lanelet::ConstLanelets & lanelet_sequence) const;
-  lanelet::ConstLanelets getClosestLaneletSequence(const geometry_msgs::Pose & pose) const;
+  lanelet::ConstLanelets getClosestLaneletSequence(const geometry_msgs::msg::Pose & pose) const;
   lanelet::ConstLanelets getNeighborsWithinRoute(const lanelet::ConstLanelet & lanelet) const;
 
   int getNumLaneToPreferredLane(const lanelet::ConstLanelet & lanelet) const;
-  bool isInPreferredLane(const geometry_msgs::PoseStamped & pose) const;
+  bool isInPreferredLane(const geometry_msgs::msg::PoseStamped & pose) const;
   std::vector<LaneChangePath> getLaneChangePaths(
     const lanelet::ConstLanelets & original_lanes, const lanelet::ConstLanelets & target_lanes,
-    const geometry_msgs::Pose & pose, const geometry_msgs::Twist & twist,
+    const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Twist & twist,
     const LaneChangerParameters & parameter) const;
-  autoware_planning_msgs::PathWithLaneId getReferencePath(
-    const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::Pose & pose,
+  autoware_planning_msgs::msg::PathWithLaneId getReferencePath(
+    const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose,
     const double backward_path_length, const double forward_path_length,
     const double minimum_lane_change_length) const;
-  autoware_planning_msgs::PathWithLaneId getReferencePath(
+  autoware_planning_msgs::msg::PathWithLaneId getReferencePath(
     const lanelet::ConstLanelets & lanelet_sequence, const double s_start, const double s_end,
     bool use_exact = true) const;
-  autoware_planning_msgs::PathWithLaneId updatePathTwist(
-    const autoware_planning_msgs::PathWithLaneId & path) const;
+  autoware_planning_msgs::msg::PathWithLaneId updatePathTwist(
+    const autoware_planning_msgs::msg::PathWithLaneId & path) const;
   bool getLaneChangeTarget(
     const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * target_lanelet) const;
-  lanelet::ConstLanelets getLaneChangeTarget(const geometry_msgs::Pose & pose) const;
+  lanelet::ConstLanelets getLaneChangeTarget(const geometry_msgs::msg::Pose & pose) const;
 
   double getLaneChangeableDistance(
-    const geometry_msgs::Pose & current_pose, const LaneChangeDirection & direction);
+    const geometry_msgs::msg::Pose & current_pose, const LaneChangeDirection & direction);
 
   lanelet::ConstLanelets getCheckTargetLanesFromPath(
-    const autoware_planning_msgs::PathWithLaneId & path,
+    const autoware_planning_msgs::msg::PathWithLaneId & path,
     const lanelet::ConstLanelets & target_lanes, const double check_length);
 
   lanelet::routing::RoutingGraphContainer getOverallGraph() const;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/route_handler.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/route_handler.h
@@ -32,6 +32,8 @@
 
 #include <lane_change_planner/parameters.h>
 
+#include <rclcpp/rclcpp.hpp>
+
 #include <vector>
 
 namespace lane_change_planner
@@ -49,7 +51,7 @@ struct LaneChangePath
 class RouteHandler
 {
 public:
-  RouteHandler();
+  RouteHandler(const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr & clock);
   ~RouteHandler() = default;
 
 private:
@@ -67,6 +69,9 @@ private:
   lanelet::ConstLanelets preferred_lanelets_;
   lanelet::ConstLanelets start_lanelets_;
   lanelet::ConstLanelets goal_lanelets_;
+
+  rclcpp::Logger logger_;
+  rclcpp::Clock::SharedPtr clock_;
 
   void setRouteLanelets();
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/aborting_lane_change.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/aborting_lane_change.h
@@ -37,7 +37,7 @@ public:
   void update() override;
   State getNextState() const override;
   State getCurrentState() const override;
-  autoware_planning_msgs::PathWithLaneId getPath() const override;
+  autoware_planning_msgs::msg::PathWithLaneId getPath() const override;
 };
 }  // namespace lane_change_planner
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/blocked_by_obstacle.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/blocked_by_obstacle.h
@@ -17,9 +17,9 @@
 #ifndef LANE_CHANGE_PLANNER_STATE_BLOCKED_BY_OBSTACLE_H
 #define LANE_CHANGE_PLANNER_STATE_BLOCKED_BY_OBSTACLE_H
 
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/TwistStamped.h>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 #include <lane_change_planner/state/state_base_class.h>
 #include <lanelet2_core/primitives/Primitive.h>
 #include <memory>
@@ -29,9 +29,9 @@ namespace lane_change_planner
 class BlockedByObstacleState : public StateBase
 {
 private:
-  geometry_msgs::PoseStamped current_pose_;
-  geometry_msgs::TwistStamped::ConstPtr current_twist_;
-  autoware_perception_msgs::DynamicObjectArray::ConstPtr dynamic_objects_;
+  geometry_msgs::msg::PoseStamped current_pose_;
+  geometry_msgs::msg::TwistStamped::ConstPtr current_twist_;
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr dynamic_objects_;
   bool lane_change_approved_;
   bool force_lane_change_;
   bool found_safe_path_;
@@ -49,9 +49,9 @@ private:
   bool laneChangeForcedByOperator() const;
 
   // utility function
-  std::vector<autoware_perception_msgs::DynamicObject> getBlockingObstacles() const;
-  autoware_planning_msgs::PathWithLaneId setStopPointFromObstacle(
-    const autoware_planning_msgs::PathWithLaneId & path);
+  std::vector<autoware_perception_msgs::msg::DynamicObject> getBlockingObstacles() const;
+  autoware_planning_msgs::msg::PathWithLaneId setStopPointFromObstacle(
+    const autoware_planning_msgs::msg::PathWithLaneId & path);
 
 public:
   BlockedByObstacleState(
@@ -63,7 +63,7 @@ public:
   void update() override;
   State getNextState() const override;
   State getCurrentState() const override;
-  autoware_planning_msgs::PathWithLaneId getPath() const override;
+  autoware_planning_msgs::msg::PathWithLaneId getPath() const override;
 };
 }  // namespace lane_change_planner
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/blocked_by_obstacle.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/blocked_by_obstacle.h
@@ -30,8 +30,8 @@ class BlockedByObstacleState : public StateBase
 {
 private:
   geometry_msgs::msg::PoseStamped current_pose_;
-  geometry_msgs::msg::TwistStamped::ConstPtr current_twist_;
-  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr dynamic_objects_;
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr current_twist_;
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr dynamic_objects_;
   bool lane_change_approved_;
   bool force_lane_change_;
   bool found_safe_path_;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/common_functions.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/common_functions.h
@@ -35,14 +35,14 @@ bool selectLaneChangePath(
   const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr & dynamic_objects,
   const geometry_msgs::msg::Pose & current_pose, const geometry_msgs::msg::Twist & current_twist,
   const bool isInGoalRouteSection, const geometry_msgs::msg::Pose & goal_pose,
-  const LaneChangerParameters & ros_parameters, LaneChangePath * path);
+  const LaneChangerParameters & ros_parameters, LaneChangePath * path, const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr & clock);
 
 bool isLaneChangePathSafe(
   const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
   const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr & dynamic_objects,
   const geometry_msgs::msg::Pose & current_pose, const geometry_msgs::msg::Twist & current_twist,
-  const LaneChangerParameters & ros_parameters, const bool use_buffer = true,
+  const LaneChangerParameters & ros_parameters, const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr & clock, const bool use_buffer = true,
   const double acceleration = 0.0);
 bool hasEnoughDistance(
   const LaneChangePath & path, const lanelet::ConstLanelets & current_lanes,

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/common_functions.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/common_functions.h
@@ -15,9 +15,9 @@
  */
 #pragma once
 
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/TwistStamped.h>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 #include <lane_change_planner/state/state_base_class.h>
 #include <lanelet2_core/primitives/Primitive.h>
 #include <memory>
@@ -32,24 +32,24 @@ bool selectLaneChangePath(
   const std::vector<LaneChangePath> & paths, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
   const lanelet::routing::RoutingGraphContainer & overall_graphs,
-  const autoware_perception_msgs::DynamicObjectArray::ConstPtr & dynamic_objects,
-  const geometry_msgs::Pose & current_pose, const geometry_msgs::Twist & current_twist,
-  const bool isInGoalRouteSection, const geometry_msgs::Pose & goal_pose,
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr & dynamic_objects,
+  const geometry_msgs::msg::Pose & current_pose, const geometry_msgs::msg::Twist & current_twist,
+  const bool isInGoalRouteSection, const geometry_msgs::msg::Pose & goal_pose,
   const LaneChangerParameters & ros_parameters, LaneChangePath * path);
 
 bool isLaneChangePathSafe(
-  const autoware_planning_msgs::PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
-  const autoware_perception_msgs::DynamicObjectArray::ConstPtr & dynamic_objects,
-  const geometry_msgs::Pose & current_pose, const geometry_msgs::Twist & current_twist,
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr & dynamic_objects,
+  const geometry_msgs::msg::Pose & current_pose, const geometry_msgs::msg::Twist & current_twist,
   const LaneChangerParameters & ros_parameters, const bool use_buffer = true,
   const double acceleration = 0.0);
 bool hasEnoughDistance(
   const LaneChangePath & path, const lanelet::ConstLanelets & current_lanes,
-  const lanelet::ConstLanelets & target_lanes, const geometry_msgs::Pose & current_pose,
-  const bool isInGoalRouteSection, const geometry_msgs::Pose & goal_pose,
+  const lanelet::ConstLanelets & target_lanes, const geometry_msgs::msg::Pose & current_pose,
+  const bool isInGoalRouteSection, const geometry_msgs::msg::Pose & goal_pose,
   const lanelet::routing::RoutingGraphContainer & overall_graphs);
-bool isObjectFront(const geometry_msgs::Pose & ego_pose, const geometry_msgs::Pose & obj_pose);
+bool isObjectFront(const geometry_msgs::msg::Pose & ego_pose, const geometry_msgs::msg::Pose & obj_pose);
 }  // namespace common_functions
 }  // namespace state_machine
 }  // namespace lane_change_planner

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/common_functions.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/common_functions.h
@@ -32,7 +32,7 @@ bool selectLaneChangePath(
   const std::vector<LaneChangePath> & paths, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
   const lanelet::routing::RoutingGraphContainer & overall_graphs,
-  const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr & dynamic_objects,
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr & dynamic_objects,
   const geometry_msgs::msg::Pose & current_pose, const geometry_msgs::msg::Twist & current_twist,
   const bool isInGoalRouteSection, const geometry_msgs::msg::Pose & goal_pose,
   const LaneChangerParameters & ros_parameters, LaneChangePath * path, const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr & clock);
@@ -40,7 +40,7 @@ bool selectLaneChangePath(
 bool isLaneChangePathSafe(
   const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
-  const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr & dynamic_objects,
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr & dynamic_objects,
   const geometry_msgs::msg::Pose & current_pose, const geometry_msgs::msg::Twist & current_twist,
   const LaneChangerParameters & ros_parameters, const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr & clock, const bool use_buffer = true,
   const double acceleration = 0.0);

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/executing_lane_change.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/executing_lane_change.h
@@ -34,8 +34,8 @@ class ExecutingLaneChangeState : public StateBase
 {
 private:
   geometry_msgs::msg::PoseStamped current_pose_;
-  geometry_msgs::msg::TwistStamped::ConstPtr current_twist_;
-  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr dynamic_objects_;
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr current_twist_;
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr dynamic_objects_;
 
   lanelet::ConstLanelets original_lanes_;
   lanelet::ConstLanelets target_lanes_;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/executing_lane_change.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/executing_lane_change.h
@@ -17,12 +17,12 @@
 #ifndef LANE_CHANGE_PLANNER_STATE_EXECUTING_LANE_CHANGE_H
 #define LANE_CHANGE_PLANNER_STATE_EXECUTING_LANE_CHANGE_H
 
-#include <autoware_planning_msgs/PathWithLaneId.h>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 #include <lane_change_planner/state/state_base_class.h>
 
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/TwistStamped.h>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 
 #include <lanelet2_core/primitives/Lanelet.h>
 
@@ -33,9 +33,9 @@ namespace lane_change_planner
 class ExecutingLaneChangeState : public StateBase
 {
 private:
-  geometry_msgs::PoseStamped current_pose_;
-  geometry_msgs::TwistStamped::ConstPtr current_twist_;
-  autoware_perception_msgs::DynamicObjectArray::ConstPtr dynamic_objects_;
+  geometry_msgs::msg::PoseStamped current_pose_;
+  geometry_msgs::msg::TwistStamped::ConstPtr current_twist_;
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr dynamic_objects_;
 
   lanelet::ConstLanelets original_lanes_;
   lanelet::ConstLanelets target_lanes_;
@@ -56,7 +56,7 @@ public:
   void update() override;
   State getNextState() const override;
   State getCurrentState() const override;
-  autoware_planning_msgs::PathWithLaneId getPath() const override;
+  autoware_planning_msgs::msg::PathWithLaneId getPath() const override;
 };
 }  // namespace lane_change_planner
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/following_lane.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/following_lane.h
@@ -31,8 +31,8 @@ class FollowingLaneState : public StateBase
 {
 private:
   geometry_msgs::msg::PoseStamped current_pose_;
-  geometry_msgs::msg::TwistStamped::ConstPtr current_twist_;
-  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr dynamic_objects_;
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr current_twist_;
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr dynamic_objects_;
   bool lane_change_approved_;
   bool force_lane_change_;
   lanelet::ConstLanelets current_lanes_;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/following_lane.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/following_lane.h
@@ -17,9 +17,9 @@
 #ifndef LANE_CHANGE_PLANNER_STATE_FOLLOWING_LANE_H
 #define LANE_CHANGE_PLANNER_STATE_FOLLOWING_LANE_H
 
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/TwistStamped.h>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 #include <lane_change_planner/state/state_base_class.h>
 #include <lanelet2_core/primitives/Primitive.h>
 
@@ -30,9 +30,9 @@ namespace lane_change_planner
 class FollowingLaneState : public StateBase
 {
 private:
-  geometry_msgs::PoseStamped current_pose_;
-  geometry_msgs::TwistStamped::ConstPtr current_twist_;
-  autoware_perception_msgs::DynamicObjectArray::ConstPtr dynamic_objects_;
+  geometry_msgs::msg::PoseStamped current_pose_;
+  geometry_msgs::msg::TwistStamped::ConstPtr current_twist_;
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr dynamic_objects_;
   bool lane_change_approved_;
   bool force_lane_change_;
   lanelet::ConstLanelets current_lanes_;
@@ -58,7 +58,7 @@ public:
   void update() override;
   State getNextState() const override;
   State getCurrentState() const override;
-  autoware_planning_msgs::PathWithLaneId getPath() const override;
+  autoware_planning_msgs::msg::PathWithLaneId getPath() const override;
 };
 }  // namespace lane_change_planner
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/forcing_lane_change.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/forcing_lane_change.h
@@ -19,9 +19,9 @@
 
 #include <lane_change_planner/state/state_base_class.h>
 
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/TwistStamped.h>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 
 #include <lanelet2_core/primitives/Lanelet.h>
 
@@ -32,9 +32,9 @@ class ForcingLaneChangeState : public StateBase
 private:
   // State transition conditions
   bool hasFinishedLaneChange() const;
-  geometry_msgs::PoseStamped current_pose_;
-  geometry_msgs::TwistStamped::ConstPtr current_twist_;
-  autoware_perception_msgs::DynamicObjectArray::ConstPtr dynamic_objects_;
+  geometry_msgs::msg::PoseStamped current_pose_;
+  geometry_msgs::msg::TwistStamped::ConstPtr current_twist_;
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr dynamic_objects_;
 
   lanelet::ConstLanelets original_lanes_;
   lanelet::ConstLanelets target_lanes_;
@@ -48,7 +48,7 @@ public:
   void update() override;
   State getNextState() const override;
   State getCurrentState() const override;
-  autoware_planning_msgs::PathWithLaneId getPath() const override;
+  autoware_planning_msgs::msg::PathWithLaneId getPath() const override;
 };
 }  // namespace lane_change_planner
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/forcing_lane_change.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/forcing_lane_change.h
@@ -33,8 +33,8 @@ private:
   // State transition conditions
   bool hasFinishedLaneChange() const;
   geometry_msgs::msg::PoseStamped current_pose_;
-  geometry_msgs::msg::TwistStamped::ConstPtr current_twist_;
-  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr dynamic_objects_;
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr current_twist_;
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr dynamic_objects_;
 
   lanelet::ConstLanelets original_lanes_;
   lanelet::ConstLanelets target_lanes_;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/state_base_class.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/state_base_class.h
@@ -17,8 +17,8 @@
 #ifndef LANE_CHANGE_PLANNER_STATE_STATE_BASE_CLASS_H
 #define LANE_CHANGE_PLANNER_STATE_STATE_BASE_CLASS_H
 
-#include <autoware_planning_msgs/PathWithLaneId.h>
-#include <geometry_msgs/Point.h>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <geometry_msgs/msg/point.hpp>
 #include <lane_change_planner/data_manager.h>
 #include <lane_change_planner/parameters.h>
 #include <lane_change_planner/route_handler.h>
@@ -40,7 +40,7 @@ std::ostream & operator<<(std::ostream & ostream, const State & state);
 
 struct Status
 {
-  autoware_planning_msgs::PathWithLaneId lane_follow_path;
+  autoware_planning_msgs::msg::PathWithLaneId lane_follow_path;
   LaneChangePath lane_change_path;
   std::vector<uint64_t> lane_follow_lane_ids;
   std::vector<uint64_t> lane_change_lane_ids;
@@ -51,9 +51,9 @@ struct Status
 struct DebugData
 {
   std::vector<LaneChangePath> lane_change_candidate_paths;
-  autoware_planning_msgs::PathWithLaneId selected_path;
-  autoware_planning_msgs::PathPointWithLaneId stop_point;
-  geometry_msgs::Point stop_factor_point;
+  autoware_planning_msgs::msg::PathWithLaneId selected_path;
+  autoware_planning_msgs::msg::PathPointWithLaneId stop_point;
+  geometry_msgs::msg::Point stop_factor_point;
 };
 
 class StateBase
@@ -73,7 +73,7 @@ public:
   virtual void update() = 0;
   virtual State getNextState() const = 0;
   virtual State getCurrentState() const = 0;
-  virtual autoware_planning_msgs::PathWithLaneId getPath() const = 0;
+  virtual autoware_planning_msgs::msg::PathWithLaneId getPath() const = 0;
 
   Status getStatus() const;
   DebugData getDebugData() const;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/stopping_lane_change.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/stopping_lane_change.h
@@ -25,8 +25,8 @@ class StoppingLaneChangeState : public StateBase
 {
 private:
   geometry_msgs::msg::PoseStamped current_pose_;
-  geometry_msgs::msg::TwistStamped::ConstPtr current_twist_;
-  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr dynamic_objects_;
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr current_twist_;
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr dynamic_objects_;
 
   lanelet::ConstLanelets original_lanes_;
   lanelet::ConstLanelets target_lanes_;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/stopping_lane_change.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/stopping_lane_change.h
@@ -24,9 +24,9 @@ namespace lane_change_planner
 class StoppingLaneChangeState : public StateBase
 {
 private:
-  geometry_msgs::PoseStamped current_pose_;
-  geometry_msgs::TwistStamped::ConstPtr current_twist_;
-  autoware_perception_msgs::DynamicObjectArray::ConstPtr dynamic_objects_;
+  geometry_msgs::msg::PoseStamped current_pose_;
+  geometry_msgs::msg::TwistStamped::ConstPtr current_twist_;
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr dynamic_objects_;
 
   lanelet::ConstLanelets original_lanes_;
   lanelet::ConstLanelets target_lanes_;
@@ -35,8 +35,8 @@ private:
   bool isVehicleInOriginalLanes() const;
 
   // utility function
-  autoware_planning_msgs::PathWithLaneId setStopPoint(
-    const autoware_planning_msgs::PathWithLaneId & path);
+  autoware_planning_msgs::msg::PathWithLaneId setStopPoint(
+    const autoware_planning_msgs::msg::PathWithLaneId & path);
 
 public:
   StoppingLaneChangeState(
@@ -48,7 +48,7 @@ public:
   void update() override;
   State getNextState() const override;
   State getCurrentState() const override;
-  autoware_planning_msgs::PathWithLaneId getPath() const override;
+  autoware_planning_msgs::msg::PathWithLaneId getPath() const override;
 };
 }  // namespace lane_change_planner
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state_machine.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state_machine.h
@@ -40,7 +40,7 @@ public:
     const std::shared_ptr<DataManager> & data_manager_ptr,
     const std::shared_ptr<RouteHandler> & route_handler_ptr);
   void init();
-  void init(const autoware_planning_msgs::msg::Route & route);
+  void initCallback(const autoware_planning_msgs::msg::Route::ConstSharedPtr route);
   void updateState();
   autoware_planning_msgs::msg::PathWithLaneId getPath() const;
   Status getStatus() const;
@@ -51,7 +51,6 @@ private:
   std::unique_ptr<StateBase> state_obj_ptr_;
   std::shared_ptr<DataManager> data_manager_ptr_;
   std::shared_ptr<RouteHandler> route_handler_ptr_;
-  ros::Publisher path_marker_publisher_;
 };
 }  // namespace lane_change_planner
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state_machine.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state_machine.h
@@ -17,12 +17,12 @@
 #ifndef LANE_CHANGE_PLANNER_STATE_MACHINE_H
 #define LANE_CHANGE_PLANNER_STATE_MACHINE_H
 
-#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
-#include <autoware_planning_msgs/msg/route.hpp>
 #include <lane_change_planner/state/state_base_class.h>
 #include <lanelet2_core/primitives/Lanelet.h>
-#include <rclcpp/rclcpp.hpp>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <autoware_planning_msgs/msg/route.hpp>
 #include <memory>
+#include <rclcpp/rclcpp.hpp>
 
 namespace lane_change_planner
 {

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state_machine.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state_machine.h
@@ -17,11 +17,11 @@
 #ifndef LANE_CHANGE_PLANNER_STATE_MACHINE_H
 #define LANE_CHANGE_PLANNER_STATE_MACHINE_H
 
-#include <autoware_planning_msgs/PathWithLaneId.h>
-#include <autoware_planning_msgs/Route.h>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <autoware_planning_msgs/msg/route.hpp>
 #include <lane_change_planner/state/state_base_class.h>
 #include <lanelet2_core/primitives/Lanelet.h>
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <memory>
 
 namespace lane_change_planner
@@ -40,9 +40,9 @@ public:
     const std::shared_ptr<DataManager> & data_manager_ptr,
     const std::shared_ptr<RouteHandler> & route_handler_ptr);
   void init();
-  void init(const autoware_planning_msgs::Route & route);
+  void init(const autoware_planning_msgs::msg::Route & route);
   void updateState();
-  autoware_planning_msgs::PathWithLaneId getPath() const;
+  autoware_planning_msgs::msg::PathWithLaneId getPath() const;
   Status getStatus() const;
   DebugData getDebugData() const;
   State getState() const;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/utilities.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/utilities.h
@@ -17,15 +17,15 @@
 #ifndef LANE_CHANGE_PLANNER_UTILITIES_H
 #define LANE_CHANGE_PLANNER_UTILITIES_H
 
-#include <geometry_msgs/Point.h>
-#include <geometry_msgs/Pose.h>
-#include <geometry_msgs/PoseArray.h>
-#include <ros/ros.h>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_array.hpp>
+#include <rclcpp/rclcpp.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <autoware_planning_msgs/Path.h>
-#include <autoware_planning_msgs/PathWithLaneId.h>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_planning_msgs/msg/path.hpp>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 
 #include <boost/geometry/geometries/box.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
@@ -57,98 +57,98 @@ struct FrenetCoordinate3d
 };
 
 double normalizeRadian(const double radian);
-double l2Norm(const geometry_msgs::Vector3 vector);
+double l2Norm(const geometry_msgs::msg::Vector3 vector);
 
-Eigen::Vector3d convertToEigenPt(const geometry_msgs::Point geom_pt);
-std::vector<geometry_msgs::Point> convertToGeometryPointArray(
-  const autoware_planning_msgs::PathWithLaneId & path);
-geometry_msgs::PoseArray convertToGeometryPoseArray(
-  const autoware_planning_msgs::PathWithLaneId & path);
+Eigen::Vector3d convertToEigenPt(const geometry_msgs::msg::Point geom_pt);
+std::vector<geometry_msgs::msg::Point> convertToGeometryPointArray(
+  const autoware_planning_msgs::msg::PathWithLaneId & path);
+geometry_msgs::msg::PoseArray convertToGeometryPoseArray(
+  const autoware_planning_msgs::msg::PathWithLaneId & path);
 
-autoware_perception_msgs::PredictedPath convertToPredictedPath(
-  const autoware_planning_msgs::PathWithLaneId & path, const geometry_msgs::Twist & vehicle_twist,
-  const geometry_msgs::Pose & vehicle_pose, const double duration, const double resolution,
+autoware_perception_msgs::msg::PredictedPath convertToPredictedPath(
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const geometry_msgs::msg::Twist & vehicle_twist,
+  const geometry_msgs::msg::Pose & vehicle_pose, const double duration, const double resolution,
   const double acceleration);
-autoware_perception_msgs::PredictedPath resamplePredictedPath(
-  const autoware_perception_msgs::PredictedPath & input_path, const double resolution,
+autoware_perception_msgs::msg::PredictedPath resamplePredictedPath(
+  const autoware_perception_msgs::msg::PredictedPath & input_path, const double resolution,
   const double duration);
 
 bool convertToFrenetCoordinate3d(
-  const std::vector<geometry_msgs::Point> & linestring,
-  const geometry_msgs::Point search_point_geom, FrenetCoordinate3d * frenet_coordinate);
+  const std::vector<geometry_msgs::msg::Point> & linestring,
+  const geometry_msgs::msg::Point search_point_geom, FrenetCoordinate3d * frenet_coordinate);
 
-geometry_msgs::Pose lerpByPose(
-  const geometry_msgs::Pose & p1, const geometry_msgs::Pose & p2, const double t);
+geometry_msgs::msg::Pose lerpByPose(
+  const geometry_msgs::msg::Pose & p1, const geometry_msgs::msg::Pose & p2, const double t);
 
-geometry_msgs::Point lerpByLength(
-  const std::vector<geometry_msgs::Point> & array, const double length);
+geometry_msgs::msg::Point lerpByLength(
+  const std::vector<geometry_msgs::msg::Point> & array, const double length);
 bool lerpByTimeStamp(
-  const autoware_perception_msgs::PredictedPath & path, const ros::Time & t,
-  geometry_msgs::Pose * lerped_pt);
+  const autoware_perception_msgs::msg::PredictedPath & path, const ros::Time & t,
+  geometry_msgs::msg::Pose * lerped_pt);
 
-double getDistance3d(const geometry_msgs::Point & p1, const geometry_msgs::Point & p2);
+double getDistance3d(const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2);
 double getDistanceBetweenPredictedPaths(
-  const autoware_perception_msgs::PredictedPath & path1,
-  const autoware_perception_msgs::PredictedPath & path2, const double start_time,
+  const autoware_perception_msgs::msg::PredictedPath & path1,
+  const autoware_perception_msgs::msg::PredictedPath & path2, const double start_time,
   const double end_time, const double resolution);
 
 std::vector<size_t> filterObjectsByLanelets(
-  const autoware_perception_msgs::DynamicObjectArray & objects,
+  const autoware_perception_msgs::msg::DynamicObjectArray & objects,
   const lanelet::ConstLanelets & lanelets, const double start_arc_length,
   const double end_arc_length);
 
 std::vector<size_t> filterObjectsByLanelets(
-  const autoware_perception_msgs::DynamicObjectArray & objects,
+  const autoware_perception_msgs::msg::DynamicObjectArray & objects,
   const lanelet::ConstLanelets & target_lanelets);
 
 bool calcObjectPolygon(
-  const autoware_perception_msgs::DynamicObject & object, Polygon * object_polygon);
+  const autoware_perception_msgs::msg::DynamicObject & object, Polygon * object_polygon);
 
 std::vector<size_t> filterObjectsByPath(
-  const autoware_perception_msgs::DynamicObjectArray & objects,
+  const autoware_perception_msgs::msg::DynamicObjectArray & objects,
   const std::vector<size_t> & object_indices,
-  const autoware_planning_msgs::PathWithLaneId & ego_path, const double vehicle_width);
+  const autoware_planning_msgs::msg::PathWithLaneId & ego_path, const double vehicle_width);
 
-const geometry_msgs::Pose refineGoal(
-  const geometry_msgs::Pose & goal, const lanelet::ConstLanelet & goal_lanelet);
+const geometry_msgs::msg::Pose refineGoal(
+  const geometry_msgs::msg::Pose & goal, const lanelet::ConstLanelet & goal_lanelet);
 
-autoware_planning_msgs::PathWithLaneId refinePath(
+autoware_planning_msgs::msg::PathWithLaneId refinePath(
   const double search_radius_range, const double search_rad_range,
-  const autoware_planning_msgs::PathWithLaneId & input, const geometry_msgs::Pose & goal,
+  const autoware_planning_msgs::msg::PathWithLaneId & input, const geometry_msgs::msg::Pose & goal,
   const int64_t goal_lane_id);
-autoware_planning_msgs::PathWithLaneId removeOverlappingPoints(
-  const autoware_planning_msgs::PathWithLaneId & input_path);
+autoware_planning_msgs::msg::PathWithLaneId removeOverlappingPoints(
+  const autoware_planning_msgs::msg::PathWithLaneId & input_path);
 
 bool containsGoal(const lanelet::ConstLanelets & lanes, const lanelet::Id & goal_id);
 
-nav_msgs::OccupancyGrid generateDrivableArea(
-  const lanelet::ConstLanelets & lanes, const geometry_msgs::PoseStamped & current_pose,
+nav_msgs::msg::OccupancyGrid generateDrivableArea(
+  const lanelet::ConstLanelets & lanes, const geometry_msgs::msg::PoseStamped & current_pose,
   const double width, const double height, const double resolution, const double vehicle_length,
   const RouteHandler & route_handler);
 
 double getDistanceToEndOfLane(
-  const geometry_msgs::Pose & current_pose, const lanelet::ConstLanelets & lanelets);
+  const geometry_msgs::msg::Pose & current_pose, const lanelet::ConstLanelets & lanelets);
 
 double getDistanceToNextIntersection(
-  const geometry_msgs::Pose & current_pose, const lanelet::ConstLanelets & lanelets);
+  const geometry_msgs::msg::Pose & current_pose, const lanelet::ConstLanelets & lanelets);
 double getDistanceToCrosswalk(
-  const geometry_msgs::Pose & current_pose, const lanelet::ConstLanelets & lanelets,
+  const geometry_msgs::msg::Pose & current_pose, const lanelet::ConstLanelets & lanelets,
   const lanelet::routing::RoutingGraphContainer & overall_graphs);
 double getSignedDistance(
-  const geometry_msgs::Pose & current_pose, const geometry_msgs::Pose & goal_pose,
+  const geometry_msgs::msg::Pose & current_pose, const geometry_msgs::msg::Pose & goal_pose,
   const lanelet::ConstLanelets & lanelets);
 
 std::vector<uint64_t> getIds(const lanelet::ConstLanelets & lanelets);
 
-autoware_planning_msgs::Path convertToPathFromPathWithLaneId(
-  const autoware_planning_msgs::PathWithLaneId & path_with_lane_id);
+autoware_planning_msgs::msg::Path convertToPathFromPathWithLaneId(
+  const autoware_planning_msgs::msg::PathWithLaneId & path_with_lane_id);
 
 lanelet::Polygon3d getVehiclePolygon(
-  const geometry_msgs::Pose & vehicle_pose, const double vehicle_width,
+  const geometry_msgs::msg::Pose & vehicle_pose, const double vehicle_width,
   const double base_link2front);
 
-autoware_planning_msgs::PathPointWithLaneId insertStopPoint(
-  double length, autoware_planning_msgs::PathWithLaneId * path);
+autoware_planning_msgs::msg::PathPointWithLaneId insertStopPoint(
+  double length, autoware_planning_msgs::msg::PathWithLaneId * path);
 
 class SplineInterpolate
 {

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/utilities.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/utilities.h
@@ -83,7 +83,7 @@ geometry_msgs::msg::Pose lerpByPose(
 geometry_msgs::msg::Point lerpByLength(
   const std::vector<geometry_msgs::msg::Point> & array, const double length);
 bool lerpByTimeStamp(
-  const autoware_perception_msgs::msg::PredictedPath & path, const ros::Time & t,
+  const autoware_perception_msgs::msg::PredictedPath & path, const rclcpp::Time & t,
   geometry_msgs::msg::Pose * lerped_pt, const rclcpp::Logger & logger,
   const rclcpp::Clock::SharedPtr & clock);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/package.xml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/package.xml
@@ -8,15 +8,20 @@
 
   <license>TODO</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
-  <depend>roscpp</depend>
+  <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>libopencv-dev</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/data_manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/data_manager.cpp
@@ -81,7 +81,7 @@ LaneChangerParameters DataManager::getLaneChangerParameters() { return parameter
 bool DataManager::getLaneChangeApproval()
 {
   constexpr double timeout = 0.5;
-  if (ros::Time::now() - lane_change_approval_.stamp > ros::Duration(timeout)) {
+  if (clock_->now() - lane_change_approval_.stamp > rclcpp::Duration::from_seconds(timeout)) {
     return false;
   }
 
@@ -91,7 +91,7 @@ bool DataManager::getLaneChangeApproval()
 bool DataManager::getForceLaneChangeSignal()
 {
   constexpr double timeout = 0.5;
-  if (ros::Time::now() - force_lane_change_.stamp > ros::Duration(timeout)) {
+  if (clock_->now() - force_lane_change_.stamp > rclcpp::Duration::from_seconds(timeout)) {
     return false;
   } else {
     return force_lane_change_.data;
@@ -127,7 +127,7 @@ SelfPoseLinstener::SelfPoseLinstener(const rclcpp::Logger & logger, const rclcpp
 
 bool SelfPoseLinstener::isSelfPoseReady()
 {
-  return tf_buffer_.canTransform("map", "base_link", ros::Time(0), ros::Duration(0.1));
+  return tf_buffer_.canTransform("map", "base_link", tf2::TimePointZero);
 }
 
 bool SelfPoseLinstener::getSelfPose(geometry_msgs::msg::PoseStamped & self_pose)
@@ -136,7 +136,7 @@ bool SelfPoseLinstener::getSelfPose(geometry_msgs::msg::PoseStamped & self_pose)
     geometry_msgs::msg::TransformStamped transform;
     std::string map_frame = "map";
     transform =
-      tf_buffer_.lookupTransform(map_frame, "base_link", ros::Time(0), ros::Duration(0.1));
+      tf_buffer_.lookupTransform(map_frame, "base_link", tf2::TimePointZero);
     self_pose.pose.position.x = transform.transform.translation.x;
     self_pose.pose.position.y = transform.transform.translation.y;
     self_pose.pose.position.z = transform.transform.translation.z;
@@ -144,7 +144,7 @@ bool SelfPoseLinstener::getSelfPose(geometry_msgs::msg::PoseStamped & self_pose)
     self_pose.pose.orientation.y = transform.transform.rotation.y;
     self_pose.pose.orientation.z = transform.transform.rotation.z;
     self_pose.pose.orientation.w = transform.transform.rotation.w;
-    self_pose.header.stamp = ros::Time::now();
+    self_pose.header.stamp = clock_->now();
     self_pose.header.frame_id = map_frame;
     return true;
   } catch (tf2::TransformException & ex) {

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/data_manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/data_manager.cpp
@@ -30,28 +30,28 @@ DataManager::DataManager(const rclcpp::Logger & logger, const rclcpp::Clock::Sha
 }
 
 void DataManager::perceptionCallback(
-  const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr & input_perception_msg_ptr)
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr input_perception_msg_ptr)
 {
   perception_ptr_ = input_perception_msg_ptr;
 }
 
 void DataManager::velocityCallback(
-  const geometry_msgs::msg::TwistStamped::ConstPtr & input_twist_msg_ptr)
+  const geometry_msgs::msg::TwistStamped::ConstSharedPtr input_twist_msg_ptr)
 {
   vehicle_velocity_ptr_ = input_twist_msg_ptr;
 }
 
-void DataManager::laneChangeApprovalCallback(const std_msgs::msg::Bool & input_approval_msg)
+void DataManager::laneChangeApprovalCallback(const std_msgs::msg::Bool::ConstSharedPtr input_approval_msg)
 {
-  lane_change_approval_.data = input_approval_msg.data;
-  lane_change_approval_.stamp = ros::Time::now();
+  lane_change_approval_.data = input_approval_msg->data;
+  lane_change_approval_.stamp = clock_->now();
 }
 
 void DataManager::forceLaneChangeSignalCallback(
-  const std_msgs::msg::Bool & input_force_lane_change_msg)
+  const std_msgs::msg::Bool::ConstSharedPtr input_force_lane_change_msg)
 {
-  force_lane_change_.data = input_force_lane_change_msg.data;
-  force_lane_change_.stamp = ros::Time::now();
+  force_lane_change_.data = input_force_lane_change_msg->data;
+  force_lane_change_.stamp = clock_->now();
 }
 
 void DataManager::setLaneChangerParameters(const LaneChangerParameters & parameters)
@@ -60,12 +60,12 @@ void DataManager::setLaneChangerParameters(const LaneChangerParameters & paramet
   parameters_ = parameters;
 }
 
-autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr DataManager::getDynamicObjects()
+autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr DataManager::getDynamicObjects()
 {
   return perception_ptr_;
 }
 
-geometry_msgs::msg::TwistStamped::ConstPtr DataManager::getCurrentSelfVelocity()
+geometry_msgs::msg::TwistStamped::ConstSharedPtr DataManager::getCurrentSelfVelocity()
 {
   return vehicle_velocity_ptr_;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/data_manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/data_manager.cpp
@@ -20,11 +20,11 @@
 namespace lane_change_planner
 {
 DataManager::DataManager(const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr & clock)
-: logger_(logger),
-  clock_(clock),
+: lane_change_approval_(false),
+  force_lane_change_(false),
   is_parameter_set_(false),
-  lane_change_approval_(false),
-  force_lane_change_(false)
+  logger_(logger),
+  clock_(clock)
 {
   self_pose_listener_ptr_ = std::make_shared<SelfPoseLinstener>(logger, clock);
 }
@@ -123,7 +123,7 @@ bool DataManager::isDataReady()
 }
 
 SelfPoseLinstener::SelfPoseLinstener(const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr & clock)
-: logger_(logger), clock_(clock), tf_listener_(tf_buffer_){};
+: tf_listener_(tf_buffer_), logger_(logger), clock_(clock){}
 
 bool SelfPoseLinstener::isSelfPoseReady()
 {

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/data_manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/data_manager.cpp
@@ -26,24 +26,24 @@ DataManager::DataManager()
 }
 
 void DataManager::perceptionCallback(
-  const autoware_perception_msgs::DynamicObjectArray::ConstPtr & input_perception_msg_ptr)
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr & input_perception_msg_ptr)
 {
   perception_ptr_ = input_perception_msg_ptr;
 }
 
 void DataManager::velocityCallback(
-  const geometry_msgs::TwistStamped::ConstPtr & input_twist_msg_ptr)
+  const geometry_msgs::msg::TwistStamped::ConstPtr & input_twist_msg_ptr)
 {
   vehicle_velocity_ptr_ = input_twist_msg_ptr;
 }
 
-void DataManager::laneChangeApprovalCallback(const std_msgs::Bool & input_approval_msg)
+void DataManager::laneChangeApprovalCallback(const std_msgs::msg::Bool & input_approval_msg)
 {
   lane_change_approval_.data = input_approval_msg.data;
   lane_change_approval_.stamp = ros::Time::now();
 }
 
-void DataManager::forceLaneChangeSignalCallback(const std_msgs::Bool & input_force_lane_change_msg)
+void DataManager::forceLaneChangeSignalCallback(const std_msgs::msg::Bool & input_force_lane_change_msg)
 {
   force_lane_change_.data = input_force_lane_change_msg.data;
   force_lane_change_.stamp = ros::Time::now();
@@ -55,17 +55,17 @@ void DataManager::setLaneChangerParameters(const LaneChangerParameters & paramet
   parameters_ = parameters;
 }
 
-autoware_perception_msgs::DynamicObjectArray::ConstPtr DataManager::getDynamicObjects()
+autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr DataManager::getDynamicObjects()
 {
   return perception_ptr_;
 }
 
-geometry_msgs::TwistStamped::ConstPtr DataManager::getCurrentSelfVelocity()
+geometry_msgs::msg::TwistStamped::ConstPtr DataManager::getCurrentSelfVelocity()
 {
   return vehicle_velocity_ptr_;
 }
 
-geometry_msgs::PoseStamped DataManager::getCurrentSelfPose()
+geometry_msgs::msg::PoseStamped DataManager::getCurrentSelfPose()
 {
   self_pose_listener_ptr_->getSelfPose(self_pose_);
   return self_pose_;
@@ -114,10 +114,10 @@ bool SelfPoseLinstener::isSelfPoseReady()
   return tf_buffer_.canTransform("map", "base_link", ros::Time(0), ros::Duration(0.1));
 }
 
-bool SelfPoseLinstener::getSelfPose(geometry_msgs::PoseStamped & self_pose)
+bool SelfPoseLinstener::getSelfPose(geometry_msgs::msg::PoseStamped & self_pose)
 {
   try {
-    geometry_msgs::TransformStamped transform;
+    geometry_msgs::msg::TransformStamped transform;
     std::string map_frame = "map";
     transform =
       tf_buffer_.lookupTransform(map_frame, "base_link", ros::Time(0), ros::Duration(0.1));

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_change_planner_node.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_change_planner_node.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <lane_change_planner/lane_changer.h>
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 int main(int argc, char ** argv)
 {

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_change_planner_node.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_change_planner_node.cpp
@@ -19,11 +19,11 @@
 
 int main(int argc, char ** argv)
 {
-  ros::init(argc, argv, "lane_change_planner_node");
+  rclcpp::init(argc, argv);
 
-  lane_change_planner::LaneChanger lane_changer;
+  rclcpp::spin(std::make_shared<lane_change_planner::LaneChanger>());
 
-  ros::spin();
+  rclcpp::shutdown();
 
   return 0;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_changer.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_changer.cpp
@@ -16,19 +16,19 @@
 
 #include <lane_change_planner/lane_changer.h>
 #include <lane_change_planner/utilities.h>
-#include <visualization_msgs/MarkerArray.h>
+#include <visualization_msgs/msg/marker_array.hpp>
 
-std_msgs::ColorRGBA toRainbow(double ratio);
-visualization_msgs::Marker convertToMarker(
-  const autoware_perception_msgs::PredictedPath & path, const int id, const std::string & ns,
+std_msgs::msg::ColorRGBA toRainbow(double ratio);
+visualization_msgs::msg::Marker convertToMarker(
+  const autoware_perception_msgs::msg::PredictedPath & path, const int id, const std::string & ns,
   const double radius);
 
-visualization_msgs::Marker convertToMarker(
-  const autoware_planning_msgs::PathWithLaneId & path, const int id, const std::string & ns,
-  const std_msgs::ColorRGBA & color);
+visualization_msgs::msg::Marker convertToMarker(
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const int id, const std::string & ns,
+  const std_msgs::msg::ColorRGBA & color);
 
-visualization_msgs::MarkerArray createVirtualWall(
-  const geometry_msgs::Pose & pose, const int id, const std::string & factor_text);
+visualization_msgs::msg::MarkerArray createVirtualWall(
+  const geometry_msgs::msg::Pose & pose, const int id, const std::string & factor_text);
 
 namespace lane_change_planner
 {
@@ -105,17 +105,17 @@ void LaneChanger::init()
 
   // publisher
   path_publisher_ =
-    pnh_.advertise<autoware_planning_msgs::PathWithLaneId>("output/lane_change_path", 1);
+    pnh_.advertise<autoware_planning_msgs::msg::PathWithLaneId>("output/lane_change_path", 1);
   candidate_path_publisher_ =
-    pnh_.advertise<autoware_planning_msgs::Path>("debug/lane_change_candidate_path", 1);
+    pnh_.advertise<autoware_planning_msgs::msg::Path>("debug/lane_change_candidate_path", 1);
   path_marker_publisher_ =
-    pnh_.advertise<visualization_msgs::MarkerArray>("debug/predicted_path_markers", 1);
+    pnh_.advertise<visualization_msgs::msg::MarkerArray>("debug/predicted_path_markers", 1);
   stop_reason_publisher_ =
-    pnh_.advertise<autoware_planning_msgs::StopReasonArray>("output/stop_reasons", 1);
-  drivable_area_publisher_ = pnh_.advertise<nav_msgs::OccupancyGrid>("debug/drivable_area", 1);
-  lane_change_ready_publisher_ = pnh_.advertise<std_msgs::Bool>("output/lane_change_ready", 1);
+    pnh_.advertise<autoware_planning_msgs::msg::StopReasonArray>("output/stop_reasons", 1);
+  drivable_area_publisher_ = pnh_.advertise<nav_msgs::msg::OccupancyGrid>("debug/drivable_area", 1);
+  lane_change_ready_publisher_ = pnh_.advertise<std_msgs::msg::Bool>("output/lane_change_ready", 1);
   lane_change_available_publisher_ =
-    pnh_.advertise<std_msgs::Bool>("output/lane_change_available", 1);
+    pnh_.advertise<std_msgs::msg::Bool>("output/lane_change_available", 1);
 
   waitForData();
 
@@ -151,7 +151,7 @@ void LaneChanger::run(const ros::TimerEvent & event)
   const auto goal = route_handler_ptr_->getGoalPose();
   const auto goal_lane_id = route_handler_ptr_->getGoalLaneId();
 
-  geometry_msgs::Pose refined_goal;
+  geometry_msgs::msg::Pose refined_goal;
   {
     lanelet::ConstLanelet goal_lanelet;
     if (route_handler_ptr_->getGoalLanelet(&goal_lanelet)) {
@@ -174,11 +174,11 @@ void LaneChanger::run(const ros::TimerEvent & event)
 
   // publish lane change status
   const auto lane_change_status = state_machine_ptr_->getStatus();
-  std_msgs::Bool lane_change_ready_msg;
+  std_msgs::msg::Bool lane_change_ready_msg;
   lane_change_ready_msg.data = lane_change_status.lane_change_ready;
   lane_change_ready_publisher_.publish(lane_change_ready_msg);
 
-  std_msgs::Bool lane_change_available_msg;
+  std_msgs::msg::Bool lane_change_available_msg;
   lane_change_available_msg.data = lane_change_status.lane_change_available;
   lane_change_available_publisher_.publish(lane_change_available_msg);
 
@@ -189,7 +189,7 @@ void LaneChanger::run(const ros::TimerEvent & event)
   candidate_path_publisher_.publish(candidate_path);
 }
 
-void LaneChanger::publishDrivableArea(const autoware_planning_msgs::PathWithLaneId & path)
+void LaneChanger::publishDrivableArea(const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   drivable_area_publisher_.publish(path.drivable_area);
 }
@@ -206,8 +206,8 @@ void LaneChanger::publishDebugMarkers()
   const double time_resolution = ros_parameters.prediction_time_resolution;
   const double prediction_duration = ros_parameters.prediction_duration;
 
-  visualization_msgs::MarkerArray debug_markers;
-  autoware_planning_msgs::StopReasonArray stop_reason_array;
+  visualization_msgs::msg::MarkerArray debug_markers;
+  autoware_planning_msgs::msg::StopReasonArray stop_reason_array;
   // get ego vehicle path marker
   const auto & status = state_machine_ptr_->getStatus();
   if (!status.lane_change_path.path.points.empty()) {
@@ -262,7 +262,7 @@ void LaneChanger::publishDebugMarkers()
   // candidate paths
   {
     int i = 0;
-    std_msgs::ColorRGBA color;
+    std_msgs::msg::ColorRGBA color;
     color.r = 1;
     color.g = 1;
     color.b = 1;
@@ -283,7 +283,7 @@ void LaneChanger::publishDebugMarkers()
   {
     if (state_machine_ptr_->getState() == State::BLOCKED_BY_OBSTACLE) {
       // calculate virtual wall pose
-      geometry_msgs::Pose wall_pose;
+      geometry_msgs::msg::Pose wall_pose;
       tf2::Transform tf_map2base_link;
       tf2::fromMsg(debug_data.stop_point.point.pose, tf_map2base_link);
       tf2::Transform tf_base_link2front(
@@ -302,7 +302,7 @@ void LaneChanger::publishDebugMarkers()
   {
     if (state_machine_ptr_->getState() == State::STOPPING_LANE_CHANGE) {
       // calculate virtual wall pose
-      geometry_msgs::Pose wall_pose;
+      geometry_msgs::msg::Pose wall_pose;
       tf2::Transform tf_map2base_link;
       tf2::fromMsg(debug_data.stop_point.point.pose, tf_map2base_link);
       tf2::Transform tf_base_link2front(
@@ -324,26 +324,26 @@ void LaneChanger::publishDebugMarkers()
   stop_reason_publisher_.publish(stop_reason_array);
 }
 
-autoware_planning_msgs::StopReasonArray LaneChanger::makeStopReasonArray(
+autoware_planning_msgs::msg::StopReasonArray LaneChanger::makeStopReasonArray(
   const DebugData & debug_data, const State & state)
 {
   //create header
-  std_msgs::Header header;
+  std_msgs::msg::Header header;
   header.frame_id = "map";
   header.stamp = ros::Time::now();
 
   //create stop reason array
-  autoware_planning_msgs::StopReasonArray stop_reason_array;
+  autoware_planning_msgs::msg::StopReasonArray stop_reason_array;
   stop_reason_array.header = header;
 
   //create stop reason stamped
-  autoware_planning_msgs::StopReason stop_reason_msg;
-  autoware_planning_msgs::StopFactor stop_factor;
+  autoware_planning_msgs::msg::StopReason stop_reason_msg;
+  autoware_planning_msgs::msg::StopFactor stop_factor;
 
   if (state == lane_change_planner::State::BLOCKED_BY_OBSTACLE) {
-    stop_reason_msg.reason = autoware_planning_msgs::StopReason::BLOCKED_BY_OBSTACLE;
+    stop_reason_msg.reason = autoware_planning_msgs::msg::StopReason::BLOCKED_BY_OBSTACLE;
   } else if (state == lane_change_planner::State::STOPPING_LANE_CHANGE) {
-    stop_reason_msg.reason = autoware_planning_msgs::StopReason::STOPPING_LANE_CHANGE;
+    stop_reason_msg.reason = autoware_planning_msgs::msg::StopReason::STOPPING_LANE_CHANGE;
   } else {
     //not stop. return empty reason_point
     stop_reason_array.stop_reasons = makeEmptyStopReasons();
@@ -361,14 +361,14 @@ autoware_planning_msgs::StopReasonArray LaneChanger::makeStopReasonArray(
   return stop_reason_array;
 }
 
-std::vector<autoware_planning_msgs::StopReason> LaneChanger::makeEmptyStopReasons()
+std::vector<autoware_planning_msgs::msg::StopReason> LaneChanger::makeEmptyStopReasons()
 {
-  autoware_planning_msgs::StopReason stop_reason_blocked;
-  stop_reason_blocked.reason = autoware_planning_msgs::StopReason::BLOCKED_BY_OBSTACLE;
-  autoware_planning_msgs::StopReason stop_reason_stopping;
-  stop_reason_stopping.reason = autoware_planning_msgs::StopReason::STOPPING_LANE_CHANGE;
+  autoware_planning_msgs::msg::StopReason stop_reason_blocked;
+  stop_reason_blocked.reason = autoware_planning_msgs::msg::StopReason::BLOCKED_BY_OBSTACLE;
+  autoware_planning_msgs::msg::StopReason stop_reason_stopping;
+  stop_reason_stopping.reason = autoware_planning_msgs::msg::StopReason::STOPPING_LANE_CHANGE;
 
-  std::vector<autoware_planning_msgs::StopReason> stop_reasons;
+  std::vector<autoware_planning_msgs::msg::StopReason> stop_reasons;
   stop_reasons.emplace_back(stop_reason_blocked);
   stop_reasons.emplace_back(stop_reason_stopping);
   return stop_reasons;
@@ -376,7 +376,7 @@ std::vector<autoware_planning_msgs::StopReason> LaneChanger::makeEmptyStopReason
 
 }  // namespace lane_change_planner
 
-std_msgs::ColorRGBA toRainbow(double ratio)
+std_msgs::msg::ColorRGBA toRainbow(double ratio)
 {
   // we want to normalize ratio so that it fits in to 6 regions
   // where each region is 256 units long
@@ -418,7 +418,7 @@ std_msgs::ColorRGBA toRainbow(double ratio)
       blu = 255 - x;
       break;  // magenta
   }
-  std_msgs::ColorRGBA color;
+  std_msgs::msg::ColorRGBA color;
   color.r = static_cast<double>(red) / 255;
   color.g = static_cast<double>(grn) / 255;
   color.b = static_cast<double>(blu) / 255;
@@ -427,17 +427,17 @@ std_msgs::ColorRGBA toRainbow(double ratio)
   return color;
 }
 
-visualization_msgs::Marker convertToMarker(
-  const autoware_perception_msgs::PredictedPath & path, const int id, const std::string & ns,
+visualization_msgs::msg::Marker convertToMarker(
+  const autoware_perception_msgs::msg::PredictedPath & path, const int id, const std::string & ns,
   const double radius)
 {
-  visualization_msgs::Marker marker;
+  visualization_msgs::msg::Marker marker;
   marker.header.frame_id = "map";
   marker.header.stamp = ros::Time::now();
   marker.ns = ns;
   marker.id = id;
-  marker.type = visualization_msgs::Marker::SPHERE_LIST;
-  marker.action = visualization_msgs::Marker::ADD;
+  marker.type = visualization_msgs::msg::Marker::SPHERE_LIST;
+  marker.action = visualization_msgs::msg::Marker::ADD;
 
   marker.pose.position.x = 0.0;
   marker.pose.position.y = 0.0;
@@ -467,17 +467,17 @@ visualization_msgs::Marker convertToMarker(
   return marker;
 }
 
-visualization_msgs::Marker convertToMarker(
-  const autoware_planning_msgs::PathWithLaneId & path, const int id, const std::string & ns,
-  const std_msgs::ColorRGBA & color)
+visualization_msgs::msg::Marker convertToMarker(
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const int id, const std::string & ns,
+  const std_msgs::msg::ColorRGBA & color)
 {
-  visualization_msgs::Marker marker;
+  visualization_msgs::msg::Marker marker;
   marker.header.frame_id = "map";
   marker.header.stamp = ros::Time::now();
   marker.ns = ns;
   marker.id = id;
-  marker.type = visualization_msgs::Marker::LINE_STRIP;
-  marker.action = visualization_msgs::Marker::ADD;
+  marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+  marker.action = visualization_msgs::msg::Marker::ADD;
 
   marker.pose.position.x = 0.0;
   marker.pose.position.y = 0.0;
@@ -501,19 +501,19 @@ visualization_msgs::Marker convertToMarker(
   return marker;
 }
 
-visualization_msgs::MarkerArray createVirtualWall(
-  const geometry_msgs::Pose & pose, const int id, const std::string & factor_text)
+visualization_msgs::msg::MarkerArray createVirtualWall(
+  const geometry_msgs::msg::Pose & pose, const int id, const std::string & factor_text)
 {
-  visualization_msgs::MarkerArray msg;
+  visualization_msgs::msg::MarkerArray msg;
   {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = ros::Time::now();
     marker.ns = "stop_virtual_wall";
     marker.id = id;
     marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::CUBE;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.type = visualization_msgs::msg::Marker::CUBE;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose = pose;
     marker.pose.position.z += 1.0;
     marker.scale.x = 0.1;
@@ -527,14 +527,14 @@ visualization_msgs::MarkerArray createVirtualWall(
   }
   // Factor Text
   {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = ros::Time::now();
     marker.ns = "factor_text";
     marker.id = id;
     marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose = pose;
     marker.pose.position.z += 2.0;
     marker.scale.x = 0.0;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_changer.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_changer.cpp
@@ -51,33 +51,32 @@ void LaneChanger::init()
 
   // ROS parameters
   LaneChangerParameters parameters;
-  pnh_.param("min_stop_distance", parameters.min_stop_distance, 5.0);
-  pnh_.param("stop_time", parameters.stop_time, 2.0);
-  pnh_.param("hysteresis_buffer_distance", parameters.hysteresis_buffer_distance, 2.0);
-  pnh_.param("backward_path_length", parameters.backward_path_length, 5.0);
-  pnh_.param("forward_path_length", parameters.forward_path_length, 100.0);
-  pnh_.param("lane_change_prepare_duration", parameters.lane_change_prepare_duration, 2.0);
-  pnh_.param("lane_changing_duration", parameters.lane_changing_duration, 4.0);
-  pnh_.param("minimum_lane_change_length", parameters.minimum_lane_change_length, 8.0);
-  pnh_.param("prediction_duration", parameters.prediction_duration, 8.0);
-  pnh_.param("prediction_time_resolution", parameters.prediction_time_resolution, 0.5);
-  pnh_.param("drivable_area_resolution", parameters.drivable_area_resolution, 0.1);
-  pnh_.param("drivable_area_width", parameters.drivable_area_width, 100.0);
-  pnh_.param("drivable_area_height", parameters.drivable_area_height, 50.0);
-  pnh_.param("static_obstacle_velocity_thresh", parameters.static_obstacle_velocity_thresh, 0.1);
-  pnh_.param("maximum_deceleration", parameters.maximum_deceleration, 1.0);
-  pnh_.param("lane_change_sampling_num", parameters.lane_change_sampling_num, 10);
-  pnh_.param("enable_abort_lane_change", parameters.enable_abort_lane_change, true);
-  pnh_.param("/vehicle_info/vehicle_width", parameters.vehicle_width, 2.8);
-  pnh_.param("/vehicle_info/vehicle_length", parameters.vehicle_length, 5.0);
-  pnh_.param("/vehicle_info/max_longitudinal_offset", parameters.base_link2front, 3.74);
-  pnh_.param(
-    "abort_lane_change_velocity_thresh", parameters.abort_lane_change_velocity_thresh, 0.5);
-  pnh_.param(
-    "abort_lane_change_angle_thresh", parameters.abort_lane_change_angle_thresh,
-    0.174533);  // 10 deg
-  pnh_.param(
-    "abort_lane_change_distance_thresh", parameters.abort_lane_change_distance_thresh, 0.3);
+  parameters.min_stop_distance = declare_parameter("min_stop_distance", 5.0);
+  parameters.stop_time = declare_parameter("stop_time", 2.0);
+  parameters.hysteresis_buffer_distance = declare_parameter("hysteresis_buffer_distance", 2.0);
+  parameters.backward_path_length = declare_parameter("backward_path_length", 5.0);
+  parameters.forward_path_length = declare_parameter("forward_path_length", 100.0);
+  parameters.lane_change_prepare_duration = declare_parameter("lane_change_prepare_duration", 2.0);
+  parameters.lane_changing_duration = declare_parameter("lane_changing_duration", 4.0);
+  parameters.minimum_lane_change_length = declare_parameter("minimum_lane_change_length", 8.0);
+  parameters.prediction_duration = declare_parameter("prediction_duration", 8.0);
+  parameters.prediction_time_resolution = declare_parameter("prediction_time_resolution", 0.5);
+  parameters.drivable_area_resolution = declare_parameter("drivable_area_resolution", 0.1);
+  parameters.drivable_area_width = declare_parameter("drivable_area_width", 100.0);
+  parameters.drivable_area_height = declare_parameter("drivable_area_height", 50.0);
+  parameters.static_obstacle_velocity_thresh = declare_parameter("static_obstacle_velocity_thresh", 0.1);
+  parameters.maximum_deceleration = declare_parameter("maximum_deceleration", 1.0);
+  parameters.lane_change_sampling_num = declare_parameter("lane_change_sampling_num", 10);
+  parameters.enable_abort_lane_change = declare_parameter("enable_abort_lane_change", true);
+  parameters.vehicle_width = declare_parameter("/vehicle_info/vehicle_width", 2.8);
+  parameters.vehicle_length = declare_parameter("/vehicle_info/vehicle_length", 5.0);
+  parameters.base_link2front = declare_parameter("/vehicle_info/max_longitudinal_offset", 3.74);
+  parameters.abort_lane_change_velocity_thresh = declare_parameter(
+    "abort_lane_change_velocity_thresh", 0.5);
+  parameters.abort_lane_change_angle_thresh = declare_parameter(
+    "abort_lane_change_angle_thresh",     0.174533);  // 10 deg
+  parameters.abort_lane_change_distance_thresh = declare_parameter(
+    "abort_lane_change_distance_thresh", 0.3);
 
   // validation of parameters
   if (parameters.lane_change_sampling_num < 1) {

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_changer.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_changer.cpp
@@ -31,7 +31,7 @@ visualization_msgs::msg::MarkerArray createVirtualWall(
 
 namespace lane_change_planner
 {
-LaneChanger::LaneChanger() : { init(); }
+LaneChanger::LaneChanger() : Node("lane_change_planner_node"){ init(); }
 
 void LaneChanger::init()
 {

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/route_handler.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/route_handler.cpp
@@ -365,7 +365,7 @@ lanelet::ConstLanelets RouteHandler::getLaneletSequenceAfter(
 
   double length = 0;
   lanelet::ConstLanelet current_lanelet = lanelet;
-  while (ros::ok() && length < min_length) {
+  while (rclcpp::ok() && length < min_length) {
     lanelet::ConstLanelet next_lanelet;
     if (!getNextLaneletWithinRoute(current_lanelet, &next_lanelet)) {
       break;
@@ -389,7 +389,7 @@ lanelet::ConstLanelets RouteHandler::getLaneletSequenceUpTo(
   lanelet::ConstLanelet current_lanelet = lanelet;
   double length = 0;
 
-  while (ros::ok() && length < min_length) {
+  while (rclcpp::ok() && length < min_length) {
     lanelet::ConstLanelet prev_lanelet;
     if (!getPreviousLaneletWithinRoute(current_lanelet, &prev_lanelet)) {
       break;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/route_handler.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/route_handler.cpp
@@ -213,11 +213,11 @@ RouteHandler::RouteHandler(const rclcpp::Logger & logger, const rclcpp::Clock::S
 {
 }
 
-void RouteHandler::mapCallback(const autoware_lanelet2_msgs::msg::MapBin & map_msg)
+void RouteHandler::mapCallback(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr map_msg)
 {
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
   lanelet::utils::conversion::fromBinMsg(
-    map_msg, lanelet_map_ptr_, &traffic_rules_ptr_, &routing_graph_ptr_);
+    *map_msg, lanelet_map_ptr_, &traffic_rules_ptr_, &routing_graph_ptr_);
 
   const auto traffic_rules = lanelet::traffic_rules::TrafficRulesFactory::create(
     lanelet::Locations::Germany, lanelet::Participants::Vehicle);
@@ -237,10 +237,10 @@ void RouteHandler::mapCallback(const autoware_lanelet2_msgs::msg::MapBin & map_m
   setRouteLanelets();
 }
 
-void RouteHandler::routeCallback(const autoware_planning_msgs::msg::Route & route_msg)
+void RouteHandler::routeCallback(const autoware_planning_msgs::msg::Route::ConstSharedPtr route_msg)
 {
-  if (!isRouteLooped(route_msg)) {
-    route_msg_ = route_msg;
+  if (!isRouteLooped(*route_msg)) {
+    route_msg_ = *route_msg;
     is_route_msg_ready_ = true;
     is_handler_ready_ = false;
     setRouteLanelets();

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/route_handler.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/route_handler.cpp
@@ -205,8 +205,8 @@ lanelet::ConstPoint3d get3DPointFrom2DArcLength(
 namespace lane_change_planner
 {
 RouteHandler::RouteHandler(const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr & clock)
-: is_route_msg_ready_(false),
-  is_map_msg_ready_(false),
+: is_map_msg_ready_(false),
+  is_route_msg_ready_(false),
   is_handler_ready_(false),
   logger_(logger),
   clock_(clock)
@@ -433,7 +433,7 @@ lanelet::ConstLanelets RouteHandler::getLaneletSequence(
   }
 
   // loop check
-  if (lanelet_sequence_forward.empty() > 1 && lanelet_sequence_backward.empty() > 1) {
+  if (!lanelet_sequence_forward.empty() && !lanelet_sequence_backward.empty()) {
     if (lanelet_sequence_backward.back().id() == lanelet_sequence_forward.front().id()) {
       return lanelet_sequence_forward;
     }
@@ -565,6 +565,7 @@ int RouteHandler::getNumLaneToPreferredLane(const lanelet::ConstLanelet & lanele
       return num;
     }
   }
+  return 0;
 }
 
 bool RouteHandler::isInPreferredLane(const geometry_msgs::msg::PoseStamped & pose) const
@@ -786,7 +787,6 @@ std::vector<LaneChangePath> RouteHandler::getLaneChangePaths(
 
     PathWithLaneId reference_path1;
     {
-      const double lane_length = lanelet::utils::getLaneletLength2d(original_lanelets);
       const auto arc_position = lanelet::utils::getArcCoordinates(original_lanelets, pose);
       const double s_start = arc_position.length - backward_path_length;
       const double s_end = arc_position.length + straight_distance;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/route_handler.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/route_handler.cpp
@@ -17,7 +17,7 @@
 #include <lane_change_planner/route_handler.h>
 #include <lane_change_planner/utilities.h>
 
-#include <autoware_planning_msgs/PathWithLaneId.h>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/primitives/LaneletSequence.h>
@@ -25,14 +25,14 @@
 #include <lanelet2_extension/utility/query.h>
 #include <lanelet2_extension/utility/utilities.h>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <tf2/utils.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <unordered_set>
 
-using autoware_planning_msgs::PathPointWithLaneId;
-using autoware_planning_msgs::PathWithLaneId;
+using autoware_planning_msgs::msg::PathPointWithLaneId;
+using autoware_planning_msgs::msg::PathWithLaneId;
 using lanelet::utils::to2D;
 namespace
 {
@@ -47,7 +47,7 @@ bool exists(const std::vector<T> & vectors, const T & item)
   return false;
 }
 
-bool isRouteLooped(const autoware_planning_msgs::Route & route_msg)
+bool isRouteLooped(const autoware_planning_msgs::msg::Route & route_msg)
 {
   const auto & route_sections = route_msg.route_sections;
   for (std::size_t i = 0; i < route_sections.size(); i++) {
@@ -146,7 +146,7 @@ PathWithLaneId combineReferencePath(
 
       //set yaw
       for (size_t i = 0; i < inner_points.size(); ++i) {
-        geometry_msgs::Point prev, next;
+        geometry_msgs::msg::Point prev, next;
         if (i == 0) {
           prev = path1.points.back().point.pose.position;
         } else {
@@ -208,7 +208,7 @@ RouteHandler::RouteHandler()
 {
 }
 
-void RouteHandler::mapCallback(const autoware_lanelet2_msgs::MapBin & map_msg)
+void RouteHandler::mapCallback(const autoware_lanelet2_msgs::msg::MapBin & map_msg)
 {
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
   lanelet::utils::conversion::fromBinMsg(
@@ -232,7 +232,7 @@ void RouteHandler::mapCallback(const autoware_lanelet2_msgs::MapBin & map_msg)
   setRouteLanelets();
 }
 
-void RouteHandler::routeCallback(const autoware_planning_msgs::Route & route_msg)
+void RouteHandler::routeCallback(const autoware_planning_msgs::msg::Route & route_msg)
 {
   if (!isRouteLooped(route_msg)) {
     route_msg_ = route_msg;
@@ -298,7 +298,7 @@ std::vector<lanelet::ConstLanelet> RouteHandler::getLanesAfterGoal(
 
 lanelet::ConstLanelets RouteHandler::getRouteLanelets() const { return route_lanelets_; }
 
-geometry_msgs::Pose RouteHandler::getGoalPose() const { return route_msg_.goal_pose; }
+geometry_msgs::msg::Pose RouteHandler::getGoalPose() const { return route_msg_.goal_pose; }
 
 lanelet::Id RouteHandler::getGoalLaneId() const
 {
@@ -399,7 +399,7 @@ lanelet::ConstLanelets RouteHandler::getLaneletSequenceUpTo(
 
 lanelet::ConstLanelets RouteHandler::getLaneletSequence(const lanelet::ConstLanelet & lanelet) const
 {
-  geometry_msgs::Pose tmp_pose;
+  geometry_msgs::msg::Pose tmp_pose;
   tmp_pose.orientation.w = 1;
   if (!lanelet.centerline().empty()) {
     tmp_pose.position = lanelet::utils::conversion::toGeomMsgPt(lanelet.centerline().front());
@@ -409,7 +409,7 @@ lanelet::ConstLanelets RouteHandler::getLaneletSequence(const lanelet::ConstLane
 }
 
 lanelet::ConstLanelets RouteHandler::getLaneletSequence(
-  const lanelet::ConstLanelet & lanelet, const geometry_msgs::Pose & current_pose,
+  const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Pose & current_pose,
   const double backward_distance, const double forward_distance) const
 {
   lanelet::ConstLanelets lanelet_sequence;
@@ -442,7 +442,7 @@ lanelet::ConstLanelets RouteHandler::getLaneletSequence(
 }
 
 bool RouteHandler::getClosestLaneletWithinRoute(
-  const geometry_msgs::Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const
+  const geometry_msgs::msg::Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const
 {
   return lanelet::utils::query::getClosestLanelet(route_lanelets_, search_pose, closest_lanelet);
 }
@@ -527,7 +527,7 @@ bool RouteHandler::getLaneChangeTarget(
 }
 
 lanelet::ConstLanelets RouteHandler::getClosestLaneletSequence(
-  const geometry_msgs::Pose & pose) const
+  const geometry_msgs::msg::Pose & pose) const
 {
   lanelet::ConstLanelet lanelet;
   lanelet::ConstLanelets empty_lanelets;
@@ -561,7 +561,7 @@ int RouteHandler::getNumLaneToPreferredLane(const lanelet::ConstLanelet & lanele
   }
 }
 
-bool RouteHandler::isInPreferredLane(const geometry_msgs::PoseStamped & pose) const
+bool RouteHandler::isInPreferredLane(const geometry_msgs::msg::PoseStamped & pose) const
 {
   lanelet::ConstLanelet lanelet;
   if (!getClosestLaneletWithinRoute(pose.pose, &lanelet)) {
@@ -570,7 +570,7 @@ bool RouteHandler::isInPreferredLane(const geometry_msgs::PoseStamped & pose) co
   return exists(preferred_lanelets_, lanelet);
 }
 bool RouteHandler::isInTargetLane(
-  const geometry_msgs::PoseStamped & pose, const lanelet::ConstLanelets & target) const
+  const geometry_msgs::msg::PoseStamped & pose, const lanelet::ConstLanelets & target) const
 {
   lanelet::ConstLanelet lanelet;
   if (!getClosestLaneletWithinRoute(pose.pose, &lanelet)) {
@@ -580,7 +580,7 @@ bool RouteHandler::isInTargetLane(
 }
 
 PathWithLaneId RouteHandler::getReferencePath(
-  const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::Pose & pose,
+  const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose,
   const double backward_path_length, const double forward_path_length,
   const double minimum_lane_change_length) const
 {
@@ -711,7 +711,7 @@ PathWithLaneId RouteHandler::updatePathTwist(const PathWithLaneId & path) const
   return updated_path;
 }
 
-lanelet::ConstLanelets RouteHandler::getLaneChangeTarget(const geometry_msgs::Pose & pose) const
+lanelet::ConstLanelets RouteHandler::getLaneChangeTarget(const geometry_msgs::msg::Pose & pose) const
 {
   lanelet::ConstLanelet lanelet;
   lanelet::ConstLanelets target_lanelets;
@@ -737,7 +737,7 @@ lanelet::ConstLanelets RouteHandler::getLaneChangeTarget(const geometry_msgs::Po
 
 std::vector<LaneChangePath> RouteHandler::getLaneChangePaths(
   const lanelet::ConstLanelets & original_lanelets, const lanelet::ConstLanelets & target_lanelets,
-  const geometry_msgs::Pose & pose, const geometry_msgs::Twist & twist,
+  const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Twist & twist,
   const LaneChangerParameters & parameter) const
 {
   std::vector<LaneChangePath> candidate_paths;
@@ -812,7 +812,7 @@ std::vector<LaneChangePath> RouteHandler::getLaneChangePaths(
 
     // set fixed flag
     for (auto & pt : candidate_path.path.points) {
-      pt.point.type = autoware_planning_msgs::PathPoint::FIXED;
+      pt.point.type = autoware_planning_msgs::msg::PathPoint::FIXED;
     }
     candidate_paths.push_back(candidate_path);
   }
@@ -821,7 +821,7 @@ std::vector<LaneChangePath> RouteHandler::getLaneChangePaths(
 }
 
 double RouteHandler::getLaneChangeableDistance(
-  const geometry_msgs::Pose & current_pose, const LaneChangeDirection & direction)
+  const geometry_msgs::msg::Pose & current_pose, const LaneChangeDirection & direction)
 {
   lanelet::ConstLanelet current_lane;
   if (!getClosestLaneletWithinRoute(current_pose, &current_lane)) {
@@ -870,7 +870,7 @@ double RouteHandler::getLaneChangeableDistance(
 }
 
 lanelet::ConstLanelets RouteHandler::getCheckTargetLanesFromPath(
-  const autoware_planning_msgs::PathWithLaneId & path, const lanelet::ConstLanelets & target_lanes,
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::ConstLanelets & target_lanes,
   const double check_length)
 {
   std::vector<int64_t> target_lane_ids;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/aborting_lane_change.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/aborting_lane_change.cpp
@@ -28,7 +28,7 @@ State AbortingLaneChangeState::getCurrentState() const { return State::ABORTING_
 
 void AbortingLaneChangeState::entry() {}
 
-autoware_planning_msgs::PathWithLaneId AbortingLaneChangeState::getPath() const
+autoware_planning_msgs::msg::PathWithLaneId AbortingLaneChangeState::getPath() const
 {
   return status_.lane_follow_path;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/blocked_by_obstacle.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/blocked_by_obstacle.cpp
@@ -43,7 +43,7 @@ void BlockedByObstacleState::entry()
   current_lanes_ = route_handler_ptr_->getLaneletsFromIds(status_.lane_follow_lane_ids);
 }
 
-autoware_planning_msgs::PathWithLaneId BlockedByObstacleState::getPath() const
+autoware_planning_msgs::msg::PathWithLaneId BlockedByObstacleState::getPath() const
 {
   return status_.lane_follow_path;
 }
@@ -203,8 +203,8 @@ State BlockedByObstacleState::getNextState() const
   return State::BLOCKED_BY_OBSTACLE;
 }
 
-autoware_planning_msgs::PathWithLaneId BlockedByObstacleState::setStopPointFromObstacle(
-  const autoware_planning_msgs::PathWithLaneId & path)
+autoware_planning_msgs::msg::PathWithLaneId BlockedByObstacleState::setStopPointFromObstacle(
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto blocking_objects = getBlockingObstacles();
 
@@ -217,7 +217,7 @@ autoware_planning_msgs::PathWithLaneId BlockedByObstacleState::setStopPointFromO
   }
 
   // find the closest static obstacle in front of ego vehicle
-  autoware_perception_msgs::DynamicObject closest_object;
+  autoware_perception_msgs::msg::DynamicObject closest_object;
   bool found_closest_object = false;
   double closest_distance = std::numeric_limits<double>::max();
   for (const auto & object : blocking_objects) {
@@ -240,7 +240,7 @@ autoware_planning_msgs::PathWithLaneId BlockedByObstacleState::setStopPointFromO
   double stop_insert_length =
     closest_distance - ros_parameters_.minimum_lane_change_length - ros_parameters_.base_link2front;
   stop_insert_length = std::max(stop_insert_length, 0.0);
-  autoware_planning_msgs::PathWithLaneId modified_path = path;
+  autoware_planning_msgs::msg::PathWithLaneId modified_path = path;
   debug_data_.stop_factor_point = closest_object.state.pose_covariance.pose.position;
   debug_data_.stop_point = util::insertStopPoint(stop_insert_length, &modified_path);
   return modified_path;
@@ -267,10 +267,10 @@ bool BlockedByObstacleState::isLaneBlocked() const
   return !blocking_objects.empty();
 }
 
-std::vector<autoware_perception_msgs::DynamicObject> BlockedByObstacleState::getBlockingObstacles()
+std::vector<autoware_perception_msgs::msg::DynamicObject> BlockedByObstacleState::getBlockingObstacles()
   const
 {
-  std::vector<autoware_perception_msgs::DynamicObject> blocking_obstacles;
+  std::vector<autoware_perception_msgs::msg::DynamicObject> blocking_obstacles;
 
   const auto arc = lanelet::utils::getArcCoordinates(current_lanes_, current_pose_.pose);
   constexpr double max_check_distance = 100;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/blocked_by_obstacle.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/blocked_by_obstacle.cpp
@@ -65,7 +65,7 @@ void BlockedByObstacleState::update()
   // update lanes
   {
     if (!route_handler_ptr_->getClosestLaneletWithinRoute(current_pose_.pose, &current_lane)) {
-      ROS_ERROR("failed to find closest lanelet within route!!!");
+      RCLCPP_ERROR(data_manager_ptr_->getLogger(), "failed to find closest lanelet within route!!!");
       return;
     }
     lanelet::ConstLanelet right_lane;
@@ -134,7 +134,7 @@ void BlockedByObstacleState::update()
           lane_change_paths, current_lanes_, check_lanes, route_handler_ptr_->getOverallGraph(),
           dynamic_objects_, current_pose_.pose, current_twist_->twist,
           route_handler_ptr_->isInGoalRouteSection(current_lanes_.back()),
-          route_handler_ptr_->getGoalPose(), ros_parameters_, &selected_path)) {
+          route_handler_ptr_->getGoalPose(), ros_parameters_, &selected_path, data_manager_ptr_->getLogger(), data_manager_ptr_->getClock())) {
       found_safe_path_ = true;
     }
     debug_data_.selected_path = selected_path.path;
@@ -165,7 +165,8 @@ void BlockedByObstacleState::update()
           lane_change_paths, current_lanes_, check_lanes, route_handler_ptr_->getOverallGraph(),
           dynamic_objects_, current_pose_.pose, current_twist_->twist,
           route_handler_ptr_->isInGoalRouteSection(current_lanes_.back()),
-          route_handler_ptr_->getGoalPose(), ros_parameters_, &selected_path)) {
+          route_handler_ptr_->getGoalPose(), ros_parameters_, &selected_path,
+          data_manager_ptr_->getLogger(), data_manager_ptr_->getClock())) {
       found_safe_path_ = true;
     }
 
@@ -250,7 +251,7 @@ bool BlockedByObstacleState::isOutOfCurrentLanes() const
 {
   lanelet::ConstLanelet closest_lane;
   if (!route_handler_ptr_->getClosestLaneletWithinRoute(current_pose_.pose, &closest_lane)) {
-    ROS_ERROR("failed to find closest lanelet within route!!!");
+    RCLCPP_ERROR(data_manager_ptr_->getLogger(), "failed to find closest lanelet within route!!!");
     return true;
   }
   for (const auto & llt : current_lanes_) {
@@ -267,8 +268,8 @@ bool BlockedByObstacleState::isLaneBlocked() const
   return !blocking_objects.empty();
 }
 
-std::vector<autoware_perception_msgs::msg::DynamicObject> BlockedByObstacleState::getBlockingObstacles()
-  const
+std::vector<autoware_perception_msgs::msg::DynamicObject>
+BlockedByObstacleState::getBlockingObstacles() const
 {
   std::vector<autoware_perception_msgs::msg::DynamicObject> blocking_obstacles;
 
@@ -286,9 +287,9 @@ std::vector<autoware_perception_msgs::msg::DynamicObject> BlockedByObstacleState
     current_lanes_, arc.length, arc.length + check_distance);
 
   if (polygon.size() < 3) {
-    ROS_WARN_STREAM(
-      "could not get polygon from lanelet with arc lengths: " << arc.length << " to "
-                                                              << arc.length + check_distance);
+    RCLCPP_WARN_STREAM(
+      data_manager_ptr_->getLogger(), "could not get polygon from lanelet with arc lengths: "
+                                        << arc.length << " to " << arc.length + check_distance);
     return blocking_obstacles;
   }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/blocked_by_obstacle.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/blocked_by_obstacle.cpp
@@ -82,8 +82,6 @@ void BlockedByObstacleState::update()
   }
 
   const double minimum_lane_change_length = ros_parameters_.minimum_lane_change_length;
-  const double lane_change_prepare_duration = ros_parameters_.lane_change_prepare_duration;
-  const double lane_changing_duration = ros_parameters_.lane_changing_duration;
 
   // update lane_follow_path
   {

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/common_functions.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/common_functions.cpp
@@ -27,9 +27,9 @@ bool selectLaneChangePath(
   const std::vector<LaneChangePath> & paths, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
   const lanelet::routing::RoutingGraphContainer & overall_graphs,
-  const autoware_perception_msgs::DynamicObjectArray::ConstPtr & dynamic_objects,
-  const geometry_msgs::Pose & current_pose, const geometry_msgs::Twist & current_twist,
-  const bool isInGoalRouteSection, const geometry_msgs::Pose & goal_pose,
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr & dynamic_objects,
+  const geometry_msgs::msg::Pose & current_pose, const geometry_msgs::msg::Twist & current_twist,
+  const bool isInGoalRouteSection, const geometry_msgs::msg::Pose & goal_pose,
   const LaneChangerParameters & ros_parameters, LaneChangePath * selected_path)
 {
   for (const auto & path : paths) {
@@ -58,8 +58,8 @@ bool selectLaneChangePath(
 
 bool hasEnoughDistance(
   const LaneChangePath & path, const lanelet::ConstLanelets & current_lanes,
-  const lanelet::ConstLanelets & target_lanes, const geometry_msgs::Pose & current_pose,
-  const bool isInGoalRouteSection, const geometry_msgs::Pose & goal_pose,
+  const lanelet::ConstLanelets & target_lanes, const geometry_msgs::msg::Pose & current_pose,
+  const bool isInGoalRouteSection, const geometry_msgs::msg::Pose & goal_pose,
   const lanelet::routing::RoutingGraphContainer & overall_graphs)
 {
   const double lane_change_prepare_distance = path.preparation_length;
@@ -90,10 +90,10 @@ bool hasEnoughDistance(
 }
 
 bool isLaneChangePathSafe(
-  const autoware_planning_msgs::PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
-  const autoware_perception_msgs::DynamicObjectArray::ConstPtr & dynamic_objects,
-  const geometry_msgs::Pose & current_pose, const geometry_msgs::Twist & current_twist,
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr & dynamic_objects,
+  const geometry_msgs::msg::Pose & current_pose, const geometry_msgs::msg::Twist & current_twist,
   const LaneChangerParameters & ros_parameters, const bool use_buffer, const double acceleration)
 {
   if (path.points.empty()) {
@@ -188,10 +188,10 @@ bool isLaneChangePathSafe(
   return true;
 }
 
-bool isObjectFront(const geometry_msgs::Pose & ego_pose, const geometry_msgs::Pose & obj_pose)
+bool isObjectFront(const geometry_msgs::msg::Pose & ego_pose, const geometry_msgs::msg::Pose & obj_pose)
 {
   tf2::Transform tf_map2ego, tf_map2obj;
-  geometry_msgs::Pose obj_from_ego;
+  geometry_msgs::msg::Pose obj_from_ego;
   tf2::fromMsg(ego_pose, tf_map2ego);
   tf2::fromMsg(obj_pose, tf_map2obj);
   tf2::toMsg(tf_map2ego.inverse() * tf_map2obj, obj_from_ego);

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/common_functions.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/common_functions.cpp
@@ -27,7 +27,7 @@ bool selectLaneChangePath(
   const std::vector<LaneChangePath> & paths, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes,
   const lanelet::routing::RoutingGraphContainer & overall_graphs,
-  const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr & dynamic_objects,
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr & dynamic_objects,
   const geometry_msgs::msg::Pose & current_pose, const geometry_msgs::msg::Twist & current_twist,
   const bool isInGoalRouteSection, const geometry_msgs::msg::Pose & goal_pose,
   const LaneChangerParameters & ros_parameters, LaneChangePath * selected_path, const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr & clock)
@@ -92,7 +92,7 @@ bool hasEnoughDistance(
 bool isLaneChangePathSafe(
   const autoware_planning_msgs::msg::PathWithLaneId & path,
   const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & target_lanes,
-  const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr & dynamic_objects,
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr & dynamic_objects,
   const geometry_msgs::msg::Pose & current_pose, const geometry_msgs::msg::Twist & current_twist,
   const LaneChangerParameters & ros_parameters, const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr & clock, const bool use_buffer, const double acceleration)
 {

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/common_functions.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/common_functions.cpp
@@ -110,10 +110,6 @@ bool isLaneChangePathSafe(
 
   // parameters
   const double time_resolution = ros_parameters.prediction_time_resolution;
-  const double prediction_duration = ros_parameters.prediction_duration;
-  const double current_lane_check_start_time = 0.0;
-  const double current_lane_check_end_time =
-    ros_parameters.lane_change_prepare_duration + ros_parameters.lane_changing_duration;
   const double target_lane_check_start_time = 0.0;
   const double target_lane_check_end_time =
     ros_parameters.lane_change_prepare_duration + ros_parameters.lane_changing_duration;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/executing_lane_change.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/executing_lane_change.cpp
@@ -112,8 +112,8 @@ bool ExecutingLaneChangeState::isAbortConditionSatisfied() const
   lanelet::ConstLanelet closest_lanelet;
   if (!lanelet::utils::query::getClosestLanelet(
         original_lanes_, current_pose_.pose, &closest_lanelet)) {
-    ROS_ERROR_THROTTLE(
-      1, "Failed to find closest lane! Lane change aborting function is not working!");
+    RCLCPP_ERROR_THROTTLE(data_manager_ptr_->getLogger(), *data_manager_ptr_->getClock(),
+      1.0, "Failed to find closest lane! Lane change aborting function is not working!");
     return false;
   }
 
@@ -130,7 +130,7 @@ bool ExecutingLaneChangeState::isAbortConditionSatisfied() const
 
     is_path_safe = state_machine::common_functions::isLaneChangePathSafe(
       path.path, original_lanes_, check_lanes, dynamic_objects_, current_pose_.pose,
-      current_twist_->twist, ros_parameters_, false, status_.lane_change_path.acceleration);
+      current_twist_->twist, ros_parameters_, data_manager_ptr_->getLogger(), data_manager_ptr_->getClock(), false, status_.lane_change_path.acceleration);
   }
 
   // check vehicle velocity thresh
@@ -177,8 +177,8 @@ bool ExecutingLaneChangeState::isAbortConditionSatisfied() const
     if (is_distance_small && is_angle_diff_small) {
       return true;
     }
-    ROS_WARN_STREAM_THROTTLE(
-      1, "DANGER!!! Path is not safe anymore, but it is too late to abort! Please be catious");
+    RCLCPP_WARN_STREAM_THROTTLE(data_manager_ptr_->getLogger(), *data_manager_ptr_->getClock(),
+      1.0, "DANGER!!! Path is not safe anymore, but it is too late to abort! Please be catious");
   }
 
   return false;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/executing_lane_change.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/executing_lane_change.cpp
@@ -44,7 +44,7 @@ void ExecutingLaneChangeState::entry()
   status_.lane_change_ready = false;
 }
 
-autoware_planning_msgs::PathWithLaneId ExecutingLaneChangeState::getPath() const
+autoware_planning_msgs::msg::PathWithLaneId ExecutingLaneChangeState::getPath() const
 {
   return status_.lane_change_path.path;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/executing_lane_change.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/executing_lane_change.cpp
@@ -186,12 +186,13 @@ bool ExecutingLaneChangeState::isAbortConditionSatisfied() const
 
 bool ExecutingLaneChangeState::hasFinishedLaneChange() const
 {
-  static ros::Time start_time = ros::Time::now();
+  const auto & clock = data_manager_ptr_->getClock();
+  static rclcpp::Time start_time = clock->now();
 
   if (route_handler_ptr_->isInTargetLane(current_pose_, target_lanes_)) {
-    return (ros::Time::now() - start_time > ros::Duration(2));
+    return (clock->now() - start_time > rclcpp::Duration::from_seconds(2.0));
   } else {
-    start_time = ros::Time::now();
+    start_time = clock->now();
   }
   return false;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/following_lane.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/following_lane.cpp
@@ -81,8 +81,6 @@ void FollowingLaneState::update()
   // update lane_follow_path
   {
     constexpr double check_distance = 100.0;
-    const double lane_change_prepare_duration = ros_parameters_.lane_change_prepare_duration;
-    const double lane_changing_duration = ros_parameters_.lane_changing_duration;
     const double minimum_lane_change_length = ros_parameters_.minimum_lane_change_length;
     status_.lane_follow_path = route_handler_ptr_->getReferencePath(
       current_lanes_, current_pose_.pose, backward_path_length, forward_path_length,

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/following_lane.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/following_lane.cpp
@@ -42,7 +42,7 @@ void FollowingLaneState::entry()
   status_.lane_change_ready = false;
 }
 
-autoware_planning_msgs::PathWithLaneId FollowingLaneState::getPath() const
+autoware_planning_msgs::msg::PathWithLaneId FollowingLaneState::getPath() const
 {
   return status_.lane_follow_path;
 }
@@ -188,10 +188,10 @@ bool FollowingLaneState::isLaneBlocked(const lanelet::ConstLanelets & lanes) con
 
   for (const auto & obj : dynamic_objects_->objects) {
     if (
-      obj.semantic.type == autoware_perception_msgs::Semantic::CAR ||
-      obj.semantic.type == autoware_perception_msgs::Semantic::TRUCK ||
-      obj.semantic.type == autoware_perception_msgs::Semantic::BUS ||
-      obj.semantic.type == autoware_perception_msgs::Semantic::MOTORBIKE) {
+      obj.semantic.type == autoware_perception_msgs::msg::Semantic::CAR ||
+      obj.semantic.type == autoware_perception_msgs::msg::Semantic::TRUCK ||
+      obj.semantic.type == autoware_perception_msgs::msg::Semantic::BUS ||
+      obj.semantic.type == autoware_perception_msgs::msg::Semantic::MOTORBIKE) {
       const auto velocity = util::l2Norm(obj.state.twist_covariance.twist.linear);
       if (velocity < static_obj_velocity_thresh) {
         const auto position =

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/following_lane.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/following_lane.cpp
@@ -64,7 +64,7 @@ void FollowingLaneState::update()
   // update lanes
   {
     if (!route_handler_ptr_->getClosestLaneletWithinRoute(current_pose_.pose, &current_lane)) {
-      ROS_ERROR("failed to find closest lanelet within route!!!");
+      RCLCPP_ERROR(data_manager_ptr_->getLogger(), "failed to find closest lanelet within route!!!");
       return;
     }
     current_lanes_ = route_handler_ptr_->getLaneletSequence(
@@ -112,7 +112,7 @@ void FollowingLaneState::update()
             lane_change_paths, current_lanes_, check_lanes, route_handler_ptr_->getOverallGraph(),
             dynamic_objects_, current_pose_.pose, current_twist_->twist,
             route_handler_ptr_->isInGoalRouteSection(current_lanes_.back()),
-            route_handler_ptr_->getGoalPose(), ros_parameters_, &selected_path)) {
+            route_handler_ptr_->getGoalPose(), ros_parameters_, &selected_path, data_manager_ptr_->getLogger(), data_manager_ptr_->getClock())) {
         found_safe_path = true;
       }
       debug_data_.selected_path = selected_path.path;
@@ -149,7 +149,7 @@ void FollowingLaneState::update()
 State FollowingLaneState::getNextState() const
 {
   if (current_lanes_.empty()) {
-    ROS_ERROR_THROTTLE(1, "current lanes empty. Keeping state.");
+    RCLCPP_ERROR_THROTTLE(data_manager_ptr_->getLogger(), *data_manager_ptr_->getClock(), 1.0, "current lanes empty. Keeping state.");
     return State::FOLLOWING_LANE;
   }
   if (route_handler_ptr_->isInPreferredLane(current_pose_) && isLaneBlocked(current_lanes_)) {
@@ -180,7 +180,7 @@ bool FollowingLaneState::isLaneBlocked(const lanelet::ConstLanelets & lanes) con
     lanelet::utils::getPolygonFromArcLength(lanes, arc.length, arc.length + check_distance);
 
   if (polygon.size() < 3) {
-    ROS_WARN_STREAM(
+    RCLCPP_WARN_STREAM(data_manager_ptr_->getLogger(), 
       "could not get polygon from lanelet with arc lengths: " << arc.length << " to "
                                                               << arc.length + check_distance);
     return false;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/forcing_lane_change.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/forcing_lane_change.cpp
@@ -37,7 +37,7 @@ void ForcingLaneChangeState::entry()
   target_lanes_ = route_handler_ptr_->getLaneletsFromIds(status_.lane_change_lane_ids);
 }
 
-autoware_planning_msgs::PathWithLaneId ForcingLaneChangeState::getPath() const
+autoware_planning_msgs::msg::PathWithLaneId ForcingLaneChangeState::getPath() const
 {
   return status_.lane_change_path.path;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/forcing_lane_change.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/forcing_lane_change.cpp
@@ -71,12 +71,13 @@ State ForcingLaneChangeState::getNextState() const
 
 bool ForcingLaneChangeState::hasFinishedLaneChange() const
 {
-  static ros::Time start_time = ros::Time::now();
+  const auto & clock = data_manager_ptr_->getClock();
+  static rclcpp::Time start_time = clock->now();
 
   if (route_handler_ptr_->isInTargetLane(current_pose_, target_lanes_)) {
-    return (ros::Time::now() - start_time > ros::Duration(2));
+    return (clock->now() - start_time > rclcpp::Duration::from_seconds(2.0));
   } else {
-    start_time = ros::Time::now();
+    start_time = clock->now();
   }
   return false;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/state_base_class.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/state_base_class.cpp
@@ -52,7 +52,7 @@ std::ostream & operator<<(std::ostream & ostream, const State & state)
 StateBase::StateBase(
   const Status & status, const std::shared_ptr<DataManager> & data_manager_ptr,
   const std::shared_ptr<RouteHandler> & route_handler_ptr)
-: data_manager_ptr_(data_manager_ptr), route_handler_ptr_(route_handler_ptr), status_(status)
+: status_(status), data_manager_ptr_(data_manager_ptr), route_handler_ptr_(route_handler_ptr)
 {
 }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/stopping_lane_change.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/stopping_lane_change.cpp
@@ -77,8 +77,8 @@ bool StoppingLaneChangeState::isSafe() const
 
     is_path_safe = state_machine::common_functions::isLaneChangePathSafe(
       status_.lane_change_path.path, original_lanes_, check_lanes, dynamic_objects_,
-      current_pose_.pose, current_twist_->twist, ros_parameters_, false,
-      status_.lane_change_path.acceleration);
+      current_pose_.pose, current_twist_->twist, ros_parameters_, data_manager_ptr_->getLogger(),
+      data_manager_ptr_->getClock(), false, status_.lane_change_path.acceleration);
   }
   return is_path_safe;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/stopping_lane_change.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/stopping_lane_change.cpp
@@ -41,7 +41,7 @@ void StoppingLaneChangeState::entry()
   status_.lane_change_ready = false;
 }
 
-autoware_planning_msgs::PathWithLaneId StoppingLaneChangeState::getPath() const
+autoware_planning_msgs::msg::PathWithLaneId StoppingLaneChangeState::getPath() const
 {
   return status_.lane_change_path.path;
 }
@@ -102,10 +102,10 @@ bool StoppingLaneChangeState::isVehicleInOriginalLanes() const
   return intersection_area / vehicle_area > 0.9;
 }
 
-autoware_planning_msgs::PathWithLaneId StoppingLaneChangeState::setStopPoint(
-  const autoware_planning_msgs::PathWithLaneId & path)
+autoware_planning_msgs::msg::PathWithLaneId StoppingLaneChangeState::setStopPoint(
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
-  autoware_planning_msgs::PathWithLaneId modified_path = path;
+  autoware_planning_msgs::msg::PathWithLaneId modified_path = path;
   debug_data_.stop_point = util::insertStopPoint(0.1, &modified_path);
   return modified_path;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state_machine.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state_machine.cpp
@@ -42,7 +42,7 @@ void StateMachine::init()
   state_obj_ptr_->entry();
 }
 
-void StateMachine::init(const autoware_planning_msgs::msg::Route & route) { init(); }
+void StateMachine::initCallback(const autoware_planning_msgs::msg::Route::ConstSharedPtr route) { init(); }
 
 void StateMachine::updateState()
 {

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state_machine.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state_machine.cpp
@@ -53,7 +53,7 @@ void StateMachine::updateState()
 
   // Transit to next state
   if (next_state != current_state) {
-    ROS_INFO_STREAM("changing state: " << current_state << " => " << next_state);
+    RCLCPP_INFO_STREAM(data_manager_ptr_->getLogger(), "changing state: " << current_state << " => " << next_state);
     const auto previous_status = state_obj_ptr_->getStatus();
     switch (next_state) {
       case State::FOLLOWING_LANE:

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state_machine.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state_machine.cpp
@@ -80,6 +80,8 @@ void StateMachine::updateState()
         state_obj_ptr_ = std::make_unique<BlockedByObstacleState>(
           previous_status, data_manager_ptr_, route_handler_ptr_);
         break;
+      default:
+        break;
     }
     state_obj_ptr_->entry();
     state_obj_ptr_->update();

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state_machine.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state_machine.cpp
@@ -21,9 +21,9 @@
 #include <lane_change_planner/state/forcing_lane_change.h>
 #include <lane_change_planner/state/stopping_lane_change.h>
 #include <lane_change_planner/state_machine.h>
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include <visualization_msgs/Marker.h>
+#include <visualization_msgs/msg/marker.hpp>
 
 namespace lane_change_planner
 {
@@ -42,7 +42,7 @@ void StateMachine::init()
   state_obj_ptr_->entry();
 }
 
-void StateMachine::init(const autoware_planning_msgs::Route & route) { init(); }
+void StateMachine::init(const autoware_planning_msgs::msg::Route & route) { init(); }
 
 void StateMachine::updateState()
 {
@@ -86,7 +86,7 @@ void StateMachine::updateState()
   }
 }
 
-autoware_planning_msgs::PathWithLaneId StateMachine::getPath() const
+autoware_planning_msgs::msg::PathWithLaneId StateMachine::getPath() const
 {
   return state_obj_ptr_->getPath();
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/utilities.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/utilities.cpp
@@ -49,7 +49,7 @@ ros::Time safeAddition(const ros::Time & t1, const double seconds)
 }
 
 cv::Point toCVPoint(
-  const geometry_msgs::Point & geom_point, const double width_m, const double height_m,
+  const geometry_msgs::msg::Point & geom_point, const double width_m, const double height_m,
   const double resolution)
 {
   return cv::Point(
@@ -57,7 +57,7 @@ cv::Point toCVPoint(
     static_cast<int>((width_m - geom_point.x) / resolution));
 }
 
-void imageToOccupancyGrid(const cv::Mat & cv_image, nav_msgs::OccupancyGrid * occupancy_grid)
+void imageToOccupancyGrid(const cv::Mat & cv_image, nav_msgs::msg::OccupancyGrid * occupancy_grid)
 {
   occupancy_grid->data.reserve(cv_image.rows * cv_image.cols);
   for (int x = cv_image.cols - 1; x >= 0; x--) {
@@ -74,8 +74,8 @@ namespace lane_change_planner
 {
 namespace util
 {
-using autoware_perception_msgs::PredictedPath;
-using autoware_planning_msgs::PathWithLaneId;
+using autoware_perception_msgs::msg::PredictedPath;
+using autoware_planning_msgs::msg::PathWithLaneId;
 
 double normalizeRadian(const double radian)
 {
@@ -89,20 +89,20 @@ double normalizeRadian(const double radian)
   return normalized;
 }
 
-double l2Norm(const geometry_msgs::Vector3 vector)
+double l2Norm(const geometry_msgs::msg::Vector3 vector)
 {
   return std::sqrt(std::pow(vector.x, 2) + std::pow(vector.y, 2) + std::pow(vector.z, 2));
 }
 
-Eigen::Vector3d convertToEigenPt(const geometry_msgs::Point geom_pt)
+Eigen::Vector3d convertToEigenPt(const geometry_msgs::msg::Point geom_pt)
 {
   return Eigen::Vector3d(geom_pt.x, geom_pt.y, geom_pt.z);
 }
 
 // returns false when search point is off the linestring
 bool convertToFrenetCoordinate3d(
-  const std::vector<geometry_msgs::Point> & linestring,
-  const geometry_msgs::Point search_point_geom, FrenetCoordinate3d * frenet_coordinate)
+  const std::vector<geometry_msgs::msg::Point> & linestring,
+  const geometry_msgs::msg::Point search_point_geom, FrenetCoordinate3d * frenet_coordinate)
 {
   if (linestring.empty()) {
     return false;
@@ -169,9 +169,9 @@ bool convertToFrenetCoordinate3d(
   return found;
 }
 
-std::vector<geometry_msgs::Point> convertToGeometryPointArray(const PathWithLaneId & path)
+std::vector<geometry_msgs::msg::Point> convertToGeometryPointArray(const PathWithLaneId & path)
 {
-  std::vector<geometry_msgs::Point> converted_path;
+  std::vector<geometry_msgs::msg::Point> converted_path;
   converted_path.reserve(path.points.size());
   for (const auto & point_with_id : path.points) {
     converted_path.push_back(point_with_id.point.pose.position);
@@ -179,9 +179,9 @@ std::vector<geometry_msgs::Point> convertToGeometryPointArray(const PathWithLane
   return converted_path;
 }
 
-std::vector<geometry_msgs::Point> convertToGeometryPointArray(const PredictedPath & path)
+std::vector<geometry_msgs::msg::Point> convertToGeometryPointArray(const PredictedPath & path)
 {
-  std::vector<geometry_msgs::Point> converted_path;
+  std::vector<geometry_msgs::msg::Point> converted_path;
 
   converted_path.reserve(path.path.size());
   for (const auto & pose_with_cov_stamped : path.path) {
@@ -190,9 +190,9 @@ std::vector<geometry_msgs::Point> convertToGeometryPointArray(const PredictedPat
   return converted_path;
 }
 
-geometry_msgs::PoseArray convertToGeometryPoseArray(const PathWithLaneId & path)
+geometry_msgs::msg::PoseArray convertToGeometryPoseArray(const PathWithLaneId & path)
 {
-  geometry_msgs::PoseArray converted_array;
+  geometry_msgs::msg::PoseArray converted_array;
   converted_array.header = path.header;
 
   converted_array.poses.reserve(path.points.size());
@@ -203,8 +203,8 @@ geometry_msgs::PoseArray convertToGeometryPoseArray(const PathWithLaneId & path)
 }
 
 PredictedPath convertToPredictedPath(
-  const PathWithLaneId & path, const geometry_msgs::Twist & vehicle_twist,
-  const geometry_msgs::Pose & vehicle_pose, const double duration, const double resolution,
+  const PathWithLaneId & path, const geometry_msgs::msg::Twist & vehicle_twist,
+  const geometry_msgs::msg::Pose & vehicle_pose, const double duration, const double resolution,
   const double acceleration)
 {
   PredictedPath predicted_path;
@@ -231,7 +231,7 @@ PredictedPath convertToPredictedPath(
 
   // first point
   const auto pt = lerpByLength(geometry_points, vehicle_pose_frenet.length);
-  geometry_msgs::PoseWithCovarianceStamped predicted_pose;
+  geometry_msgs::msg::PoseWithCovarianceStamped predicted_pose;
   predicted_pose.header.stamp = start_time;
   predicted_pose.pose.pose.position = pt;
   predicted_path.path.push_back(predicted_pose);
@@ -248,7 +248,7 @@ PredictedPath convertToPredictedPath(
 
     length += travel_distance;
     const auto pt = lerpByLength(geometry_points, vehicle_pose_frenet.length + length);
-    geometry_msgs::PoseWithCovarianceStamped predicted_pose;
+    geometry_msgs::msg::PoseWithCovarianceStamped predicted_pose;
     predicted_pose.header.stamp = safeAddition(start_time, t);
     predicted_pose.pose.pose.position = pt;
     predicted_path.path.push_back(predicted_pose);
@@ -270,11 +270,11 @@ PredictedPath resamplePredictedPath(
   ros::Time end_time = ros::Time::now() + prediction_duration;
 
   for (auto t = start_time; t < end_time; t += t_delta) {
-    geometry_msgs::Pose pose;
+    geometry_msgs::msg::Pose pose;
     if (!lerpByTimeStamp(input_path, t, &pose)) {
       continue;
     }
-    geometry_msgs::PoseWithCovarianceStamped predicted_pose;
+    geometry_msgs::msg::PoseWithCovarianceStamped predicted_pose;
     predicted_pose.header.frame_id = "map";
     predicted_pose.header.stamp = t;
     predicted_pose.pose.pose = pose;
@@ -284,8 +284,8 @@ PredictedPath resamplePredictedPath(
   return resampled_path;
 }
 
-geometry_msgs::Pose lerpByPose(
-  const geometry_msgs::Pose & p1, const geometry_msgs::Pose & p2, const double t)
+geometry_msgs::msg::Pose lerpByPose(
+  const geometry_msgs::msg::Pose & p1, const geometry_msgs::msg::Pose & p2, const double t)
 {
   tf2::Transform tf_transform1, tf_transform2;
   tf2::fromMsg(p1, tf_transform1);
@@ -294,14 +294,14 @@ geometry_msgs::Pose lerpByPose(
   const auto & tf_quaternion =
     tf2::slerp(tf_transform1.getRotation(), tf_transform2.getRotation(), t);
 
-  geometry_msgs::Pose pose;
+  geometry_msgs::msg::Pose pose;
   pose.position = tf2::toMsg(tf_point, pose.position);
   pose.orientation = tf2::toMsg(tf_quaternion);
   return pose;
 }
 
-geometry_msgs::Point lerpByPoint(
-  const geometry_msgs::Point & p1, const geometry_msgs::Point & p2, const double t)
+geometry_msgs::msg::Point lerpByPoint(
+  const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2, const double t)
 {
   tf2::Vector3 v1, v2;
   v1.setValue(p1.x, p1.y, p1.z);
@@ -309,21 +309,21 @@ geometry_msgs::Point lerpByPoint(
 
   const auto lerped_point = v1.lerp(v2, t);
 
-  geometry_msgs::Point point;
+  geometry_msgs::msg::Point point;
   point.x = lerped_point.x();
   point.y = lerped_point.y();
   point.z = lerped_point.z();
   return point;
 }
 
-geometry_msgs::Point lerpByLength(
-  const std::vector<geometry_msgs::Point> & point_array, const double length)
+geometry_msgs::msg::Point lerpByLength(
+  const std::vector<geometry_msgs::msg::Point> & point_array, const double length)
 {
-  geometry_msgs::Point lerped_point;
+  geometry_msgs::msg::Point lerped_point;
   if (point_array.empty()) {
     return lerped_point;
   }
-  geometry_msgs::Point prev_pt = point_array.front();
+  geometry_msgs::msg::Point prev_pt = point_array.front();
   double accumulated_length = 0;
   for (const auto & pt : point_array) {
     const double distance = getDistance3d(prev_pt, pt);
@@ -338,7 +338,7 @@ geometry_msgs::Point lerpByLength(
 }
 
 bool lerpByTimeStamp(
-  const PredictedPath & path, const ros::Time & t, geometry_msgs::Pose * lerped_pt)
+  const PredictedPath & path, const ros::Time & t, geometry_msgs::msg::Pose * lerped_pt)
 {
   if (lerped_pt == nullptr) {
     ROS_WARN_STREAM_THROTTLE(1, "failed to lerp by time due to nullptr pt");
@@ -387,7 +387,7 @@ bool lerpByTimeStamp(
   return false;
 }
 
-double getDistance3d(const geometry_msgs::Point & p1, const geometry_msgs::Point & p2)
+double getDistance3d(const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2)
 {
   return std::sqrt(std::pow(p1.x - p2.x, 2) + std::pow(p1.y - p2.y, 2) + std::pow(p1.z - p2.z, 2));
 }
@@ -402,7 +402,7 @@ double getDistanceBetweenPredictedPaths(
   ros::Time ros_end_time = ros::Time::now() + ros::Duration(end_time);
   const auto ego_path_point_array = convertToGeometryPointArray(ego_path);
   for (auto t = ros_start_time; t < ros_end_time; t += t_delta) {
-    geometry_msgs::Pose object_pose, ego_pose;
+    geometry_msgs::msg::Pose object_pose, ego_pose;
     if (!lerpByTimeStamp(object_path, t, &object_pose)) {
       continue;
     }
@@ -419,7 +419,7 @@ double getDistanceBetweenPredictedPaths(
 
 // only works with consecutive lanes
 std::vector<size_t> filterObjectsByLanelets(
-  const autoware_perception_msgs::DynamicObjectArray & objects,
+  const autoware_perception_msgs::msg::DynamicObjectArray & objects,
   const lanelet::ConstLanelets & target_lanelets, const double start_arc_length,
   const double end_arc_length)
 {
@@ -461,7 +461,7 @@ std::vector<size_t> filterObjectsByLanelets(
 
 // works with random lanelets
 std::vector<size_t> filterObjectsByLanelets(
-  const autoware_perception_msgs::DynamicObjectArray & objects,
+  const autoware_perception_msgs::msg::DynamicObjectArray & objects,
   const lanelet::ConstLanelets & target_lanelets)
 {
   std::vector<size_t> indices;
@@ -500,11 +500,11 @@ std::vector<size_t> filterObjectsByLanelets(
 }
 
 bool calcObjectPolygon(
-  const autoware_perception_msgs::DynamicObject & object, Polygon * object_polygon)
+  const autoware_perception_msgs::msg::DynamicObject & object, Polygon * object_polygon)
 {
   const double obj_x = object.state.pose_covariance.pose.position.x;
   const double obj_y = object.state.pose_covariance.pose.position.y;
-  if (object.shape.type == autoware_perception_msgs::Shape::BOUNDING_BOX) {
+  if (object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     const double len_x = object.shape.dimensions.x;
     const double len_y = object.shape.dimensions.y;
 
@@ -547,14 +547,14 @@ bool calcObjectPolygon(
     object_polygon->outer().push_back(Point(p3_obj.x(), p3_obj.y()));
     object_polygon->outer().push_back(Point(p4_obj.x(), p4_obj.y()));
 
-  } else if (object.shape.type == autoware_perception_msgs::Shape::CYLINDER) {
+  } else if (object.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
     const size_t N = 20;
     const double r = object.shape.dimensions.x / 2;
     for (size_t i = 0; i < N; ++i) {
       object_polygon->outer().push_back(
         Point(obj_x + r * std::cos(2.0 * M_PI / N * i), obj_y + r * std::sin(2.0 * M_PI / N * i)));
     }
-  } else if (object.shape.type == autoware_perception_msgs::Shape::POLYGON) {
+  } else if (object.shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
     const auto obj_points = object.shape.footprint.points;
     for (const auto & obj_point : obj_points) {
       object_polygon->outer().push_back(Point(obj_point.x, obj_point.y));
@@ -569,9 +569,9 @@ bool calcObjectPolygon(
 }
 
 std::vector<size_t> filterObjectsByPath(
-  const autoware_perception_msgs::DynamicObjectArray & objects,
+  const autoware_perception_msgs::msg::DynamicObjectArray & objects,
   const std::vector<size_t> & object_indices,
-  const autoware_planning_msgs::PathWithLaneId & ego_path, const double vehicle_width)
+  const autoware_planning_msgs::msg::PathWithLaneId & ego_path, const double vehicle_width)
 {
   std::vector<size_t> indices;
   const auto ego_path_point_array = convertToGeometryPointArray(ego_path);
@@ -621,7 +621,7 @@ bool exists(std::vector<T> vec, T element)
 
 bool setGoal(
   const double search_radius_range, const double search_rad_range, const PathWithLaneId & input,
-  const geometry_msgs::Pose & goal, const int64_t goal_lane_id, PathWithLaneId * output_ptr)
+  const geometry_msgs::msg::Pose & goal, const int64_t goal_lane_id, PathWithLaneId * output_ptr)
 {
   try {
     if (input.points.empty()) {
@@ -667,13 +667,13 @@ bool setGoal(
         }
       }
     }
-    autoware_planning_msgs::PathPointWithLaneId refined_goal;
+    autoware_planning_msgs::msg::PathPointWithLaneId refined_goal;
     refined_goal.point.pose = goal;
     refined_goal.point.pose.position.z = goal_z;
     refined_goal.point.twist.linear.x = 0.0;
     refined_goal.lane_ids = input.points.back().lane_ids;
 
-    autoware_planning_msgs::PathPointWithLaneId pre_refined_goal;
+    autoware_planning_msgs::msg::PathPointWithLaneId pre_refined_goal;
     double roll, pitch, yaw;
     pre_refined_goal.point.pose = goal;
     tf2::Quaternion tf2_quaternion(
@@ -701,8 +701,8 @@ bool setGoal(
   }
 }
 
-const geometry_msgs::Pose refineGoal(
-  const geometry_msgs::Pose & goal, const lanelet::ConstLanelet & goal_lanelet)
+const geometry_msgs::msg::Pose refineGoal(
+  const geometry_msgs::msg::Pose & goal, const lanelet::ConstLanelet & goal_lanelet)
 {
   // return goal;
   const auto lanelet_point = lanelet::utils::conversion::toLaneletPoint(goal.position);
@@ -718,7 +718,7 @@ const geometry_msgs::Pose refineGoal(
     return goal;
   }
 
-  geometry_msgs::Pose refined_goal;
+  geometry_msgs::msg::Pose refined_goal;
   {
     // find position
     const auto p1 = segment.front().basicPoint();
@@ -743,7 +743,7 @@ const geometry_msgs::Pose refineGoal(
 
 PathWithLaneId refinePath(
   const double search_radius_range, const double search_rad_range, const PathWithLaneId & input,
-  const geometry_msgs::Pose & goal, const int64_t goal_lane_id)
+  const geometry_msgs::msg::Pose & goal, const int64_t goal_lane_id)
 {
   PathWithLaneId filtered_path, path_with_goal;
   filtered_path = removeOverlappingPoints(input);
@@ -773,8 +773,8 @@ bool containsGoal(const lanelet::ConstLanelets & lanes, const lanelet::Id & goal
 }
 
 // input lanes must be in sequence
-nav_msgs::OccupancyGrid generateDrivableArea(
-  const lanelet::ConstLanelets & lanes, const geometry_msgs::PoseStamped & current_pose,
+nav_msgs::msg::OccupancyGrid generateDrivableArea(
+  const lanelet::ConstLanelets & lanes, const geometry_msgs::msg::PoseStamped & current_pose,
   const double width, const double height, const double resolution, const double vehicle_length,
   const RouteHandler & route_handler)
 {
@@ -785,8 +785,8 @@ nav_msgs::OccupancyGrid generateDrivableArea(
     drivable_lanes.insert(drivable_lanes.end(), lanes_after_goal.begin(), lanes_after_goal.end());
   }
 
-  nav_msgs::OccupancyGrid occupancy_grid;
-  geometry_msgs::PoseStamped grid_origin;
+  nav_msgs::msg::OccupancyGrid occupancy_grid;
+  geometry_msgs::msg::PoseStamped grid_origin;
 
   // calculate grid origin
   {
@@ -855,8 +855,8 @@ nav_msgs::OccupancyGrid generateDrivableArea(
         occupancy_grid.info.width, occupancy_grid.info.height, CV_8UC1, cv::Scalar(occupied_space));
       std::vector<cv::Point> cv_polygon;
       for (const auto & llt_pt : lane.polygon3d()) {
-        geometry_msgs::Point geom_pt = lanelet::utils::conversion::toGeomMsgPt(llt_pt);
-        geometry_msgs::Point transformed_geom_pt;
+        geometry_msgs::msg::Point geom_pt = lanelet::utils::conversion::toGeomMsgPt(llt_pt);
+        geometry_msgs::msg::Point transformed_geom_pt;
         tf2::doTransform(geom_pt, transformed_geom_pt, geom_tf_map2grid);
         cv_polygon.push_back(toCVPoint(transformed_geom_pt, width, height, resolution));
       }
@@ -876,7 +876,7 @@ nav_msgs::OccupancyGrid generateDrivableArea(
 }
 
 double getDistanceToEndOfLane(
-  const geometry_msgs::Pose & current_pose, const lanelet::ConstLanelets & lanelets)
+  const geometry_msgs::msg::Pose & current_pose, const lanelet::ConstLanelets & lanelets)
 {
   const auto & arc_coordinates = lanelet::utils::getArcCoordinates(lanelets, current_pose);
   const double lanelet_length = lanelet::utils::getLaneletLength3d(lanelets);
@@ -884,7 +884,7 @@ double getDistanceToEndOfLane(
 }
 
 double getDistanceToNextIntersection(
-  const geometry_msgs::Pose & current_pose, const lanelet::ConstLanelets & lanelets)
+  const geometry_msgs::msg::Pose & current_pose, const lanelet::ConstLanelets & lanelets)
 {
   const auto & arc_coordinates = lanelet::utils::getArcCoordinates(lanelets, current_pose);
 
@@ -909,7 +909,7 @@ double getDistanceToNextIntersection(
 }
 
 double getDistanceToCrosswalk(
-  const geometry_msgs::Pose & current_pose, const lanelet::ConstLanelets & lanelets,
+  const geometry_msgs::msg::Pose & current_pose, const lanelet::ConstLanelets & lanelets,
   const lanelet::routing::RoutingGraphContainer & overall_graphs)
 {
   const auto & arc_coordinates = lanelet::utils::getArcCoordinates(lanelets, current_pose);
@@ -950,7 +950,7 @@ double getDistanceToCrosswalk(
 
           for (const auto & point : points_intersection) {
             lanelet::ConstLanelets lanelets = {llt};
-            geometry_msgs::Pose pose_point;
+            geometry_msgs::msg::Pose pose_point;
             pose_point.position.x = point.x();
             pose_point.position.y = point.y();
             const lanelet::ArcCoordinates & arc_crosswalk =
@@ -974,7 +974,7 @@ double getDistanceToCrosswalk(
 }
 
 double getSignedDistance(
-  const geometry_msgs::Pose & current_pose, const geometry_msgs::Pose & goal_pose,
+  const geometry_msgs::msg::Pose & current_pose, const geometry_msgs::msg::Pose & goal_pose,
   const lanelet::ConstLanelets & lanelets)
 {
   const auto arc_current = lanelet::utils::getArcCoordinates(lanelets, current_pose);
@@ -992,10 +992,10 @@ std::vector<uint64_t> getIds(const lanelet::ConstLanelets & lanelets)
   return ids;
 }
 
-autoware_planning_msgs::Path convertToPathFromPathWithLaneId(
-  const autoware_planning_msgs::PathWithLaneId & path_with_lane_id)
+autoware_planning_msgs::msg::Path convertToPathFromPathWithLaneId(
+  const autoware_planning_msgs::msg::PathWithLaneId & path_with_lane_id)
 {
-  autoware_planning_msgs::Path path;
+  autoware_planning_msgs::msg::Path path;
   path.header = path_with_lane_id.header;
   path.drivable_area = path_with_lane_id.drivable_area;
   for (const auto & pt_with_lane_id : path_with_lane_id.points) {
@@ -1005,7 +1005,7 @@ autoware_planning_msgs::Path convertToPathFromPathWithLaneId(
 }
 
 lanelet::Polygon3d getVehiclePolygon(
-  const geometry_msgs::Pose & vehicle_pose, const double vehicle_width,
+  const geometry_msgs::msg::Pose & vehicle_pose, const double vehicle_width,
   const double base_link2front)
 {
   tf2::Vector3 front_left, front_right, rear_left, rear_right;
@@ -1033,16 +1033,16 @@ lanelet::Polygon3d getVehiclePolygon(
   return llt_poly;
 }
 
-autoware_planning_msgs::PathPointWithLaneId insertStopPoint(
-  double length, autoware_planning_msgs::PathWithLaneId * path)
+autoware_planning_msgs::msg::PathPointWithLaneId insertStopPoint(
+  double length, autoware_planning_msgs::msg::PathWithLaneId * path)
 {
   if (path->points.empty()) {
-    return autoware_planning_msgs::PathPointWithLaneId();
+    return autoware_planning_msgs::msg::PathPointWithLaneId();
   }
 
   double accumulated_length = 0;
   double insert_idx = 0;
-  geometry_msgs::Pose stop_pose;
+  geometry_msgs::msg::Pose stop_pose;
   for (int i = 1; i < path->points.size(); i++) {
     const auto prev_pose = path->points.at(i - 1).point.pose;
     const auto curr_pose = path->points.at(i).point.pose;
@@ -1056,13 +1056,13 @@ autoware_planning_msgs::PathPointWithLaneId insertStopPoint(
     }
   }
 
-  autoware_planning_msgs::PathPointWithLaneId stop_point;
+  autoware_planning_msgs::msg::PathPointWithLaneId stop_point;
   stop_point.lane_ids = path->points.at(insert_idx).lane_ids;
   stop_point.point.pose = stop_pose;
   stop_point.point.type = path->points.at(insert_idx).point.type;
   path->points.insert(path->points.begin() + insert_idx, stop_point);
   for (int i = insert_idx; i < path->points.size(); i++) {
-    geometry_msgs::Twist zero_velocity;
+    geometry_msgs::msg::Twist zero_velocity;
     path->points.at(insert_idx).point.twist = zero_velocity;
   }
   return stop_point;


### PR DESCRIPTION
This ports lane_change_planner to ROS2.
Although the package is large, porting was generally straight forward except loggers where I had to pass down many logger and clock objects of rclcpp::Node. 

Since there are many file changes, it might be easier to review each commits.