### PR TITLE
Fix RCLCPP_INFO_THROTTLE duration unit

### DIFF
--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -242,8 +242,8 @@ void VehicleCmdGate::publishControlCommands(const Commands & commands)
 
   // Check emergency
   if (use_emergency_handling_ && is_emergency_) {
-    // TODO(nikolai.morin): Use RCLCPP_INFO_THROTTLE with period 1.0 after Foxy
-    RCLCPP_INFO(get_logger(), "Emergency!");
+    RCLCPP_INFO_THROTTLE(
+      get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(), "Emergency!");
     filtered_commands.control = emergency_commands_.control;
     filtered_commands.shift = emergency_commands_.shift;  // tmp
   }

--- a/localization/pose_twist_fusion_filter/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/pose_twist_fusion_filter/ekf_localizer/src/ekf_localizer.cpp
@@ -449,7 +449,8 @@ void EKFLocalizer::measurementUpdatePose(const geometry_msgs::msg::PoseStamped &
 {
   if (pose.header.frame_id != pose_frame_id_) {
     RCLCPP_WARN_THROTTLE(
-      this->get_logger(), *this->get_clock(), 2000, "pose frame_id is %s, but pose_frame is set as %s. They must be same.",
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(2000).count(),
+      "pose frame_id is %s, but pose_frame is set as %s. They must be same.",
       pose.header.frame_id.c_str(), pose_frame_id_.c_str());
   }
   Eigen::MatrixXd X_curr(dim_x_, 1);  // curent state
@@ -464,12 +465,13 @@ void EKFLocalizer::measurementUpdatePose(const geometry_msgs::msg::PoseStamped &
   if (delay_time < 0.0) {
     delay_time = 0.0;
     RCLCPP_WARN_THROTTLE(
-      this->get_logger(), *this->get_clock(), 1000, "Pose time stamp is inappropriate, set delay to 0[s]. delay = %f", delay_time);
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+      "Pose time stamp is inappropriate, set delay to 0[s]. delay = %f", delay_time);
   }
   int delay_step = std::roundf(delay_time / ekf_dt_);
   if (delay_step > extend_state_step_ - 1) {
     RCLCPP_WARN_THROTTLE(
-      this->get_logger(), *this->get_clock(), 1000,
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
       "Pose delay exceeds the compensation limit, ignored. delay: %f[s], limit = "
       "extend_state_step * ekf_dt : %f [s]",
       delay_time, extend_state_step_ * ekf_dt_);
@@ -503,7 +505,7 @@ void EKFLocalizer::measurementUpdatePose(const geometry_msgs::msg::PoseStamped &
   P_y = P_curr.block(0, 0, dim_y, dim_y);
   if (!mahalanobisGate(pose_gate_dist_, y_ekf, y, P_y)) {
     RCLCPP_WARN_THROTTLE(
-      this->get_logger(), *this->get_clock(), 2000,
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(2000).count(),
       "[EKF] Pose measurement update, mahalanobis distance is over limit. ignore "
       "measurement data.");
     return;
@@ -562,7 +564,9 @@ void EKFLocalizer::measurementUpdatePose(const geometry_msgs::msg::PoseStamped &
 void EKFLocalizer::measurementUpdateTwist(const geometry_msgs::msg::TwistStamped & twist)
 {
   if (twist.header.frame_id != "base_link") {
-    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000, "twist frame_id must be base_link");
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(2000).count(),
+      "twist frame_id must be base_link");
   }
 
   Eigen::MatrixXd X_curr(dim_x_, 1);  // curent state
@@ -576,13 +580,14 @@ void EKFLocalizer::measurementUpdateTwist(const geometry_msgs::msg::TwistStamped
   double delay_time = (t_curr - twist.header.stamp).seconds() + twist_additional_delay_;
   if (delay_time < 0.0) {
     RCLCPP_WARN_THROTTLE(
-      this->get_logger(), *this->get_clock(), 1000, "Twist time stamp is inappropriate (delay = %f [s]), set delay to 0[s].", delay_time);
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+      "Twist time stamp is inappropriate (delay = %f [s]), set delay to 0[s].", delay_time);
     delay_time = 0.0;
   }
   int delay_step = std::roundf(delay_time / ekf_dt_);
   if (delay_step > extend_state_step_ - 1) {
     RCLCPP_WARN_THROTTLE(
-      this->get_logger(), *this->get_clock(), 1000,
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
       "Twist delay exceeds the compensation limit, ignored. delay: %f[s], limit = "
       "extend_state_step * ekf_dt : %f [s]",
       delay_time, extend_state_step_ * ekf_dt_);
@@ -609,7 +614,7 @@ void EKFLocalizer::measurementUpdateTwist(const geometry_msgs::msg::TwistStamped
   P_y = P_curr.block(4, 4, dim_y, dim_y);
   if (!mahalanobisGate(twist_gate_dist_, y_ekf, y, P_y)) {
     RCLCPP_WARN_THROTTLE(
-      this->get_logger(), *this->get_clock(), 2000,
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(2000).count(),
       "[EKF] Twist measurement update, mahalanobis distance is over limit. ignore "
       "measurement data.");
     return;

--- a/perception/object_recognition/tracking/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/object_recognition/tracking/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -83,8 +83,8 @@ void MultiObjectTracker::measurementCallback(
     auto status = future.wait_for(tf2::durationFromSec(0.5));
     if (status != std::future_status::ready) {
       RCLCPP_WARN_THROTTLE(
-        this->get_logger(), *(this->get_clock()), 1.0, "cannot transform to world frame form %s",
-        input_transformed_objects.header.frame_id);
+        this->get_logger(), *(this->get_clock()), std::chrono::milliseconds(1000).count(),
+        "cannot transform to world frame form %s", input_transformed_objects.header.frame_id);
       return;
     }
 

--- a/planning/scenario_planning/parking/freespace_planner/src/freespace_planner/freespace_planner_node.cpp
+++ b/planning/scenario_planning/parking/freespace_planner/src/freespace_planner/freespace_planner_node.cpp
@@ -407,7 +407,8 @@ void AstarNavi::updateTargetIndex()
       // Finished publishing all partial trajectories
       is_completed_ = true;
       this->set_parameter(rclcpp::Parameter("is_completed", true));
-      RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 1, "Astar completed");
+      RCLCPP_INFO_THROTTLE(
+        get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(), "Astar completed");
     } else {
       // Switch to next partial trajectory
       prev_target_index_ = target_index_;

--- a/sensing/preprocessor/gnss/gnss_poser/src/gnss_poser_core.cpp
+++ b/sensing/preprocessor/gnss/gnss_poser/src/gnss_poser_core.cpp
@@ -63,7 +63,8 @@ void GNSSPoser::callbackNavSatFix(
 
   if (!is_fixed) {
     RCLCPP_WARN_STREAM_THROTTLE(
-      this->get_logger(), *this->get_clock(), 1, "Not Fixed Topic. Skipping Calculate.");
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+      "Not Fixed Topic. Skipping Calculate.");
     return;
   }
 
@@ -75,7 +76,8 @@ void GNSSPoser::callbackNavSatFix(
   position_buffer_.push_front(position);
   if (!position_buffer_.full()) {
     RCLCPP_WARN_STREAM_THROTTLE(
-      this->get_logger(), *this->get_clock(), 1, "Buffering Position. Output Skipped.");
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+      "Buffering Position. Output Skipped.");
     return;
   }
   const auto median_position = getMedianPosition(position_buffer_);
@@ -162,7 +164,9 @@ GNSSStat GNSSPoser::convert(
   } else if (coordinate_system == CoordinateSystem::PLANE) {
     gnss_stat = NavSatFix2PLANE(nav_sat_fix_msg, plane_zone_, this->get_logger());
   } else {
-    RCLCPP_ERROR_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1, "Unknown Coordinate System");
+    RCLCPP_ERROR_STREAM_THROTTLE(
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+      "Unknown Coordinate System");
   }
   return gnss_stat;
 }
@@ -252,9 +256,10 @@ bool GNSSPoser::getTransform(
     *transform_stamped_ptr =
       tf2_buffer_.lookupTransform(target_frame, source_frame, tf2::TimePointZero);
   } catch (tf2::TransformException & ex) {
-    RCLCPP_WARN_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1, ex.what());
     RCLCPP_WARN_STREAM_THROTTLE(
-      this->get_logger(), *this->get_clock(), 1,
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(), ex.what());
+    RCLCPP_WARN_STREAM_THROTTLE(
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
       "Please publish TF " << target_frame.c_str() << " to " << source_frame.c_str());
 
     transform_stamped_ptr->header.stamp = this->now();
@@ -296,9 +301,10 @@ bool GNSSPoser::getStaticTransform(
       target_frame, source_frame,
       tf2::TimePoint(std::chrono::seconds(stamp.sec) + std::chrono::nanoseconds(stamp.nanosec)));
   } catch (tf2::TransformException & ex) {
-    RCLCPP_WARN_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1, ex.what());
     RCLCPP_WARN_STREAM_THROTTLE(
-      this->get_logger(), *this->get_clock(), 1,
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(), ex.what());
+    RCLCPP_WARN_STREAM_THROTTLE(
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
       "Please publish TF " << target_frame.c_str() << " to " << source_frame.c_str());
 
     transform_stamped_ptr->header.stamp = stamp;

--- a/system/emergency_handler/src/emergency_handler_core.cpp
+++ b/system/emergency_handler/src/emergency_handler_core.cpp
@@ -52,22 +52,30 @@ void EmergencyHandler::onTwist(const geometry_msgs::msg::TwistStamped::ConstShar
 bool EmergencyHandler::isDataReady()
 {
   if (!driving_capability_) {
-    RCLCPP_DEBUG_THROTTLE(this->get_logger(), *this->get_clock(), 1.0, "waiting for driving_capability msg...");
+    RCLCPP_DEBUG_THROTTLE(
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+      "waiting for driving_capability msg...");
     return false;
   }
 
   if (!prev_control_command_) {
-    RCLCPP_DEBUG_THROTTLE(this->get_logger(), *this->get_clock(), 1.0, "waiting for prev_control_command msg...");
+    RCLCPP_DEBUG_THROTTLE(
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+      "waiting for prev_control_command msg...");
     return false;
   }
 
   if (!current_gate_mode_) {
-    RCLCPP_DEBUG_THROTTLE(this->get_logger(), *this->get_clock(), 1.0, "waiting for current_gate_mode msg...");
+    RCLCPP_DEBUG_THROTTLE(
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+      "waiting for current_gate_mode msg...");
     return false;
   }
 
   if (!twist_) {
-    RCLCPP_DEBUG_THROTTLE(this->get_logger(), *this->get_clock(), 1.0, "waiting for twist msg...");
+    RCLCPP_DEBUG_THROTTLE(
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+      "waiting for twist msg...");
     return false;
   }
 
@@ -135,32 +143,42 @@ bool EmergencyHandler::isEmergency()
       (autoware_state_->state != AutowareState::PLANNING);
 
     if (is_in_target_state && !driving_capability_->autonomous_driving) {
-      RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1.0, "autonomous_driving is failed");
+      RCLCPP_WARN_THROTTLE(
+        this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+        "autonomous_driving is failed");
       return true;
     }
   }
 
   if (current_gate_mode_->data == GateMode::REMOTE) {
     if (!driving_capability_->remote_control) {
-      RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1.0, "remote_control is failed");
+      RCLCPP_WARN_THROTTLE(
+        this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+        "remote_control is failed");
       return true;
     }
   }
 
   if (!driving_capability_->manual_driving) {
-    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1.0, "manual_driving is failed");
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+      "manual_driving is failed");
     return true;
   }
 
   /* Currently not supported */
   // if (!driving_capability_->safe_stop) {
-  //   RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1.0, "safe_stop is failed");
+  //   RCLCPP_WARN_THROTTLE(
+  //     this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+  //     "safe_stop is failed");
   //   return true;
   // }
   /* Currently not supported */
 
   if (!driving_capability_->emergency_stop) {
-    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1.0, "emergency_stop is failed");
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), std::chrono::milliseconds(1000).count(),
+      "emergency_stop is failed");
     return true;
   }
 

--- a/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
+++ b/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
@@ -233,8 +233,9 @@ void PacmodInterface::publishCommands()
   /* guard */
   if (!raw_vehicle_cmd_ptr_ || !is_pacmod_rpt_received_) {
     RCLCPP_INFO_THROTTLE(
-      get_logger(), *get_clock(), 1.0, "vehicle_cmd = %d, pacmod_msgs = %d",
-      raw_vehicle_cmd_ptr_ != nullptr, is_pacmod_rpt_received_);
+      get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
+      "vehicle_cmd = %d, pacmod_msgs = %d", raw_vehicle_cmd_ptr_ != nullptr,
+      is_pacmod_rpt_received_);
     return;
   }
 

--- a/vehicle/as/src/ssc_interface/ssc_interface.cpp
+++ b/vehicle/as/src/ssc_interface/ssc_interface.cpp
@@ -234,7 +234,7 @@ void SSCInterface::publishCommand()
   /* guard */
   if (!command_initialized_ || !wheel_speed_rpt_ptr_ || !vel_acc_cov_ptr_ || !gear_feedback_ptr_) {
     RCLCPP_INFO_THROTTLE(
-      get_logger(), *get_clock(), 1.0,
+      get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
       "vehicle_cmd = %d, wheel_speed_rpt = %d, vel_acc_cov = %d, gear_feedback = %d",
       command_initialized_, wheel_speed_rpt_ptr_ != nullptr, vel_acc_cov_ptr_ != nullptr,
       gear_feedback_ptr_ != nullptr);
@@ -279,14 +279,14 @@ void SSCInterface::publishCommand()
 
   if (emergency) {
     RCLCPP_ERROR_THROTTLE(
-      get_logger(), *get_clock(), 1.0, "Emergency Stopping, emergency = %d, timeouted = %d",
-      emergency, timeouted);
+      get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
+      "Emergency Stopping, emergency = %d, timeouted = %d", emergency, timeouted);
     desired_speed = 0.0;
     deceleration_limit = 0.0;
   } else if (timeouted) {
     RCLCPP_ERROR_THROTTLE(
-      get_logger(), *get_clock(), 1.0, "Timeout Stopping, emergency = %d, timeouted = %d",
-      emergency, timeouted);
+      get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
+      "Timeout Stopping, emergency = %d, timeouted = %d", emergency, timeouted);
     desired_speed = 0.0;
   }
 
@@ -300,7 +300,7 @@ void SSCInterface::publishCommand()
       deceleration_limit = 0.0;  // set quick stop mode to change the shift
       desired_shift = toSSCShiftCmd(vehicle_cmd_.shift);
       RCLCPP_INFO_THROTTLE(
-        get_logger(), *get_clock(), 1.0,
+        get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
         "Doing shift change. current = %d, desired = %d. set quick stop mode",
         gear_feedback_ptr_->current_gear.gear, toSSCShiftCmd(vehicle_cmd_.shift));
     }

--- a/vehicle/raw_vehicle_cmd_converter/src/accel_map.cpp
+++ b/vehicle/raw_vehicle_cmd_converter/src/accel_map.cpp
@@ -68,7 +68,7 @@ bool AccelMap::getThrottle(double acc, double vel, double & throttle)
   if (vel < vel_index_.front()) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_,
       logger_ros_clock_,
-      RCUTILS_S_TO_NS(1),
+      std::chrono::milliseconds(1000).count(),
       "[Accel Map] Exceeding the vel range. Current vel: %f < min vel on map: %f. Use min "
       "velocity.",
       vel, vel_index_.front());
@@ -76,7 +76,7 @@ bool AccelMap::getThrottle(double acc, double vel, double & throttle)
   } else if (vel_index_.back() < vel) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, 
       logger_ros_clock_,
-      RCUTILS_S_TO_NS(1),
+      std::chrono::milliseconds(1000).count(),
       "[Accel Map] Exceeding the vel range. Current vel: %f > max vel on map: %f. Use max "
       "velocity.",
       vel, vel_index_.back());
@@ -112,7 +112,7 @@ bool AccelMap::getAcceleration(double throttle, double vel, double & acc)
   if (vel < vel_index_.front()) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, 
       logger_ros_clock_,
-      RCUTILS_S_TO_NS(1),
+      std::chrono::milliseconds(1000).count(),
       "[Accel Map] Exceeding the vel range. Current vel: %f < min vel on map: %f. Use min "
       "velocity.",
       vel, vel_index_.front());
@@ -120,7 +120,7 @@ bool AccelMap::getAcceleration(double throttle, double vel, double & acc)
   } else if (vel_index_.back() < vel) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, 
       logger_ros_clock_,
-      RCUTILS_S_TO_NS(1),
+      std::chrono::milliseconds(1000).count(),
       "[Accel Map] Exceeding the vel range. Current vel: %f > max vel on map: %f. Use max "
       "velocity.",
       vel, vel_index_.back());
@@ -142,7 +142,7 @@ bool AccelMap::getAcceleration(double throttle, double vel, double & acc)
   if (throttle < min_throttle || max_throttle < throttle) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, 
       logger_ros_clock_,
-      RCUTILS_S_TO_NS(1),
+      std::chrono::milliseconds(1000).count(),
       "[Accel Map] Input throttle: %f is out off range. use closest value.", throttle);
     throttle = std::min(std::max(throttle, min_throttle), max_throttle);
   }

--- a/vehicle/raw_vehicle_cmd_converter/src/brake_map.cpp
+++ b/vehicle/raw_vehicle_cmd_converter/src/brake_map.cpp
@@ -71,7 +71,7 @@ bool BrakeMap::getBrake(double acc, double vel, double & brake)
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
       logger_,
       logger_ros_clock_,
-      1.0,
+      std::chrono::milliseconds(1000).count(),
       "[Brake Map] Exceeding the vel range. Current vel: %f < min vel on map: %f. Use min "
       "velocity.",
       vel, vel_index_.front());
@@ -80,7 +80,7 @@ bool BrakeMap::getBrake(double acc, double vel, double & brake)
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
       logger_,
       logger_ros_clock_,
-      1.0,
+      std::chrono::milliseconds(1000).count(),
       "[Brake Map] Exceeding the vel range. Current vel: %f > max vel on map: %f. Use max "
       "velocity.",
       vel, vel_index_.back());
@@ -101,7 +101,7 @@ bool BrakeMap::getBrake(double acc, double vel, double & brake)
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
       logger_,
       logger_ros_clock_,
-      1.0,
+      std::chrono::milliseconds(1000).count(),
       "[Brake Map] Exceeding the acc range. Desired acc: %f < min acc on map: %f. return max "
       "value.",
       acc, accs_interpolated.back());
@@ -127,7 +127,7 @@ bool BrakeMap::getAcceleration(double brake, double vel, double & acc)
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
       logger_,
       logger_ros_clock_,
-      1.0,
+      std::chrono::milliseconds(1000).count(),
       "[Brake Map] Exceeding the vel range. Current vel: %f < min vel on map: %f. Use min "
       "velocity.",
       vel, vel_index_.front());
@@ -136,7 +136,7 @@ bool BrakeMap::getAcceleration(double brake, double vel, double & acc)
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
       logger_,
       logger_ros_clock_,
-      1.0,
+      std::chrono::milliseconds(1000).count(),
       "[Brake Map] Exceeding the vel range. Current vel: %f > max vel on map: %f. Use max "
       "velocity.",
       vel, vel_index_.back());
@@ -157,9 +157,8 @@ bool BrakeMap::getAcceleration(double brake, double vel, double & acc)
   const double min_brake = brake_index_.front();
   if (brake < min_brake || max_brake < brake) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
-      logger_,
-      logger_ros_clock_,
-      1.0, "[Brake Map] Input brake: %f is out off range. use closest value.", brake);
+      logger_, logger_ros_clock_, std::chrono::milliseconds(1000).count(),
+      "[Brake Map] Input brake: %f is out off range. use closest value.", brake);
     brake = std::min(std::max(brake, min_brake), max_brake);
   }
 


### PR DESCRIPTION
The duration arg for  RCLCPP_INFO_THROTTLE() is changed to [ms] from [s] in ROS2.
Some packages are using this function with a very short duration, they seem to be a mistake on porting.

Fix for these packages to use explicit ms duration.