### PR TITLE
port motion_velocity_optimizer

### DIFF
--- a/common/msgs/autoware_planning_msgs/CMakeLists.txt
+++ b/common/msgs/autoware_planning_msgs/CMakeLists.txt
@@ -29,6 +29,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/StopReasonArray.msg"
   "msg/Trajectory.msg"
   "msg/TrajectoryPoint.msg"
+  "msg/VelocityLimit.msg"
   DEPENDENCIES std_msgs geometry_msgs nav_msgs
 )
 

--- a/common/msgs/autoware_planning_msgs/msg/VelocityLimit.msg
+++ b/common/msgs/autoware_planning_msgs/msg/VelocityLimit.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+float64 data

--- a/planning/scenario_planning/common/motion_velocity_optimizer/CMakeLists.txt
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/CMakeLists.txt
@@ -1,72 +1,42 @@
-cmake_minimum_required(VERSION 3.0.2)
+# colcon build --packages-select motion_velocity_optimizer
+
+cmake_minimum_required(VERSION 3.5)
 project(motion_velocity_optimizer)
 
-add_compile_options(-std=c++14 -Wall)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  std_msgs
-  autoware_planning_msgs
-  geometry_msgs
-  tf2
-  tf2_ros
-  dynamic_reconfigure
-  osqp_interface
-)
-
-generate_dynamic_reconfigure_options(cfg/MotionVelocityOptimizer.cfg)
-
-find_package(Boost REQUIRED)
-find_package(Eigen3 REQUIRED)
-
-catkin_package(
-  INCLUDE_DIRS include
-  CATKIN_DEPENDS
-    roscpp
-    std_msgs
-    autoware_planning_msgs
-    geometry_msgs
-    tf2
-    tf2_ros
-    osqp_interface
-)
-
-include_directories(
-include
-  ${catkin_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIRS}
-)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 
 set(MOTION_VELOCITY_OPTIMIZER_SRC
+  src/motion_velocity_optimizer.cpp
   src/motion_velocity_optimizer_utils.cpp
   src/interpolate.cpp
   src/optimizer/pseudo_jerk_l2_optimizer.cpp
   src/optimizer/pseudo_jerk_linf_optimizer.cpp
 )
-
-add_executable(motion_velocity_optimizer src/motion_velocity_optimizer.cpp ${MOTION_VELOCITY_OPTIMIZER_SRC})
-add_dependencies(motion_velocity_optimizer ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS} motion_velocity_optimizer_gencfg)
-target_link_libraries(motion_velocity_optimizer ${catkin_LIBRARIES} ${PYTHON_LIBRARIES})
-
-install(
-  TARGETS
-    motion_velocity_optimizer
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+set(MOTION_VELOCITY_OPTIMIZER_HDR
+  include/motion_velocity_optimizer/motion_velocity_optimizer.hpp
+  include/motion_velocity_optimizer/motion_velocity_optimizer_utils.hpp
+  include/motion_velocity_optimizer/interpolate.h
+  include/motion_velocity_optimizer/optimizer/l2_pseudo_jerk_optimizer.hpp
+  include/motion_velocity_optimizer/optimizer/linf_pseudo_jerk_optimizer.hpp
+  include/motion_velocity_optimizer/optimizer/optimizer_base.hpp
 )
 
-install(
-  DIRECTORY
+ament_auto_add_executable(motion_velocity_optimizer 
+  ${MOTION_VELOCITY_OPTIMIZER_SRC} 
+  ${MOTION_VELOCITY_OPTIMIZER_HDR}
+)
+
+ament_auto_package(
+  INSTALL_TO_SHARE
     launch
     config
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
-
-install(
-  DIRECTORY
-    scripts
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-  USE_SOURCE_PERMISSIONS
 )

--- a/planning/scenario_planning/common/motion_velocity_optimizer/include/motion_velocity_optimizer/motion_velocity_optimizer.hpp
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/include/motion_velocity_optimizer/motion_velocity_optimizer.hpp
@@ -105,7 +105,7 @@ private:
   /* non-const methods */
   void run();
 
-  void blockUntilVehiclePositionAvailable(const tf2::Duration & timeout);
+  void blockUntilVehiclePositionAvailable(const tf2::Duration & duration);
 
   void updateCurrentPose();
 

--- a/planning/scenario_planning/common/motion_velocity_optimizer/include/motion_velocity_optimizer/motion_velocity_optimizer.hpp
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/include/motion_velocity_optimizer/motion_velocity_optimizer.hpp
@@ -13,51 +13,50 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <autoware_planning_msgs/Trajectory.h>
-#include <geometry_msgs/TwistStamped.h>
-#include <ros/ros.h>
-#include <std_msgs/Bool.h>
-#include <std_msgs/Float32.h>
-#include <std_msgs/Float32MultiArray.h>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_debug_msgs/msg/float32_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <autoware_debug_msgs/msg/float32_multi_array_stamped.hpp>
 #include <tf2/utils.h>
 #include <tf2_ros/transform_listener.h>
-#include <boost/shared_ptr.hpp>
 #include <iostream>
 #include <mutex>
 #include <string>
 
-#include <dynamic_reconfigure/server.h>
-#include <motion_velocity_optimizer/MotionVelocityOptimizerConfig.h>
 #include <motion_velocity_optimizer/motion_velocity_optimizer_utils.hpp>
 #include <motion_velocity_optimizer/optimizer/optimizer_base.hpp>
 
 #include <osqp_interface/osqp_interface.h>
 
-class MotionVelocityOptimizer
+class MotionVelocityOptimizer : public rclcpp::Node
 {
 public:
   MotionVelocityOptimizer();
   ~MotionVelocityOptimizer();
 
 private:
-  ros::NodeHandle nh_;
-  ros::NodeHandle pnh_;
-  ros::Publisher pub_trajectory_;                //!< @brief publisher for output trajectory
-  ros::Subscriber sub_current_velocity_;         //!< @brief subscriber for current velocity
-  ros::Subscriber sub_current_trajectory_;       //!< @brief subscriber for reference trajectory
-  ros::Subscriber sub_external_velocity_limit_;  //!< @brief subscriber for external velocity limit
-  tf2_ros::Buffer tf_buffer_;                    //!< @brief tf butter
-  tf2_ros::TransformListener tf_listener_;       //!< @brief tf listener
-  ros::Timer timer_;
+  rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr pub_trajectory_; //!< @brief publisher for output trajectory
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_current_velocity_;  //!< @brief subscriber for current velocity
+  rclcpp::Subscription<autoware_planning_msgs::msg::Trajectory>::SharedPtr sub_current_trajectory_;  //!< @brief subscriber for reference trajectory
+  rclcpp::Subscription<autoware_planning_msgs::msg::VelocityLimit>::SharedPtr sub_external_velocity_limit_;//!< @brief subscriber for external velocity limit
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;  //!< @brief tf butter
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;  //!< @brief tf listener
+
+  double external_velocity_limit_update_rate_;
+  rclcpp::TimerBase::SharedPtr timer_;
+
   std::mutex mutex_;
 
-  geometry_msgs::PoseStamped::ConstPtr current_pose_ptr_;           // current vehicle pose
-  geometry_msgs::TwistStamped::ConstPtr current_velocity_ptr_;      // current vehicle twist
-  autoware_planning_msgs::Trajectory::ConstPtr base_traj_raw_ptr_;  // current base_waypoints
-  std_msgs::Float32::ConstPtr external_velocity_limit_ptr_;  // current external_velocity_limit
-  boost::shared_ptr<double> external_velocity_limit_filtered_;
 
-  autoware_planning_msgs::Trajectory prev_output_;  // previously published trajectory
+  geometry_msgs::msg::PoseStamped::ConstSharedPtr current_pose_ptr_;           // current vehicle pose
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr current_velocity_ptr_;      // current vehicle twist
+  autoware_planning_msgs::msg::Trajectory::ConstSharedPtr base_traj_raw_ptr_;  // current base_waypoints
+  autoware_planning_msgs::msg::VelocityLimit::ConstSharedPtr external_velocity_limit_ptr_;  // current external_velocity_limit
+  std::shared_ptr<double> external_velocity_limit_filtered_;
+
+  autoware_planning_msgs::msg::Trajectory prev_output_;  // previously published trajectory
 
   enum class InitializeType {
     INIT = 0,
@@ -67,7 +66,7 @@ private:
   };
   InitializeType initialize_type_;
 
-  boost::shared_ptr<OptimizerBase> optimizer_;
+  std::shared_ptr<OptimizerBase> optimizer_;
 
   bool publish_debug_trajs_;  // publish planned trajectories
 
@@ -97,98 +96,75 @@ private:
   } planning_param_;
 
   /* topic callback */
-  void callbackCurrentVelocity(const geometry_msgs::TwistStamped::ConstPtr msg);
-  void callbackCurrentTrajectory(const autoware_planning_msgs::Trajectory::ConstPtr msg);
-  void callbackExternalVelocityLimit(const std_msgs::Float32::ConstPtr msg);
-  void timerCallback(const ros::TimerEvent & e);
+  void callbackCurrentVelocity(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
+  void callbackCurrentTrajectory(const autoware_planning_msgs::msg::Trajectory::ConstSharedPtr msg);
+  void callbackExternalVelocityLimit(const autoware_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
+  void timerCallback();
+
 
   /* non-const methods */
   void run();
 
+  void blockUntilVehiclePositionAvailable(const tf2::Duration & timeout);
+
   void updateCurrentPose();
 
-  autoware_planning_msgs::Trajectory calcTrajectoryVelocity(
-    const autoware_planning_msgs::Trajectory & base_traj);
+  autoware_planning_msgs::msg::Trajectory calcTrajectoryVelocity(
+    const autoware_planning_msgs::msg::Trajectory & base_traj);
   void updateExternalVelocityLimit(const double dt);
 
-  autoware_planning_msgs::Trajectory optimizeVelocity(
-    const autoware_planning_msgs::Trajectory & input, const int input_closest,
-    const autoware_planning_msgs::Trajectory & prev_output_traj, const int prev_output_closest);
+  autoware_planning_msgs::msg::Trajectory optimizeVelocity(
+    const autoware_planning_msgs::msg::Trajectory & input, const int input_closest,
+    const autoware_planning_msgs::msg::Trajectory & prev_output_traj, const int prev_output_closest);
 
   void calcInitialMotion(
-    const double & base_speed, const autoware_planning_msgs::Trajectory & base_waypoints,
-    const int base_closest, const autoware_planning_msgs::Trajectory & prev_replanned_traj,
+    const double & base_speed, const autoware_planning_msgs::msg::Trajectory & base_waypoints,
+    const int base_closest, const autoware_planning_msgs::msg::Trajectory & prev_replanned_traj,
     const int prev_replanned_traj_closest, double & initial_vel, double & initial_acc);
 
   /* const methods */
   bool resampleTrajectory(
-    const autoware_planning_msgs::Trajectory & input,
-    autoware_planning_msgs::Trajectory & output) const;
+    const autoware_planning_msgs::msg::Trajectory & input,
+    autoware_planning_msgs::msg::Trajectory & output) const;
 
   bool lateralAccelerationFilter(
-    const autoware_planning_msgs::Trajectory & input,
-    autoware_planning_msgs::Trajectory & output) const;
+    const autoware_planning_msgs::msg::Trajectory & input,
+    autoware_planning_msgs::msg::Trajectory & output) const;
 
   bool extractPathAroundIndex(
-    const autoware_planning_msgs::Trajectory & input, const int index,
-    autoware_planning_msgs::Trajectory & output) const;
+    const autoware_planning_msgs::msg::Trajectory & input, const int index,
+    autoware_planning_msgs::msg::Trajectory & output) const;
 
   bool externalVelocityLimitFilter(
-    const autoware_planning_msgs::Trajectory & input,
-    autoware_planning_msgs::Trajectory & output) const;
+    const autoware_planning_msgs::msg::Trajectory & input,
+    autoware_planning_msgs::msg::Trajectory & output) const;
 
   void preventMoveToCloseStopLine(
-    const int closest, autoware_planning_msgs::Trajectory & trajectory) const;
+    const int closest, autoware_planning_msgs::msg::Trajectory & trajectory) const;
 
-  void publishTrajectory(const autoware_planning_msgs::Trajectory & traj) const;
+  void publishTrajectory(const autoware_planning_msgs::msg::Trajectory & traj) const;
 
   void publishStopDistance(
-    const autoware_planning_msgs::Trajectory & trajectory, const int closest) const;
+    const autoware_planning_msgs::msg::Trajectory & trajectory, const int closest) const;
 
   void insertBehindVelocity(
-    const int prev_out_closest, const autoware_planning_msgs::Trajectory & prev_output,
-    const int output_closest, autoware_planning_msgs::Trajectory & output) const;
+    const int prev_out_closest, const autoware_planning_msgs::msg::Trajectory & prev_output,
+    const int output_closest, autoware_planning_msgs::msg::Trajectory & output) const;
 
-  /* dynamic reconfigure */
-  dynamic_reconfigure::Server<motion_velocity_optimizer::MotionVelocityOptimizerConfig>
-    dyncon_server_;
-  void dynamicRecofCallback(
-    motion_velocity_optimizer::MotionVelocityOptimizerConfig & config, uint32_t level)
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    planning_param_.max_velocity = config.max_velocity;
-    planning_param_.max_accel = config.max_accel;
-    planning_param_.min_decel = config.min_decel;
-    planning_param_.max_lateral_accel = config.max_lateral_accel;
-    planning_param_.min_curve_velocity = config.min_curve_velocity;
-    planning_param_.decel_distance_before_curve = config.decel_distance_before_curve;
-    planning_param_.decel_distance_after_curve = config.decel_distance_after_curve;
-    planning_param_.replan_vel_deviation = config.replan_vel_deviation;
-    planning_param_.engage_velocity = config.engage_velocity;
-    planning_param_.engage_acceleration = config.engage_acceleration;
-    planning_param_.engage_exit_ratio = config.engage_exit_ratio;
-    planning_param_.extract_ahead_dist = config.extract_ahead_dist;
-    planning_param_.extract_behind_dist = config.extract_behind_dist;
-    planning_param_.stop_dist_to_prohibit_engage = config.stop_dist_to_prohibit_engage;
-    planning_param_.delta_yaw_threshold = config.delta_yaw_threshold;
+  /* parameter update */
+  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
+  rcl_interfaces::msg::SetParametersResult paramCallback(
+    const std::vector<rclcpp::Parameter> & parameters);
 
-    planning_param_.resample_time = config.resample_time;
-    planning_param_.resample_dt = config.resample_dt;
-    planning_param_.max_trajectory_length = config.max_trajectory_length;
-    planning_param_.min_trajectory_length = config.min_trajectory_length;
-    planning_param_.min_trajectory_interval_distance = config.min_trajectory_interval_distance;
-
-    optimizer_->setAccel(config.max_accel);
-    optimizer_->setDecel(config.min_decel);
-  }
 
   /* debug */
-  ros::Publisher pub_dist_to_stopline_;  //!< @brief publisher for stop distance
-  ros::Publisher pub_trajectory_raw_;
-  ros::Publisher pub_trajectory_vel_lim_;
-  ros::Publisher pub_trajectory_latcc_filtered_;
-  ros::Publisher pub_trajectory_resampled_;
-  ros::Publisher debug_closest_velocity_;
-  ros::Publisher debug_closest_acc_;
-  void publishFloat(const double & data, const ros::Publisher & pub) const;
+
+  rclcpp::Publisher<autoware_debug_msgs::msg::Float32Stamped>::SharedPtr pub_dist_to_stopline_;  //!< @brief publisher for stop distance
+  rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr pub_trajectory_raw_;
+  rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr pub_trajectory_vel_lim_;
+  rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr pub_trajectory_latcc_filtered_;
+  rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr pub_trajectory_resampled_;
+  rclcpp::Publisher<autoware_debug_msgs::msg::Float32Stamped>::SharedPtr debug_closest_velocity_;
+  rclcpp::Publisher<autoware_debug_msgs::msg::Float32Stamped>::SharedPtr debug_closest_acc_;
+  void publishFloat(const double & data, const rclcpp::Publisher<autoware_debug_msgs::msg::Float32Stamped>::SharedPtr pub) const;
 };

--- a/planning/scenario_planning/common/motion_velocity_optimizer/include/motion_velocity_optimizer/motion_velocity_optimizer_utils.hpp
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/include/motion_velocity_optimizer/motion_velocity_optimizer_utils.hpp
@@ -16,64 +16,62 @@
 
 #include <iostream>
 
-#include <geometry_msgs/TwistStamped.h>
-#include <ros/ros.h>
-#include <std_msgs/Float32.h>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <rclcpp/rclcpp.hpp>
 #include <tf2/utils.h>
-#include <boost/shared_ptr.hpp>
 
-#include <autoware_planning_msgs/Trajectory.h>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
 
 namespace vpu
 {
 double square(const double & a);
-double calcSquaredDist2d(const geometry_msgs::Point & a, const geometry_msgs::Point & b);
-double calcSquaredDist2d(const geometry_msgs::Pose & a, const geometry_msgs::Pose & b);
+double calcSquaredDist2d(const geometry_msgs::msg::Point & a, const geometry_msgs::msg::Point & b);
+double calcSquaredDist2d(const geometry_msgs::msg::Pose & a, const geometry_msgs::msg::Pose & b);
 double calcSquaredDist2d(
-  const geometry_msgs::PoseStamped & a, const geometry_msgs::PoseStamped & b);
+  const geometry_msgs::msg::PoseStamped & a, const geometry_msgs::msg::PoseStamped & b);
 double calcSquaredDist2d(
-  const autoware_planning_msgs::TrajectoryPoint & a,
-  const autoware_planning_msgs::TrajectoryPoint & b);
-double calcDist2d(const geometry_msgs::Point & a, const geometry_msgs::Point & b);
-double calcDist2d(const geometry_msgs::Pose & a, const geometry_msgs::Pose & b);
-double calcDist2d(const geometry_msgs::PoseStamped & a, const geometry_msgs::PoseStamped & b);
+  const autoware_planning_msgs::msg::TrajectoryPoint & a,
+  const autoware_planning_msgs::msg::TrajectoryPoint & b);
+double calcDist2d(const geometry_msgs::msg::Point & a, const geometry_msgs::msg::Point & b);
+double calcDist2d(const geometry_msgs::msg::Pose & a, const geometry_msgs::msg::Pose & b);
+double calcDist2d(const geometry_msgs::msg::PoseStamped & a, const geometry_msgs::msg::PoseStamped & b);
 double calcDist2d(
-  const autoware_planning_msgs::TrajectoryPoint & a,
-  const autoware_planning_msgs::TrajectoryPoint & b);
+  const autoware_planning_msgs::msg::TrajectoryPoint & a,
+  const autoware_planning_msgs::msg::TrajectoryPoint & b);
 int calcClosestWaypoint(
-  const autoware_planning_msgs::Trajectory & trajectory, const geometry_msgs::Point & point);
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const geometry_msgs::msg::Point & point);
 int calcClosestWaypoint(
-  const autoware_planning_msgs::Trajectory & trajectory, const geometry_msgs::Pose & pose,
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const geometry_msgs::msg::Pose & pose,
   const double delta_yaw_threshold);
 bool extractPathAroundIndex(
-  const autoware_planning_msgs::Trajectory & trajectory, const int index,
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const int index,
   const double & ahead_length, const double & behind_length,
-  autoware_planning_msgs::Trajectory & extracted_base_waypoints);
+  autoware_planning_msgs::msg::Trajectory & extracted_base_waypoints);
 double calcLengthOnWaypoints(
-  const autoware_planning_msgs::Trajectory & trajectory, const int idx1, const int idx2);
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const int idx1, const int idx2);
 void calcTrajectoryArclength(
-  const autoware_planning_msgs::Trajectory & trajectory, std::vector<double> & arclength);
+  const autoware_planning_msgs::msg::Trajectory & trajectory, std::vector<double> & arclength);
 void calcTrajectoryIntervalDistance(
-  const autoware_planning_msgs::Trajectory & trajectory, std::vector<double> & intervals);
-void setZeroVelocity(autoware_planning_msgs::Trajectory & trajectory);
-double getMaxVelocity(const autoware_planning_msgs::Trajectory & trajectory);
-double getMaxAbsVelocity(const autoware_planning_msgs::Trajectory & trajectory);
-void mininumVelocityFilter(const double & min_vel, autoware_planning_msgs::Trajectory & trajectory);
-void maximumVelocityFilter(const double & max_vel, autoware_planning_msgs::Trajectory & trajectory);
+  const autoware_planning_msgs::msg::Trajectory & trajectory, std::vector<double> & intervals);
+void setZeroVelocity(autoware_planning_msgs::msg::Trajectory & trajectory);
+double getMaxVelocity(const autoware_planning_msgs::msg::Trajectory & trajectory);
+double getMaxAbsVelocity(const autoware_planning_msgs::msg::Trajectory & trajectory);
+void mininumVelocityFilter(const double & min_vel, autoware_planning_msgs::msg::Trajectory & trajectory);
+void maximumVelocityFilter(const double & max_vel, autoware_planning_msgs::msg::Trajectory & trajectory);
 void multiplyConstantToTrajectoryVelocity(
-  const double & scalar, autoware_planning_msgs::Trajectory & trajectory);
+  const double & scalar, autoware_planning_msgs::msg::Trajectory & trajectory);
 void insertZeroVelocityAfterIdx(
-  const int & stop_idx, autoware_planning_msgs::Trajectory & trajectory);
-double getVx(const autoware_planning_msgs::Trajectory & trajectory, const int & i);
-bool searchZeroVelocityIdx(const autoware_planning_msgs::Trajectory & trajectory, int & idx);
+  const int & stop_idx, autoware_planning_msgs::msg::Trajectory & trajectory);
+double getVx(const autoware_planning_msgs::msg::Trajectory & trajectory, const int & i);
+bool searchZeroVelocityIdx(const autoware_planning_msgs::msg::Trajectory & trajectory, int & idx);
 bool calcTrajectoryCurvatureFrom3Points(
-  const autoware_planning_msgs::Trajectory & trajectory, const unsigned int & idx_dist,
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const unsigned int & idx_dist,
   std::vector<double> & k_arr);
 double normalizeRadian(const double _angle);
 void convertEulerAngleToMonotonic(std::vector<double> & a);
-geometry_msgs::Quaternion getQuaternionFromYaw(double yaw);
+geometry_msgs::msg::Quaternion getQuaternionFromYaw(double yaw);
 bool linearInterpTrajectory(
   const std::vector<double> & base_index,
-  const autoware_planning_msgs::Trajectory & base_trajectory, const std::vector<double> & out_index,
-  autoware_planning_msgs::Trajectory & out_trajectory);
+  const autoware_planning_msgs::msg::Trajectory & base_trajectory, const std::vector<double> & out_index,
+  autoware_planning_msgs::msg::Trajectory & out_trajectory);
 }  // namespace vpu

--- a/planning/scenario_planning/common/motion_velocity_optimizer/include/motion_velocity_optimizer/optimizer/l2_pseudo_jerk_optimizer.hpp
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/include/motion_velocity_optimizer/optimizer/l2_pseudo_jerk_optimizer.hpp
@@ -17,9 +17,9 @@
 #ifndef MOTION_VELOCITY_OPTIMIZER_L2_PSEUDO_JERK_OPTIMIZER_HPP
 #define MOTION_VELOCITY_OPTIMIZER_L2_PSEUDO_JERK_OPTIMIZER_HPP
 
-#include <autoware_planning_msgs/Trajectory.h>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <osqp_interface/osqp_interface.h>
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <vector>
 
 #include <motion_velocity_optimizer/optimizer/optimizer_base.hpp>
@@ -40,8 +40,8 @@ public:
   explicit L2PseudoJerkOptimizer(const OptimizerParam & p);
   bool solve(
     const double initial_vel, const double initial_acc, const int closest,
-    const autoware_planning_msgs::Trajectory & input,
-    autoware_planning_msgs::Trajectory * output) override;
+    const autoware_planning_msgs::msg::Trajectory & input,
+    autoware_planning_msgs::msg::Trajectory * output) override;
 
   void setAccel(const double max_accel) override;
 

--- a/planning/scenario_planning/common/motion_velocity_optimizer/include/motion_velocity_optimizer/optimizer/linf_pseudo_jerk_optimizer.hpp
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/include/motion_velocity_optimizer/optimizer/linf_pseudo_jerk_optimizer.hpp
@@ -17,9 +17,9 @@
 #ifndef MOTION_VELOCITY_OPTIMIZER_LINF_PSEUDO_JERK_OPTIMIZER_HPP
 #define MOTION_VELOCITY_OPTIMIZER_LINF_PSEUDO_JERK_OPTIMIZER_HPP
 
-#include <autoware_planning_msgs/Trajectory.h>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <osqp_interface/osqp_interface.h>
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <vector>
 
 #include <motion_velocity_optimizer/optimizer/optimizer_base.hpp>
@@ -40,8 +40,8 @@ public:
   explicit LinfPseudoJerkOptimizer(const OptimizerParam & p);
   bool solve(
     const double initial_vel, const double initial_acc, const int closest,
-    const autoware_planning_msgs::Trajectory & input,
-    autoware_planning_msgs::Trajectory * output) override;
+    const autoware_planning_msgs::msg::Trajectory & input,
+    autoware_planning_msgs::msg::Trajectory * output) override;
 
   void setAccel(const double max_accel) override;
 

--- a/planning/scenario_planning/common/motion_velocity_optimizer/include/motion_velocity_optimizer/optimizer/optimizer_base.hpp
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/include/motion_velocity_optimizer/optimizer/optimizer_base.hpp
@@ -16,7 +16,7 @@
 
 #ifndef MOTION_VELOCITY_OPTIMIZER_OPTIMIZER_BASE_HPP
 #define MOTION_VELOCITY_OPTIMIZER_OPTIMIZER_BASE_HPP
-#include <autoware_planning_msgs/Trajectory.h>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <limits>
 #include <vector>
 
@@ -25,8 +25,8 @@ class OptimizerBase
 public:
   virtual bool solve(
     const double initial_vel, const double initial_acc, const int closest,
-    const autoware_planning_msgs::Trajectory & input,
-    autoware_planning_msgs::Trajectory * output) = 0;
+    const autoware_planning_msgs::msg::Trajectory & input,
+    autoware_planning_msgs::msg::Trajectory * output) = 0;
 
   virtual void setAccel(const double max_accel) = 0;
 

--- a/planning/scenario_planning/common/motion_velocity_optimizer/package.xml
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/package.xml
@@ -8,21 +8,21 @@
 
   <license>Apache 2.0</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>std_msgs</build_export_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 
-  <depend>autoware_planning_msgs</depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+
+  <depend>rclcpp</depend>
   <depend>boost</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>autoware_planning_msgs</depend>
+  <depend>autoware_debug_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>osqp_interface</depend>
+  <depend>eigen</depend>
 
-  <export>
-  </export>
 </package>

--- a/planning/scenario_planning/common/motion_velocity_optimizer/src/interpolate.cpp
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/src/interpolate.cpp
@@ -91,9 +91,9 @@ bool LinearInterpolate::interpolate(
  * spline interpolation
  */
 
-SplineInterpolate::SplineInterpolate(){};
-SplineInterpolate::SplineInterpolate(const std::vector<double> & x) { generateSpline(x); };
-SplineInterpolate::~SplineInterpolate(){};
+SplineInterpolate::SplineInterpolate(){}
+SplineInterpolate::SplineInterpolate(const std::vector<double> & x) { generateSpline(x); }
+SplineInterpolate::~SplineInterpolate(){}
 void SplineInterpolate::generateSpline(const std::vector<double> & x)
 {
   int N = x.size();
@@ -129,7 +129,7 @@ void SplineInterpolate::generateSpline(const std::vector<double> & x)
   b_.push_back(0.0);
 
   initialized_ = true;
-};
+}
 
 double SplineInterpolate::getValue(const double & s)
 {

--- a/planning/scenario_planning/common/motion_velocity_optimizer/src/motion_velocity_optimizer_utils.cpp
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/src/motion_velocity_optimizer_utils.cpp
@@ -20,48 +20,48 @@
 namespace vpu
 {
 double square(const double & a) { return a * a; }
-double calcSquaredDist2d(const geometry_msgs::Point & a, const geometry_msgs::Point & b)
+double calcSquaredDist2d(const geometry_msgs::msg::Point & a, const geometry_msgs::msg::Point & b)
 {
   return square(a.x - b.x) + square(a.y - b.y);
 }
-double calcSquaredDist2d(const geometry_msgs::Pose & a, const geometry_msgs::Pose & b)
+double calcSquaredDist2d(const geometry_msgs::msg::Pose & a, const geometry_msgs::msg::Pose & b)
 {
   return square(a.position.x - b.position.x) + square(a.position.y - b.position.y);
 }
-double calcSquaredDist2d(const geometry_msgs::PoseStamped & a, const geometry_msgs::PoseStamped & b)
+double calcSquaredDist2d(const geometry_msgs::msg::PoseStamped & a, const geometry_msgs::msg::PoseStamped & b)
 {
   return square(a.pose.position.x - b.pose.position.x) +
          square(a.pose.position.y - b.pose.position.y);
 }
 double calcSquaredDist2d(
-  const autoware_planning_msgs::TrajectoryPoint & a,
-  const autoware_planning_msgs::TrajectoryPoint & b)
+  const autoware_planning_msgs::msg::TrajectoryPoint & a,
+  const autoware_planning_msgs::msg::TrajectoryPoint & b)
 {
   return square(a.pose.position.x - b.pose.position.x) +
          square(a.pose.position.y - b.pose.position.y);
 }
 
-double calcDist2d(const geometry_msgs::Point & a, const geometry_msgs::Point & b)
+double calcDist2d(const geometry_msgs::msg::Point & a, const geometry_msgs::msg::Point & b)
 {
   return std::sqrt(calcSquaredDist2d(a, b));
 }
-double calcDist2d(const geometry_msgs::Pose & a, const geometry_msgs::Pose & b)
+double calcDist2d(const geometry_msgs::msg::Pose & a, const geometry_msgs::msg::Pose & b)
 {
   return std::sqrt(calcSquaredDist2d(a, b));
 }
-double calcDist2d(const geometry_msgs::PoseStamped & a, const geometry_msgs::PoseStamped & b)
+double calcDist2d(const geometry_msgs::msg::PoseStamped & a, const geometry_msgs::msg::PoseStamped & b)
 {
   return std::sqrt(calcSquaredDist2d(a, b));
 }
 double calcDist2d(
-  const autoware_planning_msgs::TrajectoryPoint & a,
-  const autoware_planning_msgs::TrajectoryPoint & b)
+  const autoware_planning_msgs::msg::TrajectoryPoint & a,
+  const autoware_planning_msgs::msg::TrajectoryPoint & b)
 {
   return std::sqrt(calcSquaredDist2d(a, b));
 }
 
 int calcClosestWaypoint(
-  const autoware_planning_msgs::Trajectory & traj, const geometry_msgs::Point & point)
+  const autoware_planning_msgs::msg::Trajectory & traj, const geometry_msgs::msg::Point & point)
 {
   double dist_squared_min = std::numeric_limits<double>::max();
   int idx_min = -1;
@@ -79,7 +79,7 @@ int calcClosestWaypoint(
 }
 
 int calcClosestWaypoint(
-  const autoware_planning_msgs::Trajectory & trajectory, const geometry_msgs::Pose & pose,
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const geometry_msgs::msg::Pose & pose,
   const double delta_yaw_threshold)
 {
   double dist_squared_min = std::numeric_limits<double>::max();
@@ -102,9 +102,9 @@ int calcClosestWaypoint(
 }
 
 bool extractPathAroundIndex(
-  const autoware_planning_msgs::Trajectory & trajectory, const int index,
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const int index,
   const double & ahead_length, const double & behind_length,
-  autoware_planning_msgs::Trajectory & extracted_base_trajectory)
+  autoware_planning_msgs::msg::Trajectory & extracted_base_trajectory)
 {
   if (trajectory.points.size() == 0 || (int)trajectory.points.size() - 1 < index || index < 0) {
     return false;
@@ -144,7 +144,7 @@ bool extractPathAroundIndex(
 }
 
 double calcLengthOnWaypoints(
-  const autoware_planning_msgs::Trajectory & path, const int idx1, const int idx2)
+  const autoware_planning_msgs::msg::Trajectory & path, const int idx1, const int idx2)
 {
   if (idx1 == idx2)  // zero distance
     return 0.0;
@@ -166,32 +166,32 @@ double calcLengthOnWaypoints(
 }
 
 void calcTrajectoryArclength(
-  const autoware_planning_msgs::Trajectory & trajectory, std::vector<double> & arclength)
+  const autoware_planning_msgs::msg::Trajectory & trajectory, std::vector<double> & arclength)
 {
   double dist = 0.0;
   arclength.clear();
   arclength.push_back(dist);
   for (unsigned int i = 1; i < trajectory.points.size(); ++i) {
-    const autoware_planning_msgs::TrajectoryPoint tp = trajectory.points.at(i);
-    const autoware_planning_msgs::TrajectoryPoint tp_prev = trajectory.points.at(i - 1);
+    const autoware_planning_msgs::msg::TrajectoryPoint tp = trajectory.points.at(i);
+    const autoware_planning_msgs::msg::TrajectoryPoint tp_prev = trajectory.points.at(i - 1);
     dist += vpu::calcDist2d(tp.pose, tp_prev.pose);
     arclength.push_back(dist);
   }
 }
 
 void calcTrajectoryIntervalDistance(
-  const autoware_planning_msgs::Trajectory & trajectory, std::vector<double> & intervals)
+  const autoware_planning_msgs::msg::Trajectory & trajectory, std::vector<double> & intervals)
 {
   intervals.clear();
   for (unsigned int i = 1; i < trajectory.points.size(); ++i) {
-    const autoware_planning_msgs::TrajectoryPoint tp = trajectory.points.at(i);
-    const autoware_planning_msgs::TrajectoryPoint tp_prev = trajectory.points.at(i - 1);
+    const autoware_planning_msgs::msg::TrajectoryPoint tp = trajectory.points.at(i);
+    const autoware_planning_msgs::msg::TrajectoryPoint tp_prev = trajectory.points.at(i - 1);
     const double dist = vpu::calcDist2d(tp.pose, tp_prev.pose);
     intervals.push_back(dist);
   }
 }
 
-void setZeroVelocity(autoware_planning_msgs::Trajectory & trajectory)
+void setZeroVelocity(autoware_planning_msgs::msg::Trajectory & trajectory)
 {
   for (auto & tp : trajectory.points) {
     tp.twist.linear.x = 0.0;
@@ -199,7 +199,7 @@ void setZeroVelocity(autoware_planning_msgs::Trajectory & trajectory)
   return;
 }
 
-double getMaxVelocity(const autoware_planning_msgs::Trajectory & trajectory)
+double getMaxVelocity(const autoware_planning_msgs::msg::Trajectory & trajectory)
 {
   double max_vel = 0.0;
   for (auto & tp : trajectory.points) {
@@ -208,7 +208,7 @@ double getMaxVelocity(const autoware_planning_msgs::Trajectory & trajectory)
   return max_vel;
 }
 
-double getMaxAbsVelocity(const autoware_planning_msgs::Trajectory & trajectory)
+double getMaxAbsVelocity(const autoware_planning_msgs::msg::Trajectory & trajectory)
 {
   double max_vel = 0.0;
   for (auto & tp : trajectory.points) {
@@ -218,14 +218,14 @@ double getMaxAbsVelocity(const autoware_planning_msgs::Trajectory & trajectory)
   return max_vel;
 }
 
-void mininumVelocityFilter(const double & min_vel, autoware_planning_msgs::Trajectory & trajectory)
+void mininumVelocityFilter(const double & min_vel, autoware_planning_msgs::msg::Trajectory & trajectory)
 {
   for (auto & tp : trajectory.points) {
     if (tp.twist.linear.x < min_vel) tp.twist.linear.x = min_vel;
   }
 }
 
-void maximumVelocityFilter(const double & max_vel, autoware_planning_msgs::Trajectory & trajectory)
+void maximumVelocityFilter(const double & max_vel, autoware_planning_msgs::msg::Trajectory & trajectory)
 {
   const double abs_max_vel = std::fabs(max_vel);
   for (auto & tp : trajectory.points) {
@@ -236,7 +236,7 @@ void maximumVelocityFilter(const double & max_vel, autoware_planning_msgs::Traje
   }
 }
 void multiplyConstantToTrajectoryVelocity(
-  const double & scalar, autoware_planning_msgs::Trajectory & trajectory)
+  const double & scalar, autoware_planning_msgs::msg::Trajectory & trajectory)
 {
   for (auto & tp : trajectory.points) {
     tp.twist.linear.x *= scalar;
@@ -244,7 +244,7 @@ void multiplyConstantToTrajectoryVelocity(
 }
 
 void insertZeroVelocityAfterIdx(
-  const int & stop_idx, autoware_planning_msgs::Trajectory & trajectory)
+  const int & stop_idx, autoware_planning_msgs::msg::Trajectory & trajectory)
 {
   if (stop_idx < 0) return;
 
@@ -253,12 +253,12 @@ void insertZeroVelocityAfterIdx(
   }
 }
 
-double getVx(const autoware_planning_msgs::Trajectory & trajectory, const int & i)
+double getVx(const autoware_planning_msgs::msg::Trajectory & trajectory, const int & i)
 {
   return trajectory.points.at(i).twist.linear.x;
 }
 
-bool searchZeroVelocityIdx(const autoware_planning_msgs::Trajectory & trajectory, int & idx)
+bool searchZeroVelocityIdx(const autoware_planning_msgs::msg::Trajectory & trajectory, int & idx)
 {
   for (unsigned int i = 0; i < trajectory.points.size(); ++i) {
     if (std::fabs(vpu::getVx(trajectory, i)) < 1.0E-3) {
@@ -270,12 +270,12 @@ bool searchZeroVelocityIdx(const autoware_planning_msgs::Trajectory & trajectory
 }
 
 bool calcTrajectoryCurvatureFrom3Points(
-  const autoware_planning_msgs::Trajectory & trajectory, const unsigned int & idx_dist,
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const unsigned int & idx_dist,
   std::vector<double> & k_arr)
 {
   k_arr.clear();
   if (trajectory.points.size() < 2 * idx_dist + 1) {
-    ROS_DEBUG(
+    RCLCPP_DEBUG(rclcpp::get_logger("motion_velocity_optimizer_utils"),
       "[calcTrajectoryCurvatureFrom3Points] cannot calc curvature idx_dist = %d, trajectory.size() "
       "= %lu",
       idx_dist, trajectory.points.size());
@@ -286,7 +286,7 @@ bool calcTrajectoryCurvatureFrom3Points(
   }
 
   /* calculate curvature by circle fitting from three points */
-  geometry_msgs::Point p1, p2, p3;
+  geometry_msgs::msg::Point p1, p2, p3;
   for (unsigned int i = idx_dist; i < trajectory.points.size() - idx_dist; ++i) {
     p1.x = trajectory.points.at(i - idx_dist).pose.position.x;
     p2.x = trajectory.points.at(i).pose.position.x;
@@ -301,7 +301,9 @@ bool calcTrajectoryCurvatureFrom3Points(
 
   // for debug
   if (k_arr.size() == 0) {
-    ROS_ERROR("[calcTrajectoryCurvatureFrom3Points] k_arr.size() = 0, somthing wrong. pls check.");
+    RCLCPP_ERROR(
+      rclcpp::get_logger("motion_velocity_optimizer_utils"),
+      "[calcTrajectoryCurvatureFrom3Points] k_arr.size() = 0, somthing wrong. pls check.");
     return false;
   }
 
@@ -331,7 +333,7 @@ void convertEulerAngleToMonotonic(std::vector<double> & a)
   }
 }
 
-geometry_msgs::Quaternion getQuaternionFromYaw(double yaw)
+geometry_msgs::msg::Quaternion getQuaternionFromYaw(double yaw)
 {
   tf2::Quaternion q;
   q.setRPY(0, 0, yaw);
@@ -340,8 +342,8 @@ geometry_msgs::Quaternion getQuaternionFromYaw(double yaw)
 
 bool linearInterpTrajectory(
   const std::vector<double> & base_index,
-  const autoware_planning_msgs::Trajectory & base_trajectory, const std::vector<double> & out_index,
-  autoware_planning_msgs::Trajectory & out_trajectory)
+  const autoware_planning_msgs::msg::Trajectory & base_trajectory, const std::vector<double> & out_index,
+  autoware_planning_msgs::msg::Trajectory & out_trajectory)
 {
   std::vector<double> px, py, pz, pyaw, tlx, taz, alx, aaz;
   for (const auto & p : base_trajectory.points) {
@@ -368,13 +370,15 @@ bool linearInterpTrajectory(
     !LinearInterpolate::interpolate(base_index, taz, out_index, taz_p) ||
     !LinearInterpolate::interpolate(base_index, alx, out_index, alx_p) ||
     !LinearInterpolate::interpolate(base_index, aaz, out_index, aaz_p)) {
-    ROS_WARN("[linearInterpTrajectory] interpolation error!!");
+    RCLCPP_WARN(
+      rclcpp::get_logger("motion_velocity_optimizer_utils"),
+      "[linearInterpTrajectory] interpolation error!!");
     return false;
   }
 
   out_trajectory.header = base_trajectory.header;
   out_trajectory.points.clear();
-  autoware_planning_msgs::TrajectoryPoint point;
+  autoware_planning_msgs::msg::TrajectoryPoint point;
   for (unsigned int i = 0; i < out_index.size(); ++i) {
     point.pose.position.x = px_p.at(i);
     point.pose.position.y = py_p.at(i);

--- a/planning/scenario_planning/common/motion_velocity_optimizer/src/optimizer/pseudo_jerk_l2_optimizer.cpp
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/src/optimizer/pseudo_jerk_l2_optimizer.cpp
@@ -30,26 +30,32 @@ void L2PseudoJerkOptimizer::setDecel(const double min_decel) { param_.min_decel 
 
 bool L2PseudoJerkOptimizer::solve(
   const double initial_vel, const double initial_acc, const int closest,
-  const autoware_planning_msgs::Trajectory & input, autoware_planning_msgs::Trajectory * output)
+  const autoware_planning_msgs::msg::Trajectory & input,
+  autoware_planning_msgs::msg::Trajectory * output)
 {
   auto ts = std::chrono::system_clock::now();
 
   *output = input;
 
   if (static_cast<int>(input.points.size()) < closest) {
-    ROS_WARN("[MotionVelocityOptimizer] invalid closest.");
+    RCLCPP_WARN(
+      rclcpp::get_logger("L2PseudoJerkOptimizer"), "[MotionVelocityOptimizer] invalid closest.");
     return false;
   }
 
   if (std::fabs(input.points.at(closest).twist.linear.x) < 0.1) {
-    ROS_DEBUG("[MotionVelocityOptimizer] closest vmax < 0.1. assume vehicle stopped. return.");
+    RCLCPP_DEBUG(
+      rclcpp::get_logger("L2PseudoJerkOptimizer"),
+      "[MotionVelocityOptimizer] closest vmax < 0.1. assume vehicle stopped. return.");
     return false;
   }
 
   const unsigned int N = input.points.size() - closest;
 
   if (N < 2) {
-    ROS_WARN("[MotionVelocityOptimizer] trajectory length is not enough.");
+    RCLCPP_WARN(
+      rclcpp::get_logger("L2PseudoJerkOptimizer"),
+      "[MotionVelocityOptimizer] trajectory length is not enough.");
     return false;
   }
 
@@ -190,16 +196,18 @@ bool L2PseudoJerkOptimizer::solve(
   }
 
   // -- to check the all optimization variables --
-  // ROS_DEBUG("[after optimize Linf] idx, vel, acc, over_vel, over_acc ");
+  // RCLCPP_DEBUG(rclcpp::get_logger("L2PseudoJerkOptimizer"),"[after optimize Linf] idx, vel, acc, over_vel, over_acc ");
   // for (unsigned int i = 0; i < N; ++i) {
-  //   ROS_DEBUG(
+  //   RCLCPP_DEBUG(rclcpp::get_logger("L2PseudoJerkOptimizer"),
   //     "i = %d, v: %f, vmax: %f a: %f, b: %f, delta: %f, sigma: %f\n", i, std::sqrt(optval.at(i)),
   //     vmax[i], optval.at(i + N), optval.at(i), optval.at(i + 2 * N), optval.at(i + 3 * N));
   // }
 
   auto tf2 = std::chrono::system_clock::now();
   double dt_ms2 = std::chrono::duration_cast<std::chrono::nanoseconds>(tf2 - ts2).count() * 1.0e-6;
-  ROS_DEBUG("[optimization] init time = %f [ms], optimization time = %f [ms]", dt_ms1, dt_ms2);
+  RCLCPP_DEBUG(
+    rclcpp::get_logger("L2PseudoJerkOptimizer"),
+    "[optimization] init time = %f [ms], optimization time = %f [ms]", dt_ms1, dt_ms2);
 
   return true;
 }

--- a/planning/scenario_planning/common/motion_velocity_optimizer/src/optimizer/pseudo_jerk_linf_optimizer.cpp
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/src/optimizer/pseudo_jerk_linf_optimizer.cpp
@@ -29,19 +29,23 @@ void LinfPseudoJerkOptimizer::setDecel(const double min_decel) { param_.min_dece
 
 bool LinfPseudoJerkOptimizer::solve(
   const double initial_vel, const double initial_acc, const int closest,
-  const autoware_planning_msgs::Trajectory & input, autoware_planning_msgs::Trajectory * output)
+  const autoware_planning_msgs::msg::Trajectory & input,
+  autoware_planning_msgs::msg::Trajectory * output)
 {
   auto ts = std::chrono::system_clock::now();
 
   *output = input;
 
   if (static_cast<int>(input.points.size()) < closest) {
-    ROS_WARN("[MotionVelocityOptimizer::solveOptimization Linf] invalid closest.");
+    RCLCPP_WARN(
+      rclcpp::get_logger("LinfPseudoJerkOptimizer"),
+      "[MotionVelocityOptimizer::solveOptimization Linf] invalid closest.");
     return false;
   }
 
   if (std::fabs(input.points.at(closest).twist.linear.x) < 0.1) {
-    ROS_DEBUG(
+    RCLCPP_DEBUG(
+      rclcpp::get_logger("LinfPseudoJerkOptimizer"),
       "[MotionVelocityOptimizer::solveOptimization Linf] closest vmax < 0.1, keep stopping. "
       "return.");
     return false;
@@ -203,15 +207,17 @@ bool LinfPseudoJerkOptimizer::solve(
   }
 
   // -- to check the all optimization variables --
-  // ROS_DEBUG("[after optimize Linf] idx, vel, acc, over_vel, over_acc ");
+  // RCLCPP_DEBUG(rclcpp::get_logger("LinfPseudoJerkOptimizer"),"[after optimize Linf] idx, vel, acc, over_vel, over_acc ");
   // for (unsigned int i = 0; i < N; ++i) {
-  //   ROS_DEBUG(
+  //   RCLCPP_DEBUG(rclcpp::get_logger("LinfPseudoJerkOptimizer"),
   //     "i = %d, v: %f, vmax: %f a: %f, b: %f, delta: %f, sigma: %f", i, std::sqrt(optval.at(i)),
   //     vmax[i], optval.at(i + N), optval.at(i), optval.at(i + 2 * N), optval.at(i + 3 * N));
   // }
 
   auto tf2 = std::chrono::system_clock::now();
   double dt_ms2 = std::chrono::duration_cast<std::chrono::nanoseconds>(tf2 - ts2).count() * 1.0e-6;
-  ROS_DEBUG("[optimization] init time = %f [ms], optimization time = %f [ms]", dt_ms1, dt_ms2);
+  RCLCPP_DEBUG(
+    rclcpp::get_logger("LinfPseudoJerkOptimizer"),
+    "[optimization] init time = %f [ms], optimization time = %f [ms]", dt_ms1, dt_ms2);
   return true;
 }


### PR DESCRIPTION
Remarks
 - add autoware_planning_msgs/VelocityLimit.msg
 - replace boost::shared_ptr to std::shared_ptr
 - replace dynamic reconfigure to `add_on_set_parameters_callback`.
 - add `blockUntilVehiclePositionAvailable` as in mpc_follower porting

TODO
 - [x] needs osqp fix to be merged : https://github.com/tier4/Pilot.Auto/pull/66
 - [x] needs to add dynamic-reconfigure function
 - [x] wait for the tf-discussion