### PR TITLE
Fix osqp_interface dependencies

### DIFF
--- a/common/math/osqp_interface/CMakeLists.txt
+++ b/common/math/osqp_interface/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
+find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 
 find_package(osqp_vendor REQUIRED)
@@ -19,21 +20,21 @@ find_package(osqp_vendor REQUIRED)
 find_package(osqp REQUIRED)
 get_target_property(OSQP_INCLUDE_DIR osqp::osqpstatic INTERFACE_INCLUDE_DIRECTORIES)
 
-set(EXTERNAL_INCLUDE_DIRS
-  "${EIGEN3_INCLUDE_DIR}"
-  "${OSQP_INCLUDE_DIR}"
-  )
-
-ament_auto_add_library(osqp_interface
+ament_auto_add_library(osqp_interface STATIC
   src/osqp_interface.cpp
   src/csc_matrix_conv.cpp
   include/osqp_interface/osqp_interface.h
   include/osqp_interface/csc_matrix_conv.h
   )
-target_link_libraries(osqp_interface osqp::osqpstatic)
 
-target_include_directories(osqp_interface PUBLIC "${EXTERNAL_INCLUDE_DIRS}")
+target_include_directories(osqp_interface PUBLIC "${OSQP_INCLUDE_DIR}")
+ament_target_dependencies(osqp_interface Eigen3)
+ament_target_dependencies(osqp_interface osqp_vendor)
+
 # needed so clients of this package don't need to worry about includes of this package
-ament_export_include_directories("${EXTERNAL_INCLUDE_DIRS}")
+ament_export_include_directories("${OSQP_INCLUDE_DIR}")
+ament_export_dependencies(eigen3_cmake_module)
+ament_export_dependencies(Eigen3)
+ament_export_dependencies(osqp_vendor)
 
 ament_auto_package()

--- a/common/math/osqp_interface/CMakeLists.txt
+++ b/common/math/osqp_interface/CMakeLists.txt
@@ -31,10 +31,9 @@ target_include_directories(osqp_interface PUBLIC "${OSQP_INCLUDE_DIR}")
 ament_target_dependencies(osqp_interface Eigen3)
 ament_target_dependencies(osqp_interface osqp_vendor)
 
-# needed so clients of this package don't need to worry about includes of this package
+# crucial so downstream package builds because osqp_interface exposes osqp.h
 ament_export_include_directories("${OSQP_INCLUDE_DIR}")
-ament_export_dependencies(eigen3_cmake_module)
-ament_export_dependencies(Eigen3)
-ament_export_dependencies(osqp_vendor)
+# crucial so the linking order is correct in a downstream package: libosqp_interface.a should come before libosqp.a
+ament_export_libraries(osqp::osqpstatic)
 
 ament_auto_package()

--- a/common/math/osqp_interface/package.xml
+++ b/common/math/osqp_interface/package.xml
@@ -7,12 +7,14 @@
   <license>Apache 2</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+  <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
+  <build_depend>eigen</build_depend>
+  <build_export_depend>eigen</build_export_depend>
 
   <depend>osqp_vendor</depend>
 
   <export>
     <build_type>ament_cmake</build_type>
   </export>
-
-  <depend>rclcpp</depend>
 </package>


### PR DESCRIPTION
This PR introduces two fixes:

1. Eigen is consumed and exported properly to fix #63 
2. osqp lib is exported to correct linker errors with static libs

@nnmm This came out our discussion with @jilaada on PR https://github.com/tier4/Pilot.Auto/pull/24

the 2nd point bugged me for a week and I finally better understood what goes on behind the scenes. I will add some guidelines to the porting doc. You can't see it in this PR but in https://github.com/tier4/Pilot.Auto/pull/52 I can now drop this

```diff
modified   control/mpc_follower/CMakeLists.txt
@@ -43,9 +43,6 @@ set(MPC_FOLLOWER_HDR
   )
 
 ament_auto_add_executable(mpc_follower ${MPC_FOLLOWER_SRC} ${MPC_FOLLOWER_HDR})
-# TODO(Frederik.Beaujean) not clear why this isn't taken care of by `ament_auto_add_executable` but `ospq_interface`
-# isn't linked in otherwise
-ament_target_dependencies(mpc_follower osqp_interface)

```
which was needed even though `ament_target_dependencies(mpc_follower osqp_interface)` was already called once because of the linking order of static libs. Pretty nasty!