### PR TITLE
Port behavior_velocity_planner to ROS2

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -7,9 +7,3 @@ repositories:
     type: git
     url: https://github.com/tier4/ublox.git
     version: foxy-devel
-  # temporary adding geometry2 package to add support for transforming covariance
-  # TODO(mitsudome-r): remove after geometry2 package is released in Foxy anytime after 2020/10/30
-  vendor/geometry2:
-    type: git
-    url: https://github.com/ros2/geometry2.git
-    version: foxy

--- a/common/msgs/autoware_perception_msgs/CMakeLists.txt
+++ b/common/msgs/autoware_perception_msgs/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TRAFFIC_LIGHT_RECOGNITION_MSG_FILES
   "TrafficLightRoiArray.msg"
   "TrafficLightState.msg"
   "TrafficLightStateArray.msg"
+  "TrafficLightStateStamped.msg"
 )
 
 if(${ROS_VERSION} EQUAL 1)

--- a/localization/twist_estimator/pose2twist/package.xml
+++ b/localization/twist_estimator/pose2twist/package.xml
@@ -11,7 +11,6 @@
     <depend>geometry_msgs</depend>
     <depend>rclcpp</depend>
     <depend>std_msgs</depend>
-    <depend>tf2</depend>
     <depend>tf2_geometry_msgs</depend>
 
     <export>

--- a/map/lanelet2_extension/package.xml
+++ b/map/lanelet2_extension/package.xml
@@ -22,8 +22,6 @@
   <depend>lanelet2_validation</depend>
   <depend>autoware_lanelet2_msgs</depend>
   <depend>geometry_msgs</depend>
-  <depend>tf2</depend>
-  <depend>tf2_geometry_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>pugixml-dev</depend>
 

--- a/planning/mission_planning/mission_planner/package.xml
+++ b/planning/mission_planning/mission_planner/package.xml
@@ -14,7 +14,6 @@
   <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
   <depend>rclcpp</depend>
-  <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/CMakeLists.txt
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/CMakeLists.txt
@@ -1,8 +1,13 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(behavior_velocity_planner)
 
-# Compile as C++14, supported in ROS Melodic and newer
-add_compile_options(-std=c++14)
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
+endif()
 
 find_package(catkin REQUIRED COMPONENTS
   autoware_perception_msgs

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/CMakeLists.txt
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/CMakeLists.txt
@@ -9,49 +9,47 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
 endif()
 
-find_package(catkin REQUIRED COMPONENTS
+find_package(ament_cmake REQUIRED)
+find_package(autoware_perception_msgs REQUIRED)
+find_package(autoware_planning_msgs REQUIRED)
+find_package(eigen3_cmake_module REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(diagnostic_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(lanelet2_extension REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common)
+find_package(pcl_conversions REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(spline_interpolation REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_eigen REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(vehicle_info_util REQUIRED)
+find_package(visualization_msgs REQUIRED)
+
+set(BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES
+  ament_cmake
   autoware_perception_msgs
   autoware_planning_msgs
-  autoware_perception_msgs
+  Eigen3
+  diagnostic_msgs
   geometry_msgs
   lanelet2_extension
-  pcl_ros
-  roscpp
+  PCL
+  pcl_conversions
+  rclcpp
   sensor_msgs
   spline_interpolation
   tf2
   tf2_eigen
   tf2_geometry_msgs
   tf2_ros
+  vehicle_info_util
   visualization_msgs
 )
 
-find_package(Eigen3 REQUIRED)
-
-catkin_package(
-  INCLUDE_DIRS
-    include
-  CATKIN_DEPENDS
-    autoware_perception_msgs
-    autoware_planning_msgs
-    autoware_perception_msgs
-    geometry_msgs
-    lanelet2_extension
-    pcl_ros
-    sensor_msgs
-    spline_interpolation
-    tf2
-    tf2_eigen
-    tf2_geometry_msgs
-    tf2_ros
-    visualization_msgs
-)
-
-include_directories(
-  include
-  ${EIGEN3_INCLUDE_DIRS}
-  ${catkin_INCLUDE_DIRS}
-)
 
 # Common
 add_library(scene_module_lib STATIC
@@ -60,14 +58,14 @@ add_library(scene_module_lib STATIC
   src/utilization/interpolate.cpp
 )
 
-add_dependencies(scene_module_lib
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_lib
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_lib
-  ${catkin_LIBRARIES}
-)
+ament_target_dependencies(scene_module_lib ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
 
 # Scene Module: Stop Line
 add_library(scene_module_stop_line STATIC
@@ -76,15 +74,16 @@ add_library(scene_module_stop_line STATIC
   src/scene_module/stop_line/debug.cpp
 )
 
-add_dependencies(scene_module_stop_line
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_stop_line
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_stop_line
-  scene_module_lib
-  ${catkin_LIBRARIES}
-)
+ament_target_dependencies(scene_module_stop_line ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(scene_module_stop_line scene_module_lib)
+
 
 # Scene Module: Crosswalk
 add_library(scene_module_crosswalk STATIC
@@ -95,15 +94,16 @@ add_library(scene_module_crosswalk STATIC
   src/scene_module/crosswalk/util.cpp
 )
 
-add_dependencies(scene_module_crosswalk
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_crosswalk
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_crosswalk
-  scene_module_lib
-  ${catkin_LIBRARIES}
-)
+ament_target_dependencies(scene_module_crosswalk ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(scene_module_crosswalk scene_module_lib)
+
 
 # Scene Module: Intersection
 add_library(scene_module_intersection STATIC
@@ -114,15 +114,16 @@ add_library(scene_module_intersection STATIC
   src/scene_module/intersection/util.cpp
 )
 
-add_dependencies(scene_module_intersection
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_intersection
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_intersection
-  scene_module_lib
-  ${catkin_LIBRARIES}
-)
+ament_target_dependencies(scene_module_intersection ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(scene_module_intersection scene_module_lib)
+
 
 # Scene Module: Traffic Light
 add_library(scene_module_traffic_light STATIC
@@ -131,15 +132,16 @@ add_library(scene_module_traffic_light STATIC
   src/scene_module/traffic_light/debug.cpp
 )
 
-add_dependencies(scene_module_traffic_light
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_traffic_light
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_traffic_light
-  scene_module_lib
-  ${catkin_LIBRARIES}
-)
+ament_target_dependencies(scene_module_traffic_light ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(scene_module_traffic_light scene_module_lib)
+
 
 # Scene Module: Blind Spot
 add_library(scene_module_blind_spot STATIC
@@ -148,15 +150,16 @@ add_library(scene_module_blind_spot STATIC
   src/scene_module/blind_spot/debug.cpp
 )
 
-add_dependencies(scene_module_blind_spot
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_blind_spot
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_blind_spot
-  scene_module_lib
-  ${catkin_LIBRARIES}
-)
+ament_target_dependencies(scene_module_blind_spot ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(scene_module_blind_spot scene_module_lib)
+
 
 # Scene Module: Detection Area
 add_library(scene_module_detection_area STATIC
@@ -165,34 +168,32 @@ add_library(scene_module_detection_area STATIC
   src/scene_module/detection_area/debug.cpp
 )
 
-add_dependencies(scene_module_detection_area
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_detection_area
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_detection_area
-  scene_module_lib
-  ${catkin_LIBRARIES}
-)
+ament_target_dependencies(scene_module_detection_area ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(scene_module_detection_area scene_module_lib)
+
 
 # Scene Module Manager
 add_library(scene_module_manager STATIC
   src/planner_manager.cpp
 )
 
-add_dependencies(scene_module_manager
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_manager
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_manager
-  scene_module_stop_line
-  scene_module_crosswalk
-  scene_module_intersection
-  scene_module_traffic_light
-  scene_module_blind_spot
-  scene_module_detection_area
-)
+ament_target_dependencies(scene_module_manager ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(scene_module_manager scene_module_lib)
+
 
 # Node
 add_executable(behavior_velocity_planner_node
@@ -200,27 +201,24 @@ add_executable(behavior_velocity_planner_node
   src/main.cpp
 )
 
-add_dependencies(behavior_velocity_planner_node
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(behavior_velocity_planner_node
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
+
+ament_target_dependencies(behavior_velocity_planner_node ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES} )
 
 target_link_libraries(behavior_velocity_planner_node
+  scene_module_lib
+  scene_module_stop_line
+  scene_module_crosswalk
+  scene_module_intersection
+  scene_module_traffic_light
+  scene_module_blind_spot
+  scene_module_detection_area
   scene_module_manager
-  ${catkin_LIBRARIES}
 )
 
-install(
-  TARGETS
-    behavior_velocity_planner_node
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-install(
-  DIRECTORY
-    config
-    launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+ament_export_dependencies(${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+ament_package()

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/CMakeLists.txt
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/CMakeLists.txt
@@ -9,30 +9,20 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
 endif()
 
+# Find the non-obvious packages manually
 find_package(ament_cmake REQUIRED)
-find_package(autoware_perception_msgs REQUIRED)
-find_package(autoware_planning_msgs REQUIRED)
+find_package(Boost REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(diagnostic_msgs REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(lanelet2_extension REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
-find_package(pcl_conversions REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(spline_interpolation REQUIRED)
-find_package(tf2 REQUIRED)
-find_package(tf2_eigen REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
-find_package(tf2_ros REQUIRED)
-find_package(vehicle_info_util REQUIRED)
-find_package(visualization_msgs REQUIRED)
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 set(BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES
-  ament_cmake
   autoware_perception_msgs
   autoware_planning_msgs
+  Boost
   Eigen3
   diagnostic_msgs
   geometry_msgs

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/node.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/node.h
@@ -28,7 +28,7 @@
 #include <behavior_velocity_planner/planner_data.h>
 #include <behavior_velocity_planner/planner_manager.h>
 
-class BehaviorVelocityPlannerNode: public rclcpp::Node
+class BehaviorVelocityPlannerNode : public rclcpp::Node
 {
 public:
   BehaviorVelocityPlannerNode();
@@ -39,26 +39,31 @@ private:
   tf2_ros::TransformListener tf_listener_;
 
   // subscriber
-  rclcpp::Subscription<autoware_planning_msgs::msg::PathWithLaneId>::SharedPtr trigger_sub_path_with_lane_id_;
-  rclcpp::Subscription<autoware_perception_msgs::msg::DynamicObjectArray>::SharedPtr sub_dynamic_objects_;
+  rclcpp::Subscription<autoware_planning_msgs::msg::PathWithLaneId>::SharedPtr
+    trigger_sub_path_with_lane_id_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::DynamicObjectArray>::SharedPtr
+    sub_dynamic_objects_;
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_no_ground_pointcloud_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_vehicle_velocity_;
   rclcpp::Subscription<autoware_lanelet2_msgs::msg::MapBin>::SharedPtr sub_lanelet_map_;
-  rclcpp::Subscription<autoware_perception_msgs::msg::TrafficLightStateArray>::SharedPtr sub_traffic_light_states_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::TrafficLightStateArray>::SharedPtr
+    sub_traffic_light_states_;
 
   void onTrigger(const autoware_planning_msgs::msg::PathWithLaneId::ConstSharedPtr input_path_msg);
-  void onDynamicObjects(const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr msg);
+  void onDynamicObjects(
+    const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr msg);
   void onNoGroundPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
   void onVehicleVelocity(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
   void onLaneletMap(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr msg);
-  void onTrafficLightStates(const autoware_perception_msgs::msg::TrafficLightStateArray::ConstSharedPtr msg);
+  void onTrafficLightStates(
+    const autoware_perception_msgs::msg::TrafficLightStateArray::ConstSharedPtr msg);
 
   // publisher
   rclcpp::Publisher<autoware_planning_msgs::msg::Path>::SharedPtr path_pub_;
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticStatus>::SharedPtr stop_reason_diag_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
 
-  void publishDebugMarker(const autoware_planning_msgs::msg::Path & path, const rclcpp::Publisher & pub);
+  void publishDebugMarker(const autoware_planning_msgs::msg::Path & path);
 
   //  parameter
   double forward_path_length_;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/node.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/node.h
@@ -18,51 +18,47 @@
 #include <memory>
 #include <string>
 
-#include <autoware_lanelet2_msgs/MapBin.h>
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <autoware_planning_msgs/Path.h>
-#include <autoware_planning_msgs/PathWithLaneId.h>
-#include <ros/ros.h>
-#include <sensor_msgs/PointCloud2.h>
+#include <autoware_lanelet2_msgs/msg/map_bin.hpp>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_planning_msgs/msg/path.hpp>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <behavior_velocity_planner/planner_data.h>
 #include <behavior_velocity_planner/planner_manager.h>
 
-class BehaviorVelocityPlannerNode
+class BehaviorVelocityPlannerNode: public rclcpp::Node
 {
 public:
   BehaviorVelocityPlannerNode();
 
 private:
-  // node handle
-  ros::NodeHandle nh_;
-  ros::NodeHandle pnh_;
-
   // tf
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 
   // subscriber
-  ros::Subscriber trigger_sub_path_with_lane_id_;
-  ros::Subscriber sub_dynamic_objects_;
-  ros::Subscriber sub_no_ground_pointcloud_;
-  ros::Subscriber sub_vehicle_velocity_;
-  ros::Subscriber sub_traffic_light_states_;
-  ros::Subscriber sub_lanelet_map_;
+  rclcpp::Subscription<autoware_planning_msgs::msg::PathWithLaneId>::SharedPtr trigger_sub_path_with_lane_id_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::DynamicObjectArray>::SharedPtr sub_dynamic_objects_;
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_no_ground_pointcloud_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_vehicle_velocity_;
+  rclcpp::Subscription<autoware_lanelet2_msgs::msg::MapBin>::SharedPtr sub_lanelet_map_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::TrafficLightStateArray>::SharedPtr sub_traffic_light_states_;
 
-  void onTrigger(const autoware_planning_msgs::PathWithLaneId & input_path_msg);
-  void onDynamicObjects(const autoware_perception_msgs::DynamicObjectArray::ConstPtr & msg);
-  void onNoGroundPointCloud(const sensor_msgs::PointCloud2::ConstPtr & msg);
-  void onVehicleVelocity(const geometry_msgs::TwistStamped::ConstPtr & msg);
-  void onLaneletMap(const autoware_lanelet2_msgs::MapBin::ConstPtr & msg);
-  void onTrafficLightStates(const autoware_perception_msgs::TrafficLightStateArray::ConstPtr & msg);
+  void onTrigger(const autoware_planning_msgs::msg::PathWithLaneId::ConstSharedPtr input_path_msg);
+  void onDynamicObjects(const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr msg);
+  void onNoGroundPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
+  void onVehicleVelocity(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
+  void onLaneletMap(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr msg);
+  void onTrafficLightStates(const autoware_perception_msgs::msg::TrafficLightStateArray::ConstSharedPtr msg);
 
   // publisher
-  ros::Publisher path_pub_;
-  ros::Publisher stop_reason_diag_pub_;
-  ros::Publisher debug_viz_pub_;
+  rclcpp::Publisher<autoware_planning_msgs::msg::Path>::SharedPtr path_pub_;
+  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticStatus>::SharedPtr stop_reason_diag_pub_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
 
-  void publishDebugMarker(const autoware_planning_msgs::Path & path, const ros::Publisher & pub);
+  void publishDebugMarker(const autoware_planning_msgs::msg::Path & path, const rclcpp::Publisher & pub);
 
   //  parameter
   double forward_path_length_;
@@ -73,6 +69,6 @@ private:
   BehaviorVelocityPlannerManager planner_manager_;
 
   // function
-  geometry_msgs::PoseStamped getCurrentPose();
+  geometry_msgs::msg::PoseStamped getCurrentPose();
   bool isDataReady();
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.h
@@ -24,14 +24,14 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
-#include <autoware_lanelet2_msgs/MapBin.h>
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <autoware_perception_msgs/TrafficLightStateArray.h>
-#include <autoware_perception_msgs/TrafficLightStateStamped.h>
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/TwistStamped.h>
-#include <sensor_msgs/PointCloud2.h>
-#include <std_msgs/Header.h>
+#include <autoware_lanelet2_msgs/msg/map_bin.hpp>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_state_array.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_state_stamped.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <std_msgs/msg/header.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
@@ -42,16 +42,16 @@
 struct PlannerData
 {
   // tf
-  geometry_msgs::PoseStamped current_pose;
+  geometry_msgs::msg::PoseStamped current_pose;
 
   // msgs from callbacks that are used for data-ready
-  geometry_msgs::TwistStamped::ConstPtr current_velocity;
-  autoware_perception_msgs::DynamicObjectArray::ConstPtr dynamic_objects;
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr current_velocity;
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr dynamic_objects;
   pcl::PointCloud<pcl::PointXYZ>::ConstPtr no_ground_pointcloud;
   lanelet::LaneletMapPtr lanelet_map;
 
   // other internal data
-  std::map<int, autoware_perception_msgs::TrafficLightStateStamped> traffic_light_id_map_;
+  std::map<int, autoware_perception_msgs::msg::TrafficLightStateStamped> traffic_light_id_map_;
   lanelet::traffic_rules::TrafficRulesPtr traffic_rules;
   lanelet::routing::RoutingGraphPtr routing_graph;
   std::shared_ptr<const lanelet::routing::RoutingGraphContainer> overall_graphs;
@@ -72,11 +72,11 @@ struct PlannerData
     return current_velocity->twist.linear.x < 0.1;
   }
 
-  std::shared_ptr<autoware_perception_msgs::TrafficLightStateStamped> getTrafficLightState(const int id) const
+  std::shared_ptr<autoware_perception_msgs::msg::TrafficLightStateStamped> getTrafficLightState(const int id) const
   {
     if (traffic_light_id_map_.count(id) == 0) {
       return {};
     }
-    return std::make_shared<autoware_perception_msgs::TrafficLightStateStamped>(traffic_light_id_map_.at(id));
+    return std::make_shared<autoware_perception_msgs::msg::TrafficLightStateStamped>(traffic_light_id_map_.at(id));
   }
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.h
@@ -32,15 +32,21 @@
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/header.hpp>
+#include <vehicle_info_util/vehicle_info.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_routing/RoutingGraphContainer.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
 
-
 struct PlannerData
 {
+  PlannerData(rclcpp::Node & node) : vehicle_info_(vehicle_info_util::VehicleInfo::create(node))
+  {
+    max_stop_acceleration_threshold_ = node.declare_parameter(
+      "max_accel", -5.0);  // TODO read min_acc in velocity_controller_param.yaml?
+    delay_response_time_ = node.declare_parameter("delay_response_time", 1.3);
+  }
   // tf
   geometry_msgs::msg::PoseStamped current_pose;
 
@@ -57,10 +63,7 @@ struct PlannerData
   std::shared_ptr<const lanelet::routing::RoutingGraphContainer> overall_graphs;
 
   // parameters
-  double wheel_base;
-  double front_overhang;
-  double vehicle_width;
-  double base_link2front;
+  vehicle_info_util::VehicleInfo vehicle_info_;
 
   // additional parameters
   double max_stop_acceleration_threshold_;
@@ -72,11 +75,13 @@ struct PlannerData
     return current_velocity->twist.linear.x < 0.1;
   }
 
-  std::shared_ptr<autoware_perception_msgs::msg::TrafficLightStateStamped> getTrafficLightState(const int id) const
+  std::shared_ptr<autoware_perception_msgs::msg::TrafficLightStateStamped> getTrafficLightState(
+    const int id) const
   {
     if (traffic_light_id_map_.count(id) == 0) {
       return {};
     }
-    return std::make_shared<autoware_perception_msgs::msg::TrafficLightStateStamped>(traffic_light_id_map_.at(id));
+    return std::make_shared<autoware_perception_msgs::msg::TrafficLightStateStamped>(
+      traffic_light_id_map_.at(id));
   }
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_manager.h
@@ -20,13 +20,13 @@
 #include <string>
 #include <vector>
 
-#include <autoware_lanelet2_msgs/MapBin.h>
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <autoware_planning_msgs/Path.h>
-#include <autoware_planning_msgs/PathWithLaneId.h>
-#include <diagnostic_msgs/DiagnosticStatus.h>
-#include <ros/ros.h>
-#include <sensor_msgs/PointCloud2.h>
+#include <autoware_lanelet2_msgs/msg/map_bin.hpp>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_planning_msgs/msg/path.hpp>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tf2_ros/transform_listener.h>
 
 #include <lanelet2_core/LaneletMap.h>
@@ -41,13 +41,13 @@ public:
   void launchSceneModule(
     const std::shared_ptr<SceneModuleManagerInterface> & scene_module_manager_ptr);
 
-  autoware_planning_msgs::PathWithLaneId planPathVelocity(
+  autoware_planning_msgs::msg::PathWithLaneId planPathVelocity(
     const std::shared_ptr<const PlannerData> & planner_data,
-    const autoware_planning_msgs::PathWithLaneId & input_path_msg);
+    const autoware_planning_msgs::msg::PathWithLaneId & input_path_msg);
 
-  diagnostic_msgs::DiagnosticStatus getStopReasonDiag();
+  diagnostic_msgs::msg::DiagnosticStatus getStopReasonDiag();
 
 private:
   std::vector<std::shared_ptr<SceneModuleManagerInterface>> scene_manager_ptrs_;
-  diagnostic_msgs::DiagnosticStatus stop_reason_diag_;
+  diagnostic_msgs::msg::DiagnosticStatus stop_reason_diag_;
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_manager.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include <tf2_ros/transform_listener.h>
 #include <autoware_lanelet2_msgs/msg/map_bin.hpp>
 #include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
 #include <autoware_planning_msgs/msg/path.hpp>
@@ -27,7 +28,6 @@
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tf2_ros/transform_listener.h>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/blind_spot/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/blind_spot/manager.h
@@ -20,13 +20,13 @@
 #include <string>
 #include <vector>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include <autoware_perception_msgs/DynamicObject.h>
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <autoware_planning_msgs/PathWithLaneId.h>
-#include <geometry_msgs/Point.h>
-#include <std_msgs/Float32MultiArray.h>
+#include <autoware_perception_msgs/msg/dynamic_object.hpp>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <std_msgs/msg/float32_multi_array.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
@@ -44,8 +44,8 @@ public:
 private:
   BlindSpotModule::PlannerParam planner_param_;
 
-  void launchNewModules(const autoware_planning_msgs::PathWithLaneId & path) override;
+  void launchNewModules(const autoware_planning_msgs::msg::PathWithLaneId & path) override;
 
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
-    const autoware_planning_msgs::PathWithLaneId & path) override;
+    const autoware_planning_msgs::msg::PathWithLaneId & path) override;
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/blind_spot/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/blind_spot/manager.h
@@ -15,21 +15,12 @@
  */
 #pragma once
 
+#include <functional>
 #include <memory>
-#include <set>
-#include <string>
-#include <vector>
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_perception_msgs/msg/dynamic_object.hpp>
-#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
 #include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
-#include <geometry_msgs/msg/point.hpp>
-#include <std_msgs/msg/float32_multi_array.hpp>
-
-#include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_routing/RoutingGraph.h>
 
 #include <scene_module/blind_spot/scene.h>
 #include <scene_module/scene_module_interface.h>
@@ -37,7 +28,7 @@
 class BlindSpotModuleManager : public SceneModuleManagerInterface
 {
 public:
-  BlindSpotModuleManager();
+  BlindSpotModuleManager(rclcpp::Node & node);
 
   const char * getModuleName() override { return "blind_spot"; }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.h
@@ -21,19 +21,19 @@
 
 #include <boost/optional.hpp>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include <autoware_perception_msgs/DynamicObject.h>
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <autoware_planning_msgs/PathWithLaneId.h>
-#include <geometry_msgs/Point.h>
-#include <std_msgs/Float32MultiArray.h>
+#include <autoware_perception_msgs/msg/dynamic_object.hpp>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <std_msgs/msg/float32_multi_array.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
 #include <scene_module/scene_module_interface.h>
-#include "utilization/boost_geometry_helper.h"
+#include <utilization/boost_geometry_helper.h>
 
 struct BlindSpotPolygons
 {
@@ -79,20 +79,20 @@ public:
   private:
     State state_;                            //! current state
     double margin_time_;                     //! margin time when transit to Go from Stop
-    std::shared_ptr<ros::Time> start_time_;  //! first time received GO when STOP state
+    std::shared_ptr<rclcpp::Time> start_time_;  //! first time received GO when STOP state
   };
 
   struct DebugData
   {
-    autoware_planning_msgs::PathWithLaneId path_raw;
+    autoware_planning_msgs::msg::PathWithLaneId path_raw;
 
-    geometry_msgs::Pose virtual_wall_pose;
-    geometry_msgs::Pose stop_point_pose;
-    geometry_msgs::Pose judge_point_pose;
+    geometry_msgs::msg::Pose virtual_wall_pose;
+    geometry_msgs::msg::Pose stop_point_pose;
+    geometry_msgs::msg::Pose judge_point_pose;
     lanelet::CompoundPolygon3d confict_area_for_blind_spot;
     lanelet::CompoundPolygon3d detection_area_for_blind_spot;
-    autoware_planning_msgs::PathWithLaneId spline_path;
-    autoware_perception_msgs::DynamicObjectArray conflicting_targets;
+    autoware_planning_msgs::msg::PathWithLaneId spline_path;
+    autoware_perception_msgs::msg::DynamicObjectArray conflicting_targets;
   };
 
 public:
@@ -114,10 +114,10 @@ public:
    * and object predicted path
    */
   bool modifyPathVelocity(
-    autoware_planning_msgs::PathWithLaneId * path,
-    autoware_planning_msgs::StopReason * stop_reason) override;
+    autoware_planning_msgs::msg::PathWithLaneId * path,
+    autoware_planning_msgs::msg::StopReason * stop_reason) override;
 
-  visualization_msgs::MarkerArray createDebugMarkerArray() override;
+  visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
 
 private:
   int64_t lane_id_;
@@ -140,8 +140,8 @@ private:
   bool checkObstacleInBlindSpot(
     lanelet::LaneletMapConstPtr lanelet_map_ptr,
     lanelet::routing::RoutingGraphPtr routing_graph_ptr,
-    const autoware_planning_msgs::PathWithLaneId & path,
-    const autoware_perception_msgs::DynamicObjectArray::ConstPtr objects_ptr,
+    const autoware_planning_msgs::msg::PathWithLaneId & path,
+    const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr objects_ptr,
     const int closest_idx) const;
 
   /**
@@ -161,7 +161,7 @@ private:
   BlindSpotPolygons generateBlindSpotPolygons(
     lanelet::LaneletMapConstPtr lanelet_map_ptr,
     lanelet::routing::RoutingGraphPtr routing_graph_ptr,
-    const autoware_planning_msgs::PathWithLaneId & path, const int closest_idx) const;
+    const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx) const;
 
   /**
    * @brief Get vehicle edge
@@ -171,7 +171,7 @@ private:
    * @return edge of ego vehicle
    */
   lanelet::LineString2d getVehicleEdge(
-    const geometry_msgs::Pose & vehicle_pose, const double vehicle_width,
+    const geometry_msgs::msg::Pose & vehicle_pose, const double vehicle_width,
     const double base_link2front) const;
 
   /**
@@ -179,7 +179,7 @@ private:
    * @param object Dynamic object
    * @return True when object belong to targeted classes
    */
-  bool isTargetObjectType(const autoware_perception_msgs::DynamicObject & object) const;
+  bool isTargetObjectType(const autoware_perception_msgs::msg::DynamicObject & object) const;
 
   /**
    * @brief Check if at least one of object's predicted poistion is in area
@@ -188,7 +188,7 @@ private:
    * @return True when at least one of object's predicted position is in area
    */
   bool isPredictedPathInArea(
-    const autoware_perception_msgs::DynamicObject & object,
+    const autoware_perception_msgs::msg::DynamicObject & object,
     const lanelet::CompoundPolygon3d & area) const;
 
   /**
@@ -201,7 +201,7 @@ private:
    * @return false when generation failed
    */
   bool generateStopLine(
-    const lanelet::ConstLanelets straight_lanelets, autoware_planning_msgs::PathWithLaneId * path,
+    const lanelet::ConstLanelets straight_lanelets, autoware_planning_msgs::msg::PathWithLaneId * path,
     int * stop_line_idx, int * pass_judge_line_idx) const;
 
   /**
@@ -211,7 +211,7 @@ private:
    * @return path point index
    */
   boost::optional<int> getFirstPointConflictingLanelets(
-    const autoware_planning_msgs::PathWithLaneId & path,
+    const autoware_planning_msgs::msg::PathWithLaneId & path,
     const lanelet::ConstLanelets & lanelets) const;
 
   /**
@@ -219,7 +219,7 @@ private:
    * @param lane_id lane id of objective lanelet
    * @return end point of lanelet
    */
-  boost::optional<geometry_msgs::Point> getStartPointFromLaneLet(const int lane_id) const;
+  boost::optional<geometry_msgs::msg::Point> getStartPointFromLaneLet(const int lane_id) const;
 
   /**
    * @brief get straight lanelets in intersection
@@ -234,7 +234,7 @@ private:
    * @param time_thr    time threshold to cut path
    */
   void cutPredictPathWithDuration(
-    autoware_perception_msgs::DynamicObjectArray * objects_ptr, const double time_thr) const;
+    autoware_perception_msgs::msg::DynamicObjectArray * objects_ptr, const double time_thr) const;
 
   StateMachine state_machine_;  //! for state
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.h
@@ -17,7 +17,6 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 
 #include <boost/optional.hpp>
 
@@ -71,14 +70,14 @@ public:
       state_ = State::GO;
       margin_time_ = 0.0;
     }
-    void setStateWithMarginTime(State state);
+    void setStateWithMarginTime(State state, rclcpp::Logger logger, rclcpp::Clock & clock);
     void setState(State state);
     void setMarginTime(const double t);
     State getState();
 
   private:
-    State state_;                            //! current state
-    double margin_time_;                     //! margin time when transit to Go from Stop
+    State state_;                               //! current state
+    double margin_time_;                        //! margin time when transit to Go from Stop
     std::shared_ptr<rclcpp::Time> start_time_;  //! first time received GO when STOP state
   };
 
@@ -107,7 +106,8 @@ public:
 
   BlindSpotModule(
     const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-    const PlannerParam & planner_param);
+    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   /**
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path
@@ -201,8 +201,9 @@ private:
    * @return false when generation failed
    */
   bool generateStopLine(
-    const lanelet::ConstLanelets straight_lanelets, autoware_planning_msgs::msg::PathWithLaneId * path,
-    int * stop_line_idx, int * pass_judge_line_idx) const;
+    const lanelet::ConstLanelets straight_lanelets,
+    autoware_planning_msgs::msg::PathWithLaneId * path, int * stop_line_idx,
+    int * pass_judge_line_idx) const;
 
   /**
    * @brief Calculate first path index that is conflicting lanelets.

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/manager.h
@@ -35,10 +35,10 @@
 #include <pcl_conversions/pcl_conversions.h>
 #include <pcl_ros/point_cloud.h>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <sensor_msgs/PointCloud2.h>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_extension/utility/query.h>
@@ -57,8 +57,8 @@ public:
 private:
   CrosswalkModule::PlannerParam crosswalk_planner_param_;
   WalkwayModule::PlannerParam walkway_planner_param_;
-  void launchNewModules(const autoware_planning_msgs::PathWithLaneId & path) override;
+  void launchNewModules(const autoware_planning_msgs::msg::PathWithLaneId & path) override;
 
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
-    const autoware_planning_msgs::PathWithLaneId & path) override;
+    const autoware_planning_msgs::msg::PathWithLaneId & path) override;
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/manager.h
@@ -15,33 +15,11 @@
  */
 #pragma once
 
+#include <functional>
 #include <memory>
-#include <set>
-#include <string>
-#include <vector>
 
-#include <boost/assert.hpp>
-#include <boost/assign/list_of.hpp>
-#include <boost/geometry.hpp>
-#include <boost/geometry/geometries/linestring.hpp>
-#include <boost/geometry/geometries/point_xy.hpp>
-#include <boost/lexical_cast.hpp>
-
-#define EIGEN_MPL2_ONLY
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
-#include <pcl/point_types.h>
-#include <pcl_conversions/pcl_conversions.h>
-#include <pcl_ros/point_cloud.h>
-
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 #include <rclcpp/rclcpp.hpp>
-
-#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
-#include <sensor_msgs/msg/point_cloud2.hpp>
-
-#include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_extension/utility/query.h>
 
 #include <scene_module/crosswalk/scene_crosswalk.h>
 #include <scene_module/crosswalk/scene_walkway.h>
@@ -50,7 +28,7 @@
 class CrosswalkModuleManager : public SceneModuleManagerInterface
 {
 public:
-  CrosswalkModuleManager();
+  CrosswalkModuleManager(rclcpp::Node & node);
 
   const char * getModuleName() override { return "crosswalk"; }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.h
@@ -33,10 +33,10 @@
 #include <pcl_conversions/pcl_conversions.h>
 #include <pcl_ros/point_cloud.h>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <sensor_msgs/PointCloud2.h>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_extension/utility/query.h>
@@ -62,31 +62,31 @@ public:
     const PlannerParam & planner_param);
 
   bool modifyPathVelocity(
-    autoware_planning_msgs::PathWithLaneId * path,
-    autoware_planning_msgs::StopReason * stop_reason) override;
+    autoware_planning_msgs::msg::PathWithLaneId * path,
+    autoware_planning_msgs::msg::StopReason * stop_reason) override;
 
-  visualization_msgs::MarkerArray createDebugMarkerArray() override;
+  visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
 
 private:
   int64_t module_id_;
 
   bool checkSlowArea(
-    const autoware_planning_msgs::PathWithLaneId & input,
+    const autoware_planning_msgs::msg::PathWithLaneId & input,
     const boost::geometry::model::polygon<boost::geometry::model::d2::point_xy<double>, false> &
       polygon,
-    const autoware_perception_msgs::DynamicObjectArray::ConstPtr & objects_ptr,
+    const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr & objects_ptr,
     const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & no_ground_pointcloud_ptr,
-    autoware_planning_msgs::PathWithLaneId & output);
+    autoware_planning_msgs::msg::PathWithLaneId & output);
 
   bool checkStopArea(
-    const autoware_planning_msgs::PathWithLaneId & input,
+    const autoware_planning_msgs::msg::PathWithLaneId & input,
     const boost::geometry::model::polygon<boost::geometry::model::d2::point_xy<double>, false> &
       polygon,
-    const autoware_perception_msgs::DynamicObjectArray::ConstPtr & objects_ptr,
+    const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr & objects_ptr,
     const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & no_ground_pointcloud_ptr,
-    autoware_planning_msgs::PathWithLaneId & output, bool * insert_stop);
+    autoware_planning_msgs::msg::PathWithLaneId & output, bool * insert_stop);
 
-  bool isTargetType(const autoware_perception_msgs::DynamicObject & obj);
+  bool isTargetType(const autoware_perception_msgs::msg::DynamicObject & obj);
 
   enum class State { APPROACH, INSIDE, GO_OUT };
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.h
@@ -15,23 +15,15 @@
  */
 #pragma once
 
-#include <string>
-#include <unordered_map>
-#include <vector>
-
 #include <boost/assert.hpp>
 #include <boost/assign/list_of.hpp>
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 
-#define EIGEN_MPL2_ONLY
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
+#include <pcl/common/distances.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <pcl_ros/point_cloud.h>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -59,7 +51,8 @@ public:
 
   CrosswalkModule(
     const int64_t module_id, const lanelet::ConstLanelet & crosswalk,
-    const PlannerParam & planner_param);
+    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(
     autoware_planning_msgs::msg::PathWithLaneId * path,

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.h
@@ -33,10 +33,10 @@
 #include <pcl_conversions/pcl_conversions.h>
 #include <pcl_ros/point_cloud.h>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <sensor_msgs/PointCloud2.h>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_extension/utility/query.h>
@@ -60,10 +60,10 @@ public:
     const PlannerParam & planner_param);
 
   bool modifyPathVelocity(
-    autoware_planning_msgs::PathWithLaneId * path,
-    autoware_planning_msgs::StopReason * stop_reason) override;
+    autoware_planning_msgs::msg::PathWithLaneId * path,
+    autoware_planning_msgs::msg::StopReason * stop_reason) override;
 
-  visualization_msgs::MarkerArray createDebugMarkerArray() override;
+  visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
 
 private:
   int64_t module_id_;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.h
@@ -15,24 +15,6 @@
  */
 #pragma once
 
-#include <string>
-#include <unordered_map>
-#include <vector>
-
-#include <boost/assert.hpp>
-#include <boost/assign/list_of.hpp>
-#include <boost/geometry.hpp>
-#include <boost/geometry/geometries/linestring.hpp>
-#include <boost/geometry/geometries/point_xy.hpp>
-
-#define EIGEN_MPL2_ONLY
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
-#include <pcl/point_types.h>
-#include <pcl_conversions/pcl_conversions.h>
-#include <pcl_ros/point_cloud.h>
-
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
@@ -57,7 +39,8 @@ public:
   };
   WalkwayModule(
     const int64_t module_id, const lanelet::ConstLanelet & walkway,
-    const PlannerParam & planner_param);
+    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(
     autoware_planning_msgs::msg::PathWithLaneId * path,

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/util.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/util.h
@@ -29,8 +29,8 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 #include <behavior_velocity_planner/planner_data.h>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 
 struct DebugData
 {

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/util.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/util.h
@@ -29,28 +29,28 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <autoware_planning_msgs/PathWithLaneId.h>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 #include <behavior_velocity_planner/planner_data.h>
 
 struct DebugData
 {
   double base_link2front;
   std::vector<Eigen::Vector3d> collision_points;
-  geometry_msgs::Pose first_stop_pose;
-  std::vector<geometry_msgs::Pose> stop_poses;
-  std::vector<geometry_msgs::Pose> slow_poses;
+  geometry_msgs::msg::Pose first_stop_pose;
+  std::vector<geometry_msgs::msg::Pose> stop_poses;
+  std::vector<geometry_msgs::msg::Pose> slow_poses;
   std::vector<std::vector<Eigen::Vector3d>> collision_lines;
   std::vector<std::vector<Eigen::Vector3d>> crosswalk_polygons;
   std::vector<std::vector<Eigen::Vector3d>> stop_polygons;
-  std::vector<geometry_msgs::Point> stop_factor_points;
+  std::vector<geometry_msgs::msg::Point> stop_factor_points;
   std::vector<std::vector<Eigen::Vector3d>> slow_polygons;
-  geometry_msgs::Point nearest_collision_point;
+  geometry_msgs::msg::Point nearest_collision_point;
 };
 
 bool insertTargetVelocityPoint(
-  const autoware_planning_msgs::PathWithLaneId & input,
+  const autoware_planning_msgs::msg::PathWithLaneId & input,
   const boost::geometry::model::polygon<boost::geometry::model::d2::point_xy<double>, false> &
     polygon,
   const double & margin, const double & velocity, const PlannerData & planner_data,
-  autoware_planning_msgs::PathWithLaneId & output, DebugData & debug_data,
+  autoware_planning_msgs::msg::PathWithLaneId & output, DebugData & debug_data,
   boost::optional<int> & first_stop_path_point_index);

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/detection_area/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/detection_area/manager.h
@@ -27,7 +27,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_extension/regulatory_elements/detection_area.h>
@@ -46,8 +46,8 @@ public:
 
 private:
   DetectionAreaModule::PlannerParam planner_param_;
-  void launchNewModules(const autoware_planning_msgs::PathWithLaneId & path) override;
+  void launchNewModules(const autoware_planning_msgs::msg::PathWithLaneId & path) override;
 
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
-    const autoware_planning_msgs::PathWithLaneId & path) override;
+    const autoware_planning_msgs::msg::PathWithLaneId & path) override;
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/detection_area/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/detection_area/manager.h
@@ -15,24 +15,11 @@
  */
 #pragma once
 
-#include <string>
-#include <unordered_map>
+#include <functional>
+#include <memory>
 
-#include <boost/assert.hpp>
-#include <boost/geometry.hpp>
-#include <boost/geometry/geometries/linestring.hpp>
-#include <boost/geometry/geometries/point_xy.hpp>
-
-#define EIGEN_MPL2_ONLY
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 #include <rclcpp/rclcpp.hpp>
-
-#include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_extension/regulatory_elements/detection_area.h>
-#include <lanelet2_extension/utility/query.h>
-#include <lanelet2_routing/RoutingGraph.h>
 
 #include <scene_module/detection_area/scene.h>
 #include <scene_module/scene_module_interface.h>
@@ -40,7 +27,7 @@
 class DetectionAreaModuleManager : public SceneModuleManagerInterface
 {
 public:
-  DetectionAreaModuleManager();
+  DetectionAreaModuleManager(rclcpp::Node & node);
 
   const char * getModuleName() override { return "detection_area"; }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/detection_area/scene.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/detection_area/scene.h
@@ -28,7 +28,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_extension/regulatory_elements/detection_area.h>
@@ -45,10 +45,10 @@ public:
   struct DebugData
   {
     double base_link2front;
-    std::vector<geometry_msgs::Pose> stop_poses;
-    std::vector<geometry_msgs::Pose> dead_line_poses;
-    geometry_msgs::Pose first_stop_pose;
-    std::vector<geometry_msgs::Point> detection_points;
+    std::vector<geometry_msgs::msg::Pose> stop_poses;
+    std::vector<geometry_msgs::msg::Pose> dead_line_poses;
+    geometry_msgs::msg::Pose first_stop_pose;
+    std::vector<geometry_msgs::msg::Point> detection_points;
   };
 
   struct PlannerParam
@@ -62,10 +62,10 @@ public:
     const PlannerParam & planner_param);
 
   bool modifyPathVelocity(
-    autoware_planning_msgs::PathWithLaneId * path,
-    autoware_planning_msgs::StopReason * stop_reason) override;
+    autoware_planning_msgs::msg::PathWithLaneId * path,
+    autoware_planning_msgs::msg::StopReason * stop_reason) override;
 
-  visualization_msgs::MarkerArray createDebugMarkerArray() override;
+  visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
 
 private:
   int64_t module_id_;
@@ -84,20 +84,20 @@ private:
     Eigen::Vector2d & output_point);
 
   bool insertTargetVelocityPoint(
-    const autoware_planning_msgs::PathWithLaneId & input,
+    const autoware_planning_msgs::msg::PathWithLaneId & input,
     const boost::geometry::model::linestring<boost::geometry::model::d2::point_xy<double>> &
       stop_line,
     const double & margin, const double & velocity,
-    autoware_planning_msgs::PathWithLaneId & output);
+    autoware_planning_msgs::msg::PathWithLaneId & output);
 
   bool createTargetPoint(
-    const autoware_planning_msgs::PathWithLaneId & input,
+    const autoware_planning_msgs::msg::PathWithLaneId & input,
     const boost::geometry::model::linestring<boost::geometry::model::d2::point_xy<double>> &
       stop_line,
     const double & margin, size_t & target_point_idx, Eigen::Vector2d & target_point);
 
   bool isOverDeadLine(
-    const geometry_msgs::Pose & self_pose, const autoware_planning_msgs::PathWithLaneId & input_path,
+    const geometry_msgs::msg::Pose & self_pose, const autoware_planning_msgs::msg::PathWithLaneId & input_path,
     const size_t & dead_line_point_idx, const Eigen::Vector2d & dead_line_point,
     const double dead_line_range);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/detection_area/scene.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/detection_area/scene.h
@@ -15,9 +15,7 @@
  */
 #pragma once
 
-#include <memory>
-#include <string>
-#include <unordered_map>
+#include <vector>
 
 #include <boost/assert.hpp>
 #include <boost/geometry.hpp>
@@ -59,7 +57,8 @@ public:
 public:
   DetectionAreaModule(
     const int64_t module_id, const lanelet::autoware::DetectionArea & detection_area_reg_elem,
-    const PlannerParam & planner_param);
+    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(
     autoware_planning_msgs::msg::PathWithLaneId * path,
@@ -97,7 +96,8 @@ private:
     const double & margin, size_t & target_point_idx, Eigen::Vector2d & target_point);
 
   bool isOverDeadLine(
-    const geometry_msgs::msg::Pose & self_pose, const autoware_planning_msgs::msg::PathWithLaneId & input_path,
+    const geometry_msgs::msg::Pose & self_pose,
+    const autoware_planning_msgs::msg::PathWithLaneId & input_path,
     const size_t & dead_line_point_idx, const Eigen::Vector2d & dead_line_point,
     const double dead_line_range);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/manager.h
@@ -20,13 +20,13 @@
 #include <string>
 #include <vector>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include <autoware_perception_msgs/DynamicObject.h>
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <autoware_planning_msgs/PathWithLaneId.h>
-#include <geometry_msgs/Point.h>
-#include <std_msgs/Float32MultiArray.h>
+#include <autoware_perception_msgs/msg/dynamic_object.hpp>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <std_msgs/msg/float32_multi_array.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
@@ -45,8 +45,8 @@ public:
 private:
   IntersectionModule::PlannerParam planner_param_;
 
-  void launchNewModules(const autoware_planning_msgs::PathWithLaneId & path) override;
+  void launchNewModules(const autoware_planning_msgs::msg::PathWithLaneId & path) override;
 
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
-    const autoware_planning_msgs::PathWithLaneId & path) override;
+    const autoware_planning_msgs::msg::PathWithLaneId & path) override;
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/manager.h
@@ -15,21 +15,11 @@
  */
 #pragma once
 
+#include <functional>
 #include <memory>
-#include <set>
-#include <string>
-#include <vector>
 
-#include <rclcpp/rclcpp.hpp>
-
-#include <autoware_perception_msgs/msg/dynamic_object.hpp>
-#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
 #include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
-#include <geometry_msgs/msg/point.hpp>
-#include <std_msgs/msg/float32_multi_array.hpp>
-
-#include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_routing/RoutingGraph.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <scene_module/intersection/scene_intersection.h>
 #include <scene_module/intersection/scene_merge_from_private_road.h>
@@ -38,7 +28,7 @@
 class IntersectionModuleManager : public SceneModuleManagerInterface
 {
 public:
-  IntersectionModuleManager();
+  IntersectionModuleManager(rclcpp::Node & node);
 
   const char * getModuleName() override { return "intersection"; }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.h
@@ -19,19 +19,19 @@
 #include <string>
 #include <vector>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include <autoware_perception_msgs/DynamicObject.h>
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <autoware_planning_msgs/PathWithLaneId.h>
-#include <geometry_msgs/Point.h>
-#include <std_msgs/Float32MultiArray.h>
+#include <autoware_perception_msgs/msg/dynamic_object.hpp>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <std_msgs/msg/float32_multi_array.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
 #include <scene_module/scene_module_interface.h>
-#include "utilization/boost_geometry_helper.h"
+#include <utilization/boost_geometry_helper.h>
 
 class IntersectionModule : public SceneModuleInterface
 {
@@ -69,22 +69,22 @@ public:
   private:
     State state_;                            //! current state
     double margin_time_;                     //! margin time when transit to Go from Stop
-    std::shared_ptr<ros::Time> start_time_;  //! first time received GO when STOP state
+    std::shared_ptr<rclcpp::Time> start_time_;  //! first time received GO when STOP state
   };
 
   struct DebugData
   {
-    autoware_planning_msgs::PathWithLaneId path_raw;
+    autoware_planning_msgs::msg::PathWithLaneId path_raw;
 
-    geometry_msgs::Pose virtual_wall_pose;
-    geometry_msgs::Pose stop_point_pose;
-    geometry_msgs::Pose judge_point_pose;
-    geometry_msgs::Polygon ego_lane_polygon;
-    geometry_msgs::Polygon stuck_vehicle_detect_area;
+    geometry_msgs::msg::Pose virtual_wall_pose;
+    geometry_msgs::msg::Pose stop_point_pose;
+    geometry_msgs::msg::Pose judge_point_pose;
+    geometry_msgs::msg::Polygon ego_lane_polygon;
+    geometry_msgs::msg::Polygon stuck_vehicle_detect_area;
     std::vector<lanelet::ConstLanelet> intersection_detection_lanelets;
     std::vector<lanelet::CompoundPolygon3d> detection_area;
-    autoware_perception_msgs::DynamicObjectArray conflicting_targets;
-    autoware_perception_msgs::DynamicObjectArray stuck_targets;
+    autoware_perception_msgs::msg::DynamicObjectArray conflicting_targets;
+    autoware_perception_msgs::msg::DynamicObjectArray stuck_targets;
   };
 
 public:
@@ -112,10 +112,10 @@ public:
    * and object predicted path
    */
   bool modifyPathVelocity(
-    autoware_planning_msgs::PathWithLaneId * path,
-    autoware_planning_msgs::StopReason * stop_reason) override;
+    autoware_planning_msgs::msg::PathWithLaneId * path,
+    autoware_planning_msgs::msg::StopReason * stop_reason) override;
 
-  visualization_msgs::MarkerArray createDebugMarkerArray() override;
+  visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
 
 private:
   int64_t lane_id_;
@@ -135,9 +135,9 @@ private:
    * @return true if collision is detected
    */
   bool checkCollision(
-    const autoware_planning_msgs::PathWithLaneId & path,
+    const autoware_planning_msgs::msg::PathWithLaneId & path,
     const std::vector<lanelet::CompoundPolygon3d> & detection_areas,
-    const autoware_perception_msgs::DynamicObjectArray::ConstPtr objects_ptr,
+    const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr objects_ptr,
     const int closest_idx);
 
   /**
@@ -148,8 +148,8 @@ private:
    * @return true if exists
    */
   bool checkStuckVehicleInIntersection(
-    const autoware_planning_msgs::PathWithLaneId & path, const int closest_idx, const int stop_idx,
-    const autoware_perception_msgs::DynamicObjectArray::ConstPtr objects_ptr) const;
+    const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx, const int stop_idx,
+    const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr objects_ptr) const;
 
   /**
    * @brief Calculate the polygon of the path from the ego-car position to the end of the
@@ -161,7 +161,7 @@ private:
    * @return generated polygon
    */
   Polygon2d generateEgoIntersectionLanePolygon(
-    const autoware_planning_msgs::PathWithLaneId & path, const int closest_idx, const int start_idx,
+    const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx, const int start_idx,
     const double extra_dist, const double ignore_dist) const;
 
   /**
@@ -170,7 +170,7 @@ private:
    * @param time_thr    time threshold to cut path
    */
   void cutPredictPathWithDuration(
-    autoware_perception_msgs::DynamicObjectArray * objects_ptr, const double time_thr) const;
+    autoware_perception_msgs::msg::DynamicObjectArray * objects_ptr, const double time_thr) const;
 
   /**
    * @brief Calculate time that is needed for ego-vehicle to cross the intersection. (to be updated)
@@ -180,7 +180,7 @@ private:
    * @return calculated time [s]
    */
   double calcIntersectionPassingTime(
-    const autoware_planning_msgs::PathWithLaneId & path, const int closest_idx,
+    const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
     const int objective_lane_id) const;
 
   /**
@@ -188,7 +188,7 @@ private:
    * @param object target object
    * @return true if the object has a target type
    */
-  bool isTargetVehicleType(const autoware_perception_msgs::DynamicObject & object) const;
+  bool isTargetVehicleType(const autoware_perception_msgs::msg::DynamicObject & object) const;
 
   StateMachine state_machine_;  //! for state
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.h
@@ -25,7 +25,6 @@
 #include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
 #include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 #include <geometry_msgs/msg/point.hpp>
-#include <std_msgs/msg/float32_multi_array.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
@@ -61,14 +60,14 @@ public:
       state_ = State::GO;
       margin_time_ = 0.0;
     }
-    void setStateWithMarginTime(State state);
+    void setStateWithMarginTime(State state, rclcpp::Logger logger, rclcpp::Clock & clock);
     void setState(State state);
     void setMarginTime(const double t);
     State getState();
 
   private:
-    State state_;                            //! current state
-    double margin_time_;                     //! margin time when transit to Go from Stop
+    State state_;                               //! current state
+    double margin_time_;                        //! margin time when transit to Go from Stop
     std::shared_ptr<rclcpp::Time> start_time_;  //! first time received GO when STOP state
   };
 
@@ -105,7 +104,8 @@ public:
 
   IntersectionModule(
     const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-    const PlannerParam & planner_param);
+    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   /**
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path
@@ -148,7 +148,8 @@ private:
    * @return true if exists
    */
   bool checkStuckVehicleInIntersection(
-    const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx, const int stop_idx,
+    const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
+    const int stop_idx,
     const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr objects_ptr) const;
 
   /**
@@ -161,8 +162,8 @@ private:
    * @return generated polygon
    */
   Polygon2d generateEgoIntersectionLanePolygon(
-    const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx, const int start_idx,
-    const double extra_dist, const double ignore_dist) const;
+    const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
+    const int start_idx, const double extra_dist, const double ignore_dist) const;
 
   /**
    * @brief Modify objects predicted path. remove path point if the time exceeds timer_thr.

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/scene_merge_from_private_road.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/scene_merge_from_private_road.h
@@ -19,20 +19,20 @@
 #include <string>
 #include <vector>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include <autoware_perception_msgs/DynamicObject.h>
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <autoware_planning_msgs/PathWithLaneId.h>
-#include <geometry_msgs/Point.h>
-#include <std_msgs/Float32MultiArray.h>
+#include <autoware_perception_msgs/msg/dynamic_object.hpp>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <std_msgs/msg/float32_multi_array.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
 #include <scene_module/intersection/scene_intersection.h>
 #include <scene_module/scene_module_interface.h>
-#include "utilization/boost_geometry_helper.h"
+#include <utilization/boost_geometry_helper.h>
 
 /**
  * @brief This module makes sure that vehicle will stop before entering public road from private road.
@@ -76,23 +76,23 @@ public:
   private:
     State state_;                            //! current state
     double margin_time_;                     //! margin time when transit to Go from Stop
-    std::shared_ptr<ros::Time> start_time_;  //! first time received GO when STOP state
+    std::shared_ptr<rclcpp::Time> start_time_;  //! first time received GO when STOP state
   };
 
   struct DebugData
   {
-    autoware_planning_msgs::PathWithLaneId path_raw;
+    autoware_planning_msgs::msg::PathWithLaneId path_raw;
 
-    geometry_msgs::Pose virtual_wall_pose;
-    geometry_msgs::Pose stop_point_pose;
-    geometry_msgs::Pose judge_point_pose;
-    geometry_msgs::Polygon ego_lane_polygon;
-    geometry_msgs::Polygon stuck_vehicle_detect_area;
+    geometry_msgs::msg::Pose virtual_wall_pose;
+    geometry_msgs::msg::Pose stop_point_pose;
+    geometry_msgs::msg::Pose judge_point_pose;
+    geometry_msgs::msg::Polygon ego_lane_polygon;
+    geometry_msgs::msg::Polygon stuck_vehicle_detect_area;
     std::vector<lanelet::ConstLanelet> intersection_detection_lanelets;
     std::vector<lanelet::CompoundPolygon3d> detection_area;
-    autoware_planning_msgs::PathWithLaneId spline_path;
-    geometry_msgs::Point first_collision_point;
-    autoware_perception_msgs::DynamicObjectArray stuck_targets;
+    autoware_planning_msgs::msg::PathWithLaneId spline_path;
+    geometry_msgs::msg::Point first_collision_point;
+    autoware_perception_msgs::msg::DynamicObjectArray stuck_targets;
   };
 
 public:
@@ -105,10 +105,10 @@ public:
    * and object predicted path
    */
   bool modifyPathVelocity(
-    autoware_planning_msgs::PathWithLaneId * path,
-    autoware_planning_msgs::StopReason * stop_reason) override;
+    autoware_planning_msgs::msg::PathWithLaneId * path,
+    autoware_planning_msgs::msg::StopReason * stop_reason) override;
 
-  visualization_msgs::MarkerArray createDebugMarkerArray() override;
+  visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
 
 private:
   int64_t lane_id_;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/scene_merge_from_private_road.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/scene_merge_from_private_road.h
@@ -67,7 +67,6 @@ public:
       state_ = State::GO;
       margin_time_ = 0.0;
     }
-    void setStateWithMarginTime(State state, rclcpp::Logger logger, rclcpp::Clock & clock);
     void setState(State state);
     void setMarginTime(const double t);
     State getState();

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/scene_merge_from_private_road.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/scene_merge_from_private_road.h
@@ -25,7 +25,6 @@
 #include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
 #include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 #include <geometry_msgs/msg/point.hpp>
-#include <std_msgs/msg/float32_multi_array.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
@@ -68,14 +67,14 @@ public:
       state_ = State::GO;
       margin_time_ = 0.0;
     }
-    void setStateWithMarginTime(State state);
+    void setStateWithMarginTime(State state, rclcpp::Logger logger, rclcpp::Clock & clock);
     void setState(State state);
     void setMarginTime(const double t);
     State getState();
 
   private:
-    State state_;                            //! current state
-    double margin_time_;                     //! margin time when transit to Go from Stop
+    State state_;                               //! current state
+    double margin_time_;                        //! margin time when transit to Go from Stop
     std::shared_ptr<rclcpp::Time> start_time_;  //! first time received GO when STOP state
   };
 
@@ -98,7 +97,8 @@ public:
 public:
   MergeFromPrivateRoadModule(
     const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-    const IntersectionModule::PlannerParam & planner_param);
+    const IntersectionModule::PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   /**
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/util.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/util.h
@@ -19,32 +19,32 @@
 #include <string>
 #include <vector>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <scene_module/intersection/scene_intersection.h>
 #include <spline_interpolation/spline_interpolation.h>
 
-#include <geometry_msgs/Point.h>
-#include <std_msgs/Float32MultiArray.h>
+#include <geometry_msgs/msg/point.hpp>
+#include <std_msgs/msg/float32_multi_array.hpp>
 
 namespace util
 {
 bool setVelocityFrom(
-  const size_t idx, const double vel, autoware_planning_msgs::PathWithLaneId * input);
+  const size_t idx, const double vel, autoware_planning_msgs::msg::PathWithLaneId * input);
 
 bool splineInterpolate(
-  const autoware_planning_msgs::PathWithLaneId & input, const double interval,
-  autoware_planning_msgs::PathWithLaneId * output);
+  const autoware_planning_msgs::msg::PathWithLaneId & input, const double interval,
+  autoware_planning_msgs::msg::PathWithLaneId * output);
 
 int insertPoint(
-  const geometry_msgs::Pose & in_pose, autoware_planning_msgs::PathWithLaneId * inout_path);
+  const geometry_msgs::msg::Pose & in_pose, autoware_planning_msgs::msg::PathWithLaneId * inout_path);
 
-geometry_msgs::Pose getAheadPose(
+geometry_msgs::msg::Pose getAheadPose(
   const size_t start_idx, const double ahead_dist,
-  const autoware_planning_msgs::PathWithLaneId & path);
+  const autoware_planning_msgs::msg::PathWithLaneId & path);
 
-bool isAheadOf(const geometry_msgs::Pose & target, const geometry_msgs::Pose & origin);
-bool hasLaneId(const autoware_planning_msgs::PathPointWithLaneId & p, const int id);
+bool isAheadOf(const geometry_msgs::msg::Pose & target, const geometry_msgs::msg::Pose & origin);
+bool hasLaneId(const autoware_planning_msgs::msg::PathPointWithLaneId & p, const int id);
 
 /**
    * @brief get objective polygons for detection area
@@ -67,7 +67,7 @@ bool generateStopLine(
   const int lane_id, const std::vector<lanelet::CompoundPolygon3d> detection_areas,
   const std::shared_ptr<const PlannerData> & planner_data,
   const IntersectionModule::PlannerParam & planner_param,
-  autoware_planning_msgs::PathWithLaneId * path, int * stop_line_idx, int * pass_judge_line_idx,
+  autoware_planning_msgs::msg::PathWithLaneId * path, int * stop_line_idx, int * pass_judge_line_idx,
   int * first_idx_inside_lane);
 
 /**
@@ -77,7 +77,7 @@ bool generateStopLine(
    * @return path point index
    */
 int getFirstPointInsidePolygons(
-  const autoware_planning_msgs::PathWithLaneId & path,
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
   const std::vector<lanelet::CompoundPolygon3d> & polygons);
 
 /**
@@ -86,7 +86,7 @@ int getFirstPointInsidePolygons(
    * @return true when the stop point is defined on map.
    */
 bool getStopPoseFromMap(
-  const int lane_id, geometry_msgs::Point * stop_pose,
+  const int lane_id, geometry_msgs::msg::Point * stop_pose,
   const std::shared_ptr<const PlannerData> & planner_data);
 
 }  // namespace util

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/util.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/util.h
@@ -34,10 +34,11 @@ bool setVelocityFrom(
 
 bool splineInterpolate(
   const autoware_planning_msgs::msg::PathWithLaneId & input, const double interval,
-  autoware_planning_msgs::msg::PathWithLaneId * output);
+  autoware_planning_msgs::msg::PathWithLaneId * output, const rclcpp::Logger logger);
 
 int insertPoint(
-  const geometry_msgs::msg::Pose & in_pose, autoware_planning_msgs::msg::PathWithLaneId * inout_path);
+  const geometry_msgs::msg::Pose & in_pose,
+  autoware_planning_msgs::msg::PathWithLaneId * inout_path);
 
 geometry_msgs::msg::Pose getAheadPose(
   const size_t start_idx, const double ahead_dist,
@@ -52,7 +53,7 @@ bool hasLaneId(const autoware_planning_msgs::msg::PathPointWithLaneId & p, const
 bool getObjectivePolygons(
   lanelet::LaneletMapConstPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr,
   const int lane_id, const IntersectionModule::PlannerParam & planner_param,
-  std::vector<lanelet::CompoundPolygon3d> * polygons);
+  std::vector<lanelet::CompoundPolygon3d> * polygons, const rclcpp::Logger logger);
 
 /**
    * @brief Generate a stop line and insert it into the path. If the stop line is defined in the map,
@@ -67,8 +68,8 @@ bool generateStopLine(
   const int lane_id, const std::vector<lanelet::CompoundPolygon3d> detection_areas,
   const std::shared_ptr<const PlannerData> & planner_data,
   const IntersectionModule::PlannerParam & planner_param,
-  autoware_planning_msgs::msg::PathWithLaneId * path, int * stop_line_idx, int * pass_judge_line_idx,
-  int * first_idx_inside_lane);
+  autoware_planning_msgs::msg::PathWithLaneId * path, int * stop_line_idx,
+  int * pass_judge_line_idx, int * first_idx_inside_lane, const rclcpp::Logger logger);
 
 /**
    * @brief Calculate first path index that is in the polygon.

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/scene_module_interface.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/scene_module_interface.h
@@ -18,16 +18,16 @@
 #include <memory>
 #include <set>
 
-#include <autoware_planning_msgs/Path.h>
-#include <autoware_planning_msgs/PathWithLaneId.h>
-#include <autoware_planning_msgs/StopReason.h>
-#include <autoware_planning_msgs/StopReasonArray.h>
+#include <autoware_planning_msgs/msg/path.hpp>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <autoware_planning_msgs/msg/stop_reason.hpp>
+#include <autoware_planning_msgs/msg/stop_reason_array.hpp>
 
 #include <behavior_velocity_planner/planner_data.h>
 
 // Debug
-#include <ros/ros.h>
-#include <visualization_msgs/MarkerArray.h>
+#include <rclcpp/rclcpp.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 class SceneModuleInterface
 {
@@ -36,9 +36,9 @@ public:
   virtual ~SceneModuleInterface() = default;
 
   virtual bool modifyPathVelocity(
-    autoware_planning_msgs::PathWithLaneId * path,
-    autoware_planning_msgs::StopReason * stop_reason) = 0;
-  virtual visualization_msgs::MarkerArray createDebugMarkerArray() = 0;
+    autoware_planning_msgs::msg::PathWithLaneId * path,
+    autoware_planning_msgs::msg::StopReason * stop_reason) = 0;
+  virtual visualization_msgs::msg::MarkerArray createDebugMarkerArray() = 0;
 
   int64_t getModuleId() const { return module_id_; }
   void setPlannerData(const std::shared_ptr<const PlannerData> & planner_data)
@@ -60,9 +60,9 @@ public:
   SceneModuleManagerInterface(const char * module_name)
   {
     const auto ns = std::string("debug/") + module_name;
-    pub_debug_ = private_nh_.advertise<visualization_msgs::MarkerArray>(ns, 20);
+    pub_debug_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(ns, 20);
     pub_stop_reason_ =
-      private_nh_.advertise<autoware_planning_msgs::StopReasonArray>("output/stop_reasons", 20);
+      this->create_publisher<autoware_planning_msgs::msg::StopReasonArray>("output/stop_reasons", 20);
   }
 
   virtual ~SceneModuleManagerInterface() = default;
@@ -73,7 +73,7 @@ public:
 
   void updateSceneModuleInstances(
     const std::shared_ptr<const PlannerData> & planner_data,
-    const autoware_planning_msgs::PathWithLaneId & path)
+    const autoware_planning_msgs::msg::PathWithLaneId & path)
   {
     planner_data_ = planner_data;
 
@@ -81,16 +81,16 @@ public:
     deleteExpiredModules(path);
   }
 
-  virtual void modifyPathVelocity(autoware_planning_msgs::PathWithLaneId * path)
+  virtual void modifyPathVelocity(autoware_planning_msgs::msg::PathWithLaneId * path)
   {
-    visualization_msgs::MarkerArray debug_marker_array;
-    autoware_planning_msgs::StopReasonArray stop_reason_array;
+    visualization_msgs::msg::MarkerArray debug_marker_array;
+    autoware_planning_msgs::msg::StopReasonArray stop_reason_array;
     stop_reason_array.header.frame_id = "map";
-    stop_reason_array.header.stamp = ros::Time::now();
+    stop_reason_array.header.stamp = this->now();
 
     first_stop_path_point_index_ = static_cast<int>(path->points.size());
     for (const auto & scene_module : scene_modules_) {
-      autoware_planning_msgs::StopReason stop_reason;
+      autoware_planning_msgs::msg::StopReason stop_reason;
       scene_module->setPlannerData(planner_data_);
       scene_module->modifyPathVelocity(path, &stop_reason);
       stop_reason_array.stop_reasons.emplace_back(stop_reason);
@@ -105,18 +105,18 @@ public:
     }
 
     if (!stop_reason_array.stop_reasons.empty()) {
-      pub_stop_reason_.publish(stop_reason_array);
+      pub_stop_reason_->publish(stop_reason_array);
     }
-    pub_debug_.publish(debug_marker_array);
+    pub_debug_->publish(debug_marker_array);
   }
 
 protected:
-  virtual void launchNewModules(const autoware_planning_msgs::PathWithLaneId & path) = 0;
+  virtual void launchNewModules(const autoware_planning_msgs::msg::PathWithLaneId & path) = 0;
 
   virtual std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
-  getModuleExpiredFunction(const autoware_planning_msgs::PathWithLaneId & path) = 0;
+  getModuleExpiredFunction(const autoware_planning_msgs::msg::PathWithLaneId & path) = 0;
 
-  void deleteExpiredModules(const autoware_planning_msgs::PathWithLaneId & path)
+  void deleteExpiredModules(const autoware_planning_msgs::msg::PathWithLaneId & path)
   {
     const auto isModuleExpired = getModuleExpiredFunction(path);
 
@@ -137,14 +137,14 @@ protected:
 
   void registerModule(const std::shared_ptr<SceneModuleInterface> & scene_module)
   {
-    ROS_INFO("register task: module = %s, id = %lu", getModuleName(), scene_module->getModuleId());
+    RCLCPP_INFO(get_logger(), "register task: module = %s, id = %lu", getModuleName(), scene_module->getModuleId());
     registered_module_id_set_.emplace(scene_module->getModuleId());
     scene_modules_.insert(scene_module);
   }
 
   void unregisterModule(const std::shared_ptr<SceneModuleInterface> & scene_module)
   {
-    ROS_INFO(
+    RCLCPP_INFO(get_logger(), 
       "unregister task: module = %s, id = %lu", getModuleName(), scene_module->getModuleId());
     registered_module_id_set_.erase(scene_module->getModuleId());
     scene_modules_.erase(scene_module);
@@ -158,7 +158,7 @@ protected:
   boost::optional<int> first_stop_path_point_index_;
 
   // Debug
-  ros::NodeHandle private_nh_{"~"};
-  ros::Publisher pub_debug_;
-  ros::Publisher pub_stop_reason_;
+  rclcpp::NodeHandle private_nh_{"~"};
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_debug_;
+  rclcpp::Publisher<autoware_planning_msgs::msg::StopReasonArray>::SharedPtr pub_stop_reason_;
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/stop_line/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/stop_line/manager.h
@@ -46,8 +46,8 @@ public:
 
 private:
   StopLineModule::PlannerParam planner_param_;
-  void launchNewModules(const autoware_planning_msgs::PathWithLaneId & path) override;
+  void launchNewModules(const autoware_planning_msgs::msg::PathWithLaneId & path) override;
 
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
-    const autoware_planning_msgs::PathWithLaneId & path) override;
+    const autoware_planning_msgs::msg::PathWithLaneId & path) override;
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/stop_line/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/stop_line/manager.h
@@ -15,24 +15,11 @@
  */
 #pragma once
 
+#include <functional>
 #include <memory>
-#include <set>
-#include <string>
-#include <vector>
 
-#include <boost/assert.hpp>
-#include <boost/assign/list_of.hpp>
-#include <boost/geometry.hpp>
-#include <boost/geometry/geometries/linestring.hpp>
-#include <boost/geometry/geometries/point_xy.hpp>
-
-#define EIGEN_MPL2_ONLY
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
-#include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_extension/utility/query.h>
-#include <lanelet2_routing/RoutingGraph.h>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #include <scene_module/scene_module_interface.h>
 #include <scene_module/stop_line/scene.h>
@@ -40,7 +27,7 @@
 class StopLineModuleManager : public SceneModuleManagerInterface
 {
 public:
-  StopLineModuleManager();
+  StopLineModuleManager(rclcpp::Node & node);
 
   const char * getModuleName() override { return "stop_line"; }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/stop_line/scene.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/stop_line/scene.h
@@ -41,8 +41,8 @@ public:
   struct DebugData
   {
     double base_link2front;
-    std::vector<geometry_msgs::Pose> stop_poses;
-    geometry_msgs::Pose first_stop_pose;
+    std::vector<geometry_msgs::msg::Pose> stop_poses;
+    geometry_msgs::msg::Pose first_stop_pose;
   };
 
   struct PlannerParam
@@ -57,10 +57,10 @@ public:
     const PlannerParam & planner_param);
 
   bool modifyPathVelocity(
-    autoware_planning_msgs::PathWithLaneId * path,
-    autoware_planning_msgs::StopReason * stop_reason) override;
+    autoware_planning_msgs::msg::PathWithLaneId * path,
+    autoware_planning_msgs::msg::StopReason * stop_reason) override;
 
-  visualization_msgs::MarkerArray createDebugMarkerArray() override;
+  visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
 
 private:
   int64_t module_id_;
@@ -70,7 +70,7 @@ private:
     const Eigen::Vector2d & base_point, const double backward_length,
     Eigen::Vector2d & output_point);
 
-  geometry_msgs::Point getCenterOfStopLine(const lanelet::ConstLineString3d & stop_line);
+  geometry_msgs::msg::Point getCenterOfStopLine(const lanelet::ConstLineString3d & stop_line);
 
   lanelet::ConstLineString3d stop_line_;
   State state_;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/stop_line/scene.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/stop_line/scene.h
@@ -16,16 +16,13 @@
 #pragma once
 
 #include <string>
-#include <unordered_map>
+#include <vector>
 
-#include <boost/assert.hpp>
-#include <boost/assign/list_of.hpp>
-#include <boost/geometry.hpp>
-#include <boost/geometry/geometries/linestring.hpp>
-#include <boost/geometry/geometries/point_xy.hpp>
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+
+#include <rclcpp/rclcpp.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_extension/utility/query.h>
@@ -54,7 +51,8 @@ public:
 public:
   StopLineModule(
     const int64_t module_id, const lanelet::ConstLineString3d & stop_line,
-    const PlannerParam & planner_param);
+    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(
     autoware_planning_msgs::msg::PathWithLaneId * path,

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/traffic_light/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/traffic_light/manager.h
@@ -27,7 +27,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_extension/utility/query.h>
@@ -43,15 +43,15 @@ public:
 
   const char * getModuleName() override { return "traffic_light"; }
 
-  virtual void modifyPathVelocity(autoware_planning_msgs::PathWithLaneId * path) override;
+  virtual void modifyPathVelocity(autoware_planning_msgs::msg::PathWithLaneId * path) override;
 
 private:
   TrafficLightModule::PlannerParam planner_param_;
-  void launchNewModules(const autoware_planning_msgs::PathWithLaneId & path) override;
+  void launchNewModules(const autoware_planning_msgs::msg::PathWithLaneId & path) override;
 
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
-    const autoware_planning_msgs::PathWithLaneId & path) override;
+    const autoware_planning_msgs::msg::PathWithLaneId & path) override;
 
   // Debug
-  ros::Publisher pub_tl_state_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightStateStamped>::SharedPtr pub_tl_state_;
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/traffic_light/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/traffic_light/manager.h
@@ -15,23 +15,11 @@
  */
 #pragma once
 
-#include <string>
-#include <unordered_map>
+#include <functional>
+#include <memory>
 
-#include <boost/assert.hpp>
-#include <boost/geometry.hpp>
-#include <boost/geometry/geometries/linestring.hpp>
-#include <boost/geometry/geometries/point_xy.hpp>
-
-#define EIGEN_MPL2_ONLY
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 #include <rclcpp/rclcpp.hpp>
-
-#include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_extension/utility/query.h>
-#include <lanelet2_routing/RoutingGraph.h>
 
 #include <scene_module/scene_module_interface.h>
 #include <scene_module/traffic_light/scene.h>
@@ -39,7 +27,7 @@
 class TrafficLightModuleManager : public SceneModuleManagerInterface
 {
 public:
-  TrafficLightModuleManager();
+  TrafficLightModuleManager(rclcpp::Node & node);
 
   const char * getModuleName() override { return "traffic_light"; }
 
@@ -53,5 +41,6 @@ private:
     const autoware_planning_msgs::msg::PathWithLaneId & path) override;
 
   // Debug
-  rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightStateStamped>::SharedPtr pub_tl_state_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightStateStamped>::SharedPtr
+    pub_tl_state_;
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.h
@@ -28,7 +28,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_extension/utility/query.h>
@@ -45,12 +45,12 @@ public:
   {
     double base_link2front;
     std::vector<std::tuple<
-      std::shared_ptr<const lanelet::TrafficLight>, autoware_perception_msgs::TrafficLightState>>
+      std::shared_ptr<const lanelet::TrafficLight>, autoware_perception_msgs::msg::TrafficLightState>>
       tl_state;  // TODO: replace tuple with struct
-    std::vector<geometry_msgs::Pose> stop_poses;
-    geometry_msgs::Pose first_stop_pose;
-    std::vector<geometry_msgs::Pose> dead_line_poses;
-    std::vector<geometry_msgs::Point> traffic_light_points;
+    std::vector<geometry_msgs::msg::Pose> stop_poses;
+    geometry_msgs::msg::Pose first_stop_pose;
+    std::vector<geometry_msgs::msg::Pose> dead_line_poses;
+    std::vector<geometry_msgs::msg::Point> traffic_light_points;
   };
 
   struct PlannerParam
@@ -65,12 +65,12 @@ public:
     lanelet::ConstLanelet lane, const PlannerParam & planner_param);
 
   bool modifyPathVelocity(
-    autoware_planning_msgs::PathWithLaneId * path,
-    autoware_planning_msgs::StopReason * stop_reason) override;
+    autoware_planning_msgs::msg::PathWithLaneId * path,
+    autoware_planning_msgs::msg::StopReason * stop_reason) override;
 
-  visualization_msgs::MarkerArray createDebugMarkerArray() override;
+  visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
 
-  inline autoware_perception_msgs::TrafficLightStateStamped getTrafficLightState() const
+  inline autoware_perception_msgs::msg::TrafficLightStateStamped getTrafficLightState() const
   {
     return tl_state_;
   };
@@ -85,33 +85,33 @@ private:
     Eigen::Vector2d & output_point);
 
   bool insertTargetVelocityPoint(
-    const autoware_planning_msgs::PathWithLaneId & input,
+    const autoware_planning_msgs::msg::PathWithLaneId & input,
     const boost::geometry::model::linestring<boost::geometry::model::d2::point_xy<double>> &
       stop_line,
     const double & margin, const double & velocity,
-    autoware_planning_msgs::PathWithLaneId & output);
+    autoware_planning_msgs::msg::PathWithLaneId & output);
 
   bool getHighestConfidenceTrafficLightState(
     const lanelet::ConstLineStringsOrPolygons3d & traffic_lights,
-    autoware_perception_msgs::TrafficLightStateStamped & highest_confidence_tl_state);
+    autoware_perception_msgs::msg::TrafficLightStateStamped & highest_confidence_tl_state);
 
   bool isOverDeadLine(
-    const geometry_msgs::Pose & self_pose,
-    const autoware_planning_msgs::PathWithLaneId & input_path, const size_t & dead_line_point_idx,
+    const geometry_msgs::msg::Pose & self_pose,
+    const autoware_planning_msgs::msg::PathWithLaneId & input_path, const size_t & dead_line_point_idx,
     const Eigen::Vector2d & dead_line_point, const double dead_line_range);
 
-  bool isStopRequired(const autoware_perception_msgs::TrafficLightState & tl_state);
+  bool isStopRequired(const autoware_perception_msgs::msg::TrafficLightState & tl_state);
 
   bool createTargetPoint(
-    const autoware_planning_msgs::PathWithLaneId & input,
+    const autoware_planning_msgs::msg::PathWithLaneId & input,
     const boost::geometry::model::linestring<boost::geometry::model::d2::point_xy<double>> &
       stop_line,
     const double & margin, size_t & target_point_idx, Eigen::Vector2d & target_point);
 
   bool hasLamp(
-    const autoware_perception_msgs::TrafficLightState & tl_state, const uint8_t & lamp_color);
+    const autoware_perception_msgs::msg::TrafficLightState & tl_state, const uint8_t & lamp_color);
 
-  geometry_msgs::Point getTrafficLightPosition(
+  geometry_msgs::msg::Point getTrafficLightPosition(
     const lanelet::ConstLineStringOrPolygon3d traffic_light);
 
   // Key Feature
@@ -128,5 +128,5 @@ private:
   DebugData debug_data_;
 
   // Traffic Light State
-  autoware_perception_msgs::TrafficLightStateStamped tl_state_;
+  autoware_perception_msgs::msg::TrafficLightStateStamped tl_state_;
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.h
@@ -17,7 +17,6 @@
 
 #include <memory>
 #include <string>
-#include <unordered_map>
 
 #include <boost/assert.hpp>
 #include <boost/geometry.hpp>
@@ -45,7 +44,8 @@ public:
   {
     double base_link2front;
     std::vector<std::tuple<
-      std::shared_ptr<const lanelet::TrafficLight>, autoware_perception_msgs::msg::TrafficLightState>>
+      std::shared_ptr<const lanelet::TrafficLight>,
+      autoware_perception_msgs::msg::TrafficLightState>>
       tl_state;  // TODO: replace tuple with struct
     std::vector<geometry_msgs::msg::Pose> stop_poses;
     geometry_msgs::msg::Pose first_stop_pose;
@@ -62,7 +62,8 @@ public:
 public:
   TrafficLightModule(
     const int64_t module_id, const lanelet::TrafficLight & traffic_light_reg_elem,
-    lanelet::ConstLanelet lane, const PlannerParam & planner_param);
+    lanelet::ConstLanelet lane, const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(
     autoware_planning_msgs::msg::PathWithLaneId * path,
@@ -97,8 +98,9 @@ private:
 
   bool isOverDeadLine(
     const geometry_msgs::msg::Pose & self_pose,
-    const autoware_planning_msgs::msg::PathWithLaneId & input_path, const size_t & dead_line_point_idx,
-    const Eigen::Vector2d & dead_line_point, const double dead_line_range);
+    const autoware_planning_msgs::msg::PathWithLaneId & input_path,
+    const size_t & dead_line_point_idx, const Eigen::Vector2d & dead_line_point,
+    const double dead_line_range);
 
   bool isStopRequired(const autoware_perception_msgs::msg::TrafficLightState & tl_state);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/boost_geometry_helper.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/boost_geometry_helper.h
@@ -30,10 +30,10 @@
 #include <boost/geometry/geometries/register/point.hpp>
 #include <boost/geometry/geometries/segment.hpp>
 
+#include <tf2/utils.h>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/polygon.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
-#include <tf2/utils.h>
 
 #include <autoware_planning_msgs/msg/path_point.hpp>
 #include <autoware_planning_msgs/msg/path_point_with_lane_id.hpp>
@@ -57,8 +57,8 @@ BOOST_GEOMETRY_REGISTER_POINT_3D(
   autoware_planning_msgs::msg::PathPointWithLaneId, double, cs::cartesian, point.pose.position.x,
   point.pose.position.y, point.pose.position.z)
 BOOST_GEOMETRY_REGISTER_POINT_3D(
-  autoware_planning_msgs::msg::TrajectoryPoint, double, cs::cartesian, pose.position.x, pose.position.y,
-  pose.position.z)
+  autoware_planning_msgs::msg::TrajectoryPoint, double, cs::cartesian, pose.position.x,
+  pose.position.y, pose.position.z)
 
 template <class T>
 Point2d to_bg2d(const T & p)
@@ -104,7 +104,8 @@ inline Polygon2d lines2polygon(const LineString2d & left_line, const LineString2
   return polygon;
 }
 
-inline Polygon2d obj2polygon(const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Vector3 & shape)
+inline Polygon2d obj2polygon(
+  const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Vector3 & shape)
 {
   //rename
   const double x = pose.position.x;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/boost_geometry_helper.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/boost_geometry_helper.h
@@ -30,14 +30,14 @@
 #include <boost/geometry/geometries/register/point.hpp>
 #include <boost/geometry/geometries/segment.hpp>
 
-#include <geometry_msgs/Point.h>
-#include <geometry_msgs/Polygon.h>
-#include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/polygon.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <tf2/utils.h>
 
-#include <autoware_planning_msgs/PathPoint.h>
-#include <autoware_planning_msgs/PathPointWithLaneId.h>
-#include <autoware_planning_msgs/TrajectoryPoint.h>
+#include <autoware_planning_msgs/msg/path_point.hpp>
+#include <autoware_planning_msgs/msg/path_point_with_lane_id.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
 
 using Point2d = boost::geometry::model::d2::point_xy<double>;
 using Segment2d = boost::geometry::model::segment<Point2d>;
@@ -45,19 +45,19 @@ using LineString2d = boost::geometry::model::linestring<Point2d>;
 using Polygon2d =
   boost::geometry::model::polygon<Point2d, false, false>;  // counter-clockwise, open
 
-BOOST_GEOMETRY_REGISTER_POINT_3D(geometry_msgs::Point, double, cs::cartesian, x, y, z)
+BOOST_GEOMETRY_REGISTER_POINT_3D(geometry_msgs::msg::Point, double, cs::cartesian, x, y, z)
 BOOST_GEOMETRY_REGISTER_POINT_3D(
-  geometry_msgs::PoseWithCovarianceStamped, double, cs::cartesian, pose.pose.position.x,
+  geometry_msgs::msg::PoseWithCovarianceStamped, double, cs::cartesian, pose.pose.position.x,
   pose.pose.position.y, pose.pose.position.z)
 
 BOOST_GEOMETRY_REGISTER_POINT_3D(
-  autoware_planning_msgs::PathPoint, double, cs::cartesian, pose.position.x, pose.position.y,
+  autoware_planning_msgs::msg::PathPoint, double, cs::cartesian, pose.position.x, pose.position.y,
   pose.position.z)
 BOOST_GEOMETRY_REGISTER_POINT_3D(
-  autoware_planning_msgs::PathPointWithLaneId, double, cs::cartesian, point.pose.position.x,
+  autoware_planning_msgs::msg::PathPointWithLaneId, double, cs::cartesian, point.pose.position.x,
   point.pose.position.y, point.pose.position.z)
 BOOST_GEOMETRY_REGISTER_POINT_3D(
-  autoware_planning_msgs::TrajectoryPoint, double, cs::cartesian, pose.position.x, pose.position.y,
+  autoware_planning_msgs::msg::TrajectoryPoint, double, cs::cartesian, pose.position.x, pose.position.y,
   pose.position.z)
 
 template <class T>
@@ -104,7 +104,7 @@ inline Polygon2d lines2polygon(const LineString2d & left_line, const LineString2
   return polygon;
 }
 
-inline Polygon2d obj2polygon(const geometry_msgs::Pose & pose, const geometry_msgs::Vector3 & shape)
+inline Polygon2d obj2polygon(const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Vector3 & shape)
 {
   //rename
   const double x = pose.position.x;
@@ -171,10 +171,10 @@ inline std::vector<Segment2d> makeSegments(const LineString2d & ls)
   return segments;
 }
 
-inline geometry_msgs::Polygon toGeomMsg(const Polygon2d & polygon)
+inline geometry_msgs::msg::Polygon toGeomMsg(const Polygon2d & polygon)
 {
-  geometry_msgs::Polygon polygon_msg;
-  geometry_msgs::Point32 point_msg;
+  geometry_msgs::msg::Polygon polygon_msg;
+  geometry_msgs::msg::Point32 point_msg;
   for (const auto & p : polygon.outer()) {
     point_msg.x = p.x();
     point_msg.y = p.y();
@@ -183,7 +183,7 @@ inline geometry_msgs::Polygon toGeomMsg(const Polygon2d & polygon)
   return polygon_msg;
 }
 
-inline Polygon2d toBoostPoly(const geometry_msgs::Polygon & polygon)
+inline Polygon2d toBoostPoly(const geometry_msgs::msg::Polygon & polygon)
 {
   Polygon2d boost_poly;
   for (const auto point : polygon.points) {

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/interpolate.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/interpolate.h
@@ -17,7 +17,6 @@
 #ifndef BEHAVIOR_VELOCITY_PLANNER_UTILIZATION_INTERPOLATE_H_
 #define BEHAVIOR_VELOCITY_PLANNER_UTILIZATION_INTERPOLATE_H_
 #include <cmath>
-#include <iostream>
 #include <vector>
 
 namespace interpolation

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/interpolate.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/interpolate.h
@@ -31,9 +31,6 @@ public:
   static bool interpolate(
     const std::vector<double> & base_index, const std::vector<double> & base_value,
     const std::vector<double> & return_index, std::vector<double> & return_value);
-  static bool interpolate(
-    const std::vector<double> & base_index, const std::vector<double> & base_value,
-    const double & return_index, double & return_value);
 };
 
 /*

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/marker_helper.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/marker_helper.h
@@ -28,7 +28,8 @@ inline geometry_msgs::msg::Point createMarkerPosition(double x, double y, double
   return point;
 }
 
-inline geometry_msgs::msg::Quaternion createMarkerOrientation(double x, double y, double z, double w)
+inline geometry_msgs::msg::Quaternion createMarkerOrientation(
+  double x, double y, double z, double w)
 {
   geometry_msgs::msg::Quaternion quaternion;
 
@@ -63,34 +64,13 @@ inline std_msgs::msg::ColorRGBA createMarkerColor(float r, float g, float b, flo
   return color;
 }
 
-inline visualization_msgs::msg::Marker createDefaultMarker(
-  const char * frame_id, const char * ns, const int32_t id, const int32_t type,
-  const std_msgs::msg::ColorRGBA & color)
-{
-  visualization_msgs::msg::Marker marker;
-
-  marker.header.frame_id = frame_id;
-  marker.header.stamp = this->now();
-  marker.ns = ns;
-  marker.id = id;
-  marker.type = type;
-  marker.action = visualization_msgs::msg::Marker::ADD;
-  marker.lifetime = rclcpp::Duration(0);
-
-  marker.pose.position = createMarkerPosition(0.0, 0.0, 0.0);
-  marker.pose.orientation = createMarkerOrientation(0.0, 0.0, 0.0, 1.0);
-  marker.scale = createMarkerScale(1.0, 1.0, 1.0);
-  marker.color = color;
-  marker.frame_locked = true;
-
-  return marker;
-}
-
 inline void appendMarkerArray(
   const visualization_msgs::msg::MarkerArray & additional_marker_array,
+  const builtin_interfaces::msg::Time current_time,
   visualization_msgs::msg::MarkerArray * marker_array)
 {
   for (const auto & marker : additional_marker_array.markers) {
     marker_array->markers.push_back(marker);
+    marker_array->markers.back().header.stamp = current_time;
   }
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/marker_helper.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/marker_helper.h
@@ -15,11 +15,11 @@
  */
 #pragma once
 
-#include <visualization_msgs/MarkerArray.h>
+#include <visualization_msgs/msg/marker_array.hpp>
 
-inline geometry_msgs::Point createMarkerPosition(double x, double y, double z)
+inline geometry_msgs::msg::Point createMarkerPosition(double x, double y, double z)
 {
-  geometry_msgs::Point point;
+  geometry_msgs::msg::Point point;
 
   point.x = x;
   point.y = y;
@@ -28,9 +28,9 @@ inline geometry_msgs::Point createMarkerPosition(double x, double y, double z)
   return point;
 }
 
-inline geometry_msgs::Quaternion createMarkerOrientation(double x, double y, double z, double w)
+inline geometry_msgs::msg::Quaternion createMarkerOrientation(double x, double y, double z, double w)
 {
-  geometry_msgs::Quaternion quaternion;
+  geometry_msgs::msg::Quaternion quaternion;
 
   quaternion.x = x;
   quaternion.y = y;
@@ -40,9 +40,9 @@ inline geometry_msgs::Quaternion createMarkerOrientation(double x, double y, dou
   return quaternion;
 }
 
-inline geometry_msgs::Vector3 createMarkerScale(double x, double y, double z)
+inline geometry_msgs::msg::Vector3 createMarkerScale(double x, double y, double z)
 {
-  geometry_msgs::Vector3 scale;
+  geometry_msgs::msg::Vector3 scale;
 
   scale.x = x;
   scale.y = y;
@@ -51,9 +51,9 @@ inline geometry_msgs::Vector3 createMarkerScale(double x, double y, double z)
   return scale;
 }
 
-inline std_msgs::ColorRGBA createMarkerColor(float r, float g, float b, float a)
+inline std_msgs::msg::ColorRGBA createMarkerColor(float r, float g, float b, float a)
 {
-  std_msgs::ColorRGBA color;
+  std_msgs::msg::ColorRGBA color;
 
   color.r = r;
   color.g = g;
@@ -63,19 +63,19 @@ inline std_msgs::ColorRGBA createMarkerColor(float r, float g, float b, float a)
   return color;
 }
 
-inline visualization_msgs::Marker createDefaultMarker(
+inline visualization_msgs::msg::Marker createDefaultMarker(
   const char * frame_id, const char * ns, const int32_t id, const int32_t type,
-  const std_msgs::ColorRGBA & color)
+  const std_msgs::msg::ColorRGBA & color)
 {
-  visualization_msgs::Marker marker;
+  visualization_msgs::msg::Marker marker;
 
   marker.header.frame_id = frame_id;
-  marker.header.stamp = ros::Time::now();
+  marker.header.stamp = this->now();
   marker.ns = ns;
   marker.id = id;
   marker.type = type;
-  marker.action = visualization_msgs::Marker::ADD;
-  marker.lifetime = ros::Duration(0);
+  marker.action = visualization_msgs::msg::Marker::ADD;
+  marker.lifetime = rclcpp::Duration(0);
 
   marker.pose.position = createMarkerPosition(0.0, 0.0, 0.0);
   marker.pose.orientation = createMarkerOrientation(0.0, 0.0, 0.0, 1.0);
@@ -87,8 +87,8 @@ inline visualization_msgs::Marker createDefaultMarker(
 }
 
 inline void appendMarkerArray(
-  const visualization_msgs::MarkerArray & additional_marker_array,
-  visualization_msgs::MarkerArray * marker_array)
+  const visualization_msgs::msg::MarkerArray & additional_marker_array,
+  visualization_msgs::msg::MarkerArray * marker_array)
 {
   for (const auto & marker : additional_marker_array.markers) {
     marker_array->markers.push_back(marker);

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/path_utilization.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/path_utilization.h
@@ -15,9 +15,9 @@
  */
 #pragma once
 
-#include <autoware_planning_msgs/Path.h>
+#include <autoware_planning_msgs/msg/path.hpp>
 
-autoware_planning_msgs::Path interpolatePath(
-  const autoware_planning_msgs::Path & path, const double length);
-autoware_planning_msgs::Path filterLitterPathPoint(const autoware_planning_msgs::Path & path);
-autoware_planning_msgs::Path filterStopPathPoint(const autoware_planning_msgs::Path & path);
+autoware_planning_msgs::msg::Path interpolatePath(
+  const autoware_planning_msgs::msg::Path & path, const double length);
+autoware_planning_msgs::msg::Path filterLitterPathPoint(const autoware_planning_msgs::msg::Path & path);
+autoware_planning_msgs::msg::Path filterStopPathPoint(const autoware_planning_msgs::msg::Path & path);

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/path_utilization.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/path_utilization.h
@@ -15,9 +15,14 @@
  */
 #pragma once
 
+#include <rclcpp/rclcpp.hpp>
+
 #include <autoware_planning_msgs/msg/path.hpp>
 
 autoware_planning_msgs::msg::Path interpolatePath(
-  const autoware_planning_msgs::msg::Path & path, const double length);
-autoware_planning_msgs::msg::Path filterLitterPathPoint(const autoware_planning_msgs::msg::Path & path);
-autoware_planning_msgs::msg::Path filterStopPathPoint(const autoware_planning_msgs::msg::Path & path);
+  const autoware_planning_msgs::msg::Path & path, const double length,
+  const rclcpp::Logger & logger);
+autoware_planning_msgs::msg::Path filterLitterPathPoint(
+  const autoware_planning_msgs::msg::Path & path);
+autoware_planning_msgs::msg::Path filterStopPathPoint(
+  const autoware_planning_msgs::msg::Path & path);

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/util.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/util.h
@@ -18,17 +18,17 @@
 #ifndef COMMON_MATH_PLANNING_UTILS_H
 #define COMMON_MATH_PLANNING_UTILS_H
 
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <autoware_planning_msgs/Path.h>
-#include <autoware_planning_msgs/PathWithLaneId.h>
-#include <autoware_planning_msgs/StopReason.h>
-#include <autoware_planning_msgs/Trajectory.h>
-#include <autoware_planning_msgs/TrajectoryPoint.h>
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/Quaternion.h>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_planning_msgs/msg/path.hpp>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
+#include <autoware_planning_msgs/msg/stop_reason.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
 #include <pcl_ros/point_cloud.h>
 #include <tf2/utils.h>
-#include <visualization_msgs/Marker.h>
+#include <visualization_msgs/msg/marker.hpp>
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
@@ -37,33 +37,33 @@
 using Point2d = boost::geometry::model::d2::point_xy<double>;
 namespace planning_utils
 {
-inline geometry_msgs::Point getPoint(const geometry_msgs::Point & p) { return p; }
-inline geometry_msgs::Point getPoint(const geometry_msgs::Pose & p) { return p.position; }
-inline geometry_msgs::Point getPoint(const geometry_msgs::PoseStamped & p)
+inline geometry_msgs::msg::Point getPoint(const geometry_msgs::msg::Point & p) { return p; }
+inline geometry_msgs::msg::Point getPoint(const geometry_msgs::msg::Pose & p) { return p.position; }
+inline geometry_msgs::msg::Point getPoint(const geometry_msgs::msg::PoseStamped & p)
 {
   return p.pose.position;
 }
-inline geometry_msgs::Point getPoint(const autoware_planning_msgs::PathPoint & p)
+inline geometry_msgs::msg::Point getPoint(const autoware_planning_msgs::msg::PathPoint & p)
 {
   return p.pose.position;
 }
-inline geometry_msgs::Point getPoint(const autoware_planning_msgs::PathPointWithLaneId & p)
+inline geometry_msgs::msg::Point getPoint(const autoware_planning_msgs::msg::PathPointWithLaneId & p)
 {
   return p.point.pose.position;
 }
-inline geometry_msgs::Point getPoint(const autoware_planning_msgs::TrajectoryPoint & p)
+inline geometry_msgs::msg::Point getPoint(const autoware_planning_msgs::msg::TrajectoryPoint & p)
 {
   return p.pose.position;
 }
-inline geometry_msgs::Pose getPose(const autoware_planning_msgs::Path & path, int idx)
+inline geometry_msgs::msg::Pose getPose(const autoware_planning_msgs::msg::Path & path, int idx)
 {
   return path.points.at(idx).pose;
 }
-inline geometry_msgs::Pose getPose(const autoware_planning_msgs::PathWithLaneId & path, int idx)
+inline geometry_msgs::msg::Pose getPose(const autoware_planning_msgs::msg::PathWithLaneId & path, int idx)
 {
   return path.points.at(idx).point.pose;
 }
-inline geometry_msgs::Pose getPose(const autoware_planning_msgs::Trajectory & traj, int idx)
+inline geometry_msgs::msg::Pose getPose(const autoware_planning_msgs::msg::Trajectory & traj, int idx)
 {
   return traj.points.at(idx).pose;
 }
@@ -72,7 +72,7 @@ inline int64_t bitShift(int64_t original_id) { return (original_id << (sizeof(in
 
 inline double square(const double & a) { return a * a; }
 double normalizeEulerAngle(double euler);
-geometry_msgs::Quaternion getQuaternionFromYaw(double yaw);
+geometry_msgs::msg::Quaternion getQuaternionFromYaw(double yaw);
 
 template <class T1, class T2>
 double calcSquaredDist2d(const T1 & a, const T2 & b)
@@ -88,31 +88,31 @@ double calcDist2d(const T1 & a, const T2 & b)
 
 template <class T>
 bool calcClosestIndex(
-  const T & path, const geometry_msgs::Pose & pose, int & closest, double dist_thr = 3.0,
+  const T & path, const geometry_msgs::msg::Pose & pose, int & closest, double dist_thr = 3.0,
   double angle_thr = M_PI_4);
 
 template <class T>
 bool calcClosestIndex(
-  const T & path, const geometry_msgs::Point & point, int & closest, double dist_thr = 3.0);
+  const T & path, const geometry_msgs::msg::Point & point, int & closest, double dist_thr = 3.0);
 
-geometry_msgs::Pose transformRelCoordinate2D(
-  const geometry_msgs::Pose & target, const geometry_msgs::Pose & origin);
-geometry_msgs::Pose transformAbsCoordinate2D(
-  const geometry_msgs::Pose & relative, const geometry_msgs::Pose & origin);
+geometry_msgs::msg::Pose transformRelCoordinate2D(
+  const geometry_msgs::msg::Pose & target, const geometry_msgs::msg::Pose & origin);
+geometry_msgs::msg::Pose transformAbsCoordinate2D(
+  const geometry_msgs::msg::Pose & relative, const geometry_msgs::msg::Pose & origin);
 
 double calcJudgeLineDist(
   const double velocity, const double max_stop_acceleration, const double delay_response_time);
 
-autoware_planning_msgs::StopReason initializeStopReason(const std::string & stop_reason);
+autoware_planning_msgs::msg::StopReason initializeStopReason(const std::string & stop_reason);
 void appendStopReason(
-  const autoware_planning_msgs::StopFactor stop_factor,
-  autoware_planning_msgs::StopReason * stop_reason);
+  const autoware_planning_msgs::msg::StopFactor stop_factor,
+  autoware_planning_msgs::msg::StopReason * stop_reason);
 
-std::vector<geometry_msgs::Point> toRosPoints(
-  const autoware_perception_msgs::DynamicObjectArray & object);
+std::vector<geometry_msgs::msg::Point> toRosPoints(
+  const autoware_perception_msgs::msg::DynamicObjectArray & object);
 
-geometry_msgs::Point toRosPoint(const pcl::PointXYZ & pcl_point);
-geometry_msgs::Point toRosPoint(const Point2d & boost_point, const double z);
+geometry_msgs::msg::Point toRosPoint(const pcl::PointXYZ & pcl_point);
+geometry_msgs::msg::Point toRosPoint(const Point2d & boost_point, const double z);
 
 template <class T>
 std::vector<T> concatVector(const std::vector<T> & vec1, const std::vector<T> & vec2)

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/util.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/util.h
@@ -18,21 +18,22 @@
 #ifndef COMMON_MATH_PLANNING_UTILS_H
 #define COMMON_MATH_PLANNING_UTILS_H
 
+#include <vector>
+
+#include <pcl/point_types.h>
+#include <tf2/utils.h>
 #include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
 #include <autoware_planning_msgs/msg/path.hpp>
 #include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_planning_msgs/msg/stop_reason.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
-#include <geometry_msgs/msg/pose_stamped.hpp>
-#include <geometry_msgs/msg/quaternion.hpp>
-#include <pcl_ros/point_cloud.h>
-#include <tf2/utils.h>
-#include <visualization_msgs/msg/marker.hpp>
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
-#include <vector>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
+#include <visualization_msgs/msg/marker.hpp>
 
 using Point2d = boost::geometry::model::d2::point_xy<double>;
 namespace planning_utils
@@ -47,7 +48,8 @@ inline geometry_msgs::msg::Point getPoint(const autoware_planning_msgs::msg::Pat
 {
   return p.pose.position;
 }
-inline geometry_msgs::msg::Point getPoint(const autoware_planning_msgs::msg::PathPointWithLaneId & p)
+inline geometry_msgs::msg::Point getPoint(
+  const autoware_planning_msgs::msg::PathPointWithLaneId & p)
 {
   return p.point.pose.position;
 }
@@ -59,11 +61,13 @@ inline geometry_msgs::msg::Pose getPose(const autoware_planning_msgs::msg::Path 
 {
   return path.points.at(idx).pose;
 }
-inline geometry_msgs::msg::Pose getPose(const autoware_planning_msgs::msg::PathWithLaneId & path, int idx)
+inline geometry_msgs::msg::Pose getPose(
+  const autoware_planning_msgs::msg::PathWithLaneId & path, int idx)
 {
   return path.points.at(idx).point.pose;
 }
-inline geometry_msgs::msg::Pose getPose(const autoware_planning_msgs::msg::Trajectory & traj, int idx)
+inline geometry_msgs::msg::Pose getPose(
+  const autoware_planning_msgs::msg::Trajectory & traj, int idx)
 {
   return traj.points.at(idx).pose;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
@@ -17,33 +17,33 @@
 
 
   <node pkg="behavior_velocity_planner" type="behavior_velocity_planner_node" name="behavior_velocity_planner" output="screen">
-    <rosparam command="load" file="$(find behavior_velocity_planner)/config/blind_spot_param.yaml" />
-    <rosparam command="load" file="$(find behavior_velocity_planner)/config/crosswalk_param.yaml" />
-    <rosparam command="load" file="$(find behavior_velocity_planner)/config/detection_area_param.yaml" />
-    <rosparam command="load" file="$(find behavior_velocity_planner)/config/intersection_param.yaml" />
-    <rosparam command="load" file="$(find behavior_velocity_planner)/config/stop_line_param.yaml" />
-    <rosparam command="load" file="$(find behavior_velocity_planner)/config/traffic_light_param.yaml" />
+    <rosparam command="load" file="$(find-pkg-share behavior_velocity_planner)/config/blind_spot_param.yaml" />
+    <rosparam command="load" file="$(find-pkg-share behavior_velocity_planner)/config/crosswalk_param.yaml" />
+    <rosparam command="load" file="$(find-pkg-share behavior_velocity_planner)/config/detection_area_param.yaml" />
+    <rosparam command="load" file="$(find-pkg-share behavior_velocity_planner)/config/intersection_param.yaml" />
+    <rosparam command="load" file="$(find-pkg-share behavior_velocity_planner)/config/stop_line_param.yaml" />
+    <rosparam command="load" file="$(find-pkg-share behavior_velocity_planner)/config/traffic_light_param.yaml" />
 
-    <remap from="~input/path_with_lane_id" to="path_with_lane_id" />
-    <remap from="~input/vector_map" to="$(arg map_topic_name)" />
-    <remap from="~input/vehicle_velocity" to="/localization/twist" />
-    <remap from="~input/dynamic_objects" to="/perception/object_recognition/objects" />
-    <remap from="~input/no_ground_pointcloud" to="/sensing/lidar/no_ground/pointcloud" />
-    <remap from="~input/traffic_light_states" to="$(arg input_traffic_light_topic_name)" />
-    <remap from="~output/path" to="path" />
-    <remap from="~output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons" />
-    <remap from="~output/traffic_light_state" to="debug/traffic_light_state" />
+    <remap from="input/path_with_lane_id" to="path_with_lane_id" />
+    <remap from="input/vector_map" to="$(var map_topic_name)" />
+    <remap from="input/vehicle_velocity" to="/localization/twist" />
+    <remap from="input/dynamic_objects" to="/perception/object_recognition/objects" />
+    <remap from="input/no_ground_pointcloud" to="/sensing/lidar/no_ground/pointcloud" />
+    <remap from="input/traffic_light_states" to="$(var input_traffic_light_topic_name)" />
+    <remap from="output/path" to="path" />
+    <remap from="output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons" />
+    <remap from="output/traffic_light_state" to="debug/traffic_light_state" />
 
-    <param name="launch_stop_line" value="$(arg launch_stop_line)" />
-    <param name="launch_crosswalk" value="$(arg launch_crosswalk)" />
-    <param name="launch_traffic_light" value="$(arg launch_traffic_light)" />
-    <param name="launch_intersection" value="$(arg launch_intersection)" />
-    <param name="launch_blind_spot" value="$(arg launch_blind_spot)" />
-    <param name="launch_detection_area" value="$(arg launch_detection_area)" />
+    <param name="launch_stop_line" value="$(var launch_stop_line)" />
+    <param name="launch_crosswalk" value="$(var launch_crosswalk)" />
+    <param name="launch_traffic_light" value="$(var launch_traffic_light)" />
+    <param name="launch_intersection" value="$(var launch_intersection)" />
+    <param name="launch_blind_spot" value="$(var launch_blind_spot)" />
+    <param name="launch_detection_area" value="$(var launch_detection_area)" />
 
-    <param name="forward_path_length" value="$(arg forward_path_length)" />
-    <param name="backward_path_length" value="$(arg backward_path_length)" />
-    <param name="max_accel" value="$(arg max_accel)" />
-    <param name="delay_response_time" value="$(arg delay_response_time)" />
+    <param name="forward_path_length" value="$(var forward_path_length)" />
+    <param name="backward_path_length" value="$(var backward_path_length)" />
+    <param name="max_accel" value="$(var max_accel)" />
+    <param name="delay_response_time" value="$(var delay_response_time)" />
   </node>
 </launch>

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/package.xml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/package.xml
@@ -14,6 +14,7 @@
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>eigen</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
   <depend>rclcpp</depend>
@@ -24,6 +25,7 @@
   <depend>tf2_ros</depend>
   <depend>tf2_eigen</depend>
   <depend>pcl_conversions</depend>
+  <depend>vehicle_info_util</depend>
   <depend>visualization_msgs</depend>
 
   <export>

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/package.xml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>behavior_velocity_planner</name>
   <version>0.1.0</version>
   <description>The behavior_velocity_planner package</description>
@@ -7,87 +8,25 @@
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <license>Apache2</license>
 
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>eigen3_cmake_modules</buildtool_depend>
 
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/behavior_velocity_planner</url> -->
+  <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
+  <depend>eigen</depend>
+  <depend>geometry_msgs</depend>
+  <depend>lanelet2_extension</depend>
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>spline_interpolation</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_eigen</depend>
+  <depend>pcl_conversions</depend>
+  <depend>visualization_msgs</depend>
 
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>autoware_perception_msgs</build_depend>
-  <build_depend>autoware_planning_msgs</build_depend>
-  <build_depend>autoware_perception_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>lanelet2_extension</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>spline_interpolation</build_depend>
-  <build_depend>tf2</build_depend>
-  <build_depend>tf2_geometry_msgs</build_depend>
-  <build_depend>tf2_ros</build_depend>
-  <build_depend>tf2_eigen</build_depend>
-  <build_depend>pcl_ros</build_depend>
-  <build_depend>visualization_msgs</build_depend>
-  <build_export_depend>autoware_perception_msgs</build_export_depend>
-  <build_export_depend>autoware_planning_msgs</build_export_depend>
-  <build_export_depend>autoware_perception_msgs</build_export_depend>
-  <build_export_depend>geometry_msgs</build_export_depend>
-  <build_export_depend>lanelet2_extension</build_export_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>sensor_msgs</build_export_depend>
-  <build_export_depend>spline_interpolation</build_export_depend>
-  <build_export_depend>tf2</build_export_depend>
-  <build_export_depend>tf2_geometry_msgs</build_export_depend>
-  <build_export_depend>tf2_ros</build_export_depend>
-  <build_export_depend>tf2_eigen</build_export_depend>
-  <build_export_depend>pcl_ros</build_export_depend>
-  <build_export_depend>visualization_msgs</build_export_depend>
-  <exec_depend>autoware_perception_msgs</exec_depend>
-  <exec_depend>autoware_planning_msgs</exec_depend>
-  <exec_depend>autoware_perception_msgs</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>lanelet2_extension</exec_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>spline_interpolation</exec_depend>
-  <exec_depend>tf2</exec_depend>
-  <exec_depend>tf2_geometry_msgs</exec_depend>
-  <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>tf2_eigen</exec_depend>
-  <exec_depend>pcl_ros</exec_depend>
-  <exec_depend>visualization_msgs</exec_depend>
-
-
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- Other tools can request additional information be placed here -->
-
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/package.xml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/package.xml
@@ -9,7 +9,7 @@
   <license>Apache2</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-  <buildtool_depend>eigen3_cmake_modules</buildtool_depend>
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/package.xml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/package.xml
@@ -8,11 +8,12 @@
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <license>Apache2</license>
 
-  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>libboost-dev</depend>
   <depend>eigen</depend>
   <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/main.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/main.cpp
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <behavior_velocity_planner/node.h>
 
 int main(int argc, char ** argv)
 {
-  ros::init(argc, argv, "behavior_velocity_planner_node");
-
-  BehaviorVelocityPlannerNode node;
-
-  ros::spin();
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<BehaviorVelocityPlannerNode>());
+  rclcpp::shutdown();
 
   return 0;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/node.cpp
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+#include <functional>
+
 #include <behavior_velocity_planner/node.h>
 
-#include <pcl_ros/transforms.h>
+#include <pcl/common/transforms.h>
 #include <tf2_eigen/tf2_eigen.h>
 
 #include <lanelet2_extension/utility/message_conversion.h>
@@ -30,71 +32,15 @@
 // Scene modules
 #include <scene_module/blind_spot/manager.h>
 #include <scene_module/crosswalk/manager.h>
+#include <scene_module/detection_area/manager.h>
 #include <scene_module/intersection/manager.h>
 #include <scene_module/stop_line/manager.h>
 #include <scene_module/traffic_light/manager.h>
-#include <scene_module/detection_area/manager.h>
 
 namespace
 {
-template <class T>
-T getParam(const rclcpp::NodeHandle & nh, const std::string & key, const T & default_value)
-{
-  T value;
-  nh.param<T>(key, value, default_value);
-  return value;
-}
-
-template <class T>
-T waitForParam(const rclcpp::NodeHandle & nh, const std::string & key)
-{
-  T value;
-
-  rclcpp::Rate rate(1.0);
-  while (rclcpp::ok()) {
-    const auto result = nh.getParam(key, value);
-    if (result) {
-      return value;
-    }
-
-    ROS_INFO("waiting for parameter `%s` ...", key.c_str());
-    rate.sleep();
-  }
-
-  return {};
-}
-
-std::shared_ptr<geometry_msgs::msg::TransformStamped> getTransform(
-  const tf2_ros::Buffer & tf_buffer, const std::string & from, const std::string & to,
-  const rclcpp::Time & time = rclcpp::Time(0), const rclcpp::Duration & duration = rclcpp::Duration(0.1))
-{
-  try {
-    return std::make_shared<geometry_msgs::msg::TransformStamped>(
-      tf_buffer.lookupTransform(from, to, time, duration));
-  } catch (tf2::TransformException & ex) {
-    return {};
-  }
-}
-
-geometry_msgs::msg::TransformStamped waitForTransform(
-  const tf2_ros::Buffer & tf_buffer, const std::string & from, const std::string & to,
-  const rclcpp::Time & time = rclcpp::Time(0), const rclcpp::Duration & duration = rclcpp::Duration(0.1))
-{
-  rclcpp::Rate rate(1.0);
-  while (rclcpp::ok()) {
-    const auto transform = getTransform(tf_buffer, from, to, time, duration);
-    if (transform) {
-      return *transform;
-    }
-
-    ROS_INFO(
-      "waiting for transform from `%s` to `%s` ... (time = %f, now = %f)", from.c_str(), to.c_str(),
-      time.toSec(), this->now().toSec());
-    rate.sleep();
-  }
-}
-
-geometry_msgs::msg::PoseStamped transform2pose(const geometry_msgs::msg::TransformStamped & transform)
+geometry_msgs::msg::PoseStamped transform2pose(
+  const geometry_msgs::msg::TransformStamped & transform)
 {
   geometry_msgs::msg::PoseStamped pose;
   pose.header = transform.header;
@@ -105,7 +51,8 @@ geometry_msgs::msg::PoseStamped transform2pose(const geometry_msgs::msg::Transfo
   return pose;
 }
 
-autoware_planning_msgs::msg::Path to_path(const autoware_planning_msgs::msg::PathWithLaneId & path_with_id)
+autoware_planning_msgs::msg::Path to_path(
+  const autoware_planning_msgs::msg::PathWithLaneId & path_with_id)
 {
   autoware_planning_msgs::msg::Path path;
   for (const auto & path_point : path_with_id.points) {
@@ -116,19 +63,34 @@ autoware_planning_msgs::msg::Path to_path(const autoware_planning_msgs::msg::Pat
 }  // namespace
 
 BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode()
-: nh_(), pnh_("~"), tf_listener_(tf_buffer_)
+: Node("behavior_velocity_planner_node"),
+  tf_buffer_(this->get_clock()),
+  tf_listener_(tf_buffer_),
+  planner_data_(*this)
 {
+  using std::placeholders::_1;
   // Trigger Subscriber
   trigger_sub_path_with_lane_id_ =
-    this->create_subscription<TODO>("input/path_with_lane_id", 1, &BehaviorVelocityPlannerNode::onTrigger, this);
+    this->create_subscription<autoware_planning_msgs::msg::PathWithLaneId>(
+      "input/path_with_lane_id", 1, std::bind(&BehaviorVelocityPlannerNode::onTrigger, this, _1));
 
   // Subscribers
-  sub_dynamic_objects_ = this->create_subscription<TODO>("input/dynamic_objects", 1, &BehaviorVelocityPlannerNode::onDynamicObjects, this);
-  sub_no_ground_pointcloud_ = this->create_subscription<TODO>("input/no_ground_pointcloud", 1, &BehaviorVelocityPlannerNode::onNoGroundPointCloud, this);
-  sub_vehicle_velocity_ = this->create_subscription<TODO>("input/vehicle_velocity", 1, &BehaviorVelocityPlannerNode::onVehicleVelocity, this);
-  sub_lanelet_map_ =
-    this->create_subscription<TODO>("input/vector_map", 10, &BehaviorVelocityPlannerNode::onLaneletMap, this);
-  sub_traffic_light_states_ = this->create_subscription<TODO>("input/traffic_light_states", 10, &BehaviorVelocityPlannerNode::onTrafficLightStates, this);
+  sub_dynamic_objects_ =
+    this->create_subscription<autoware_perception_msgs::msg::DynamicObjectArray>(
+      "input/dynamic_objects", 1,
+      std::bind(&BehaviorVelocityPlannerNode::onDynamicObjects, this, _1));
+  sub_no_ground_pointcloud_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
+    "input/no_ground_pointcloud", 1,
+    std::bind(&BehaviorVelocityPlannerNode::onNoGroundPointCloud, this, _1));
+  sub_vehicle_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+    "input/vehicle_velocity", 1,
+    std::bind(&BehaviorVelocityPlannerNode::onVehicleVelocity, this, _1));
+  sub_lanelet_map_ = this->create_subscription<autoware_lanelet2_msgs::msg::MapBin>(
+    "input/vector_map", 10, std::bind(&BehaviorVelocityPlannerNode::onLaneletMap, this, _1));
+  sub_traffic_light_states_ =
+    this->create_subscription<autoware_perception_msgs::msg::TrafficLightStateArray>(
+      "input/traffic_light_states", 10,
+      std::bind(&BehaviorVelocityPlannerNode::onTrafficLightStates, this, _1));
 
   // Publishers
   path_pub_ = this->create_publisher<autoware_planning_msgs::msg::Path>("output/path", 1);
@@ -137,39 +99,22 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode()
   debug_viz_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("debug/path", 1);
 
   // Parameters
-  pnh_.param("forward_path_length", forward_path_length_, 1000.0);
-  pnh_.param("backward_path_length", backward_path_length_, 5.0);
-
-  // Vehicle Parameters
-  planner_data_.wheel_base = waitForParam<double>(pnh_, "/vehicle_info/wheel_base");
-  planner_data_.front_overhang = waitForParam<double>(pnh_, "/vehicle_info/front_overhang");
-  planner_data_.vehicle_width = waitForParam<double>(pnh_, "/vehicle_info/vehicle_width");
-  // Additional Vehicle Parameters
-  pnh_.param(
-    "max_accel", planner_data_.max_stop_acceleration_threshold_,
-    -5.0);  // TODO read min_acc in velocity_controller_param.yaml?
-  pnh_.param("delay_response_time", planner_data_.delay_response_time_, 1.3);
-  // TODO(Kenji Miyake): get from additional vehicle_info?
-  planner_data_.base_link2front = planner_data_.front_overhang + planner_data_.wheel_base;
+  forward_path_length_ = this->declare_parameter("forward_path_length", 1000.0);
+  backward_path_length_ = this->declare_parameter("backward_path_length", 5.0);
 
   // Initialize PlannerManager
-  if (getParam<bool>(pnh_, "launch_stop_line", true))
-    planner_manager_.launchSceneModule(std::make_shared<StopLineModuleManager>());
-  if (getParam<bool>(pnh_, "launch_crosswalk", true))
-    planner_manager_.launchSceneModule(std::make_shared<CrosswalkModuleManager>());
-  if (getParam<bool>(pnh_, "launch_traffic_light", true))
-    planner_manager_.launchSceneModule(std::make_shared<TrafficLightModuleManager>());
-  if (getParam<bool>(pnh_, "launch_intersection", true))
-    planner_manager_.launchSceneModule(std::make_shared<IntersectionModuleManager>());
-  if (getParam<bool>(pnh_, "launch_blind_spot", true))
-    planner_manager_.launchSceneModule(std::make_shared<BlindSpotModuleManager>());
-  if (getParam<bool>(pnh_, "launch_detection_area", true))
-    planner_manager_.launchSceneModule(std::make_shared<DetectionAreaModuleManager>());
-}
-
-geometry_msgs::msg::PoseStamped BehaviorVelocityPlannerNode::getCurrentPose()
-{
-  return transform2pose(waitForTransform(tf_buffer_, "map", "base_link"));
+  if (this->declare_parameter("launch_stop_line", true))
+    planner_manager_.launchSceneModule(std::make_shared<StopLineModuleManager>(*this));
+  if (this->declare_parameter("launch_crosswalk", true))
+    planner_manager_.launchSceneModule(std::make_shared<CrosswalkModuleManager>(*this));
+  if (this->declare_parameter("launch_traffic_light", true))
+    planner_manager_.launchSceneModule(std::make_shared<TrafficLightModuleManager>(*this));
+  if (this->declare_parameter("launch_intersection", true))
+    planner_manager_.launchSceneModule(std::make_shared<IntersectionModuleManager>(*this));
+  if (this->declare_parameter("launch_blind_spot", true))
+    planner_manager_.launchSceneModule(std::make_shared<BlindSpotModuleManager>(*this));
+  if (this->declare_parameter("launch_detection_area", true))
+    planner_manager_.launchSceneModule(std::make_shared<DetectionAreaModuleManager>(*this));
 }
 
 bool BehaviorVelocityPlannerNode::isDataReady()
@@ -189,39 +134,41 @@ bool BehaviorVelocityPlannerNode::isDataReady()
 }
 
 void BehaviorVelocityPlannerNode::onDynamicObjects(
-  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr & msg)
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr msg)
 {
   planner_data_.dynamic_objects = msg;
 }
 
 void BehaviorVelocityPlannerNode::onNoGroundPointCloud(
-  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
-  const auto transform =
-    getTransform(tf_buffer_, "map", msg->header.frame_id, msg->header.stamp, rclcpp::Duration(0.1));
-  if (!transform) {
-    ROS_WARN("no transform found for no_ground_pointcloud");
+  geometry_msgs::msg::TransformStamped transform;
+  try {
+    transform = tf_buffer_.lookupTransform(
+      "map", msg->header.frame_id, msg->header.stamp, rclcpp::Duration(0.1));
+  } catch (tf2::LookupException & e) {
+    RCLCPP_WARN(get_logger(), "no transform found for no_ground_pointcloud");
     return;
   }
 
-  pcl::PointCloud<pcl::PointXYZ>::Ptr no_ground_pointcloud(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::PointCloud<pcl::PointXYZ> pc;
+  pcl::fromROSMsg(*msg, pc);
 
-  Eigen::Matrix4f affine = tf2::transformToEigen(transform->transform).matrix().cast<float>();
-  sensor_msgs::msg::PointCloud2 transformed_msg;
-  pcl_ros::transformPointCloud(affine, *msg, transformed_msg);
+  Eigen::Affine3f affine = tf2::transformToEigen(transform.transform).cast<float>();
+  pcl::PointCloud<pcl::PointXYZ>::Ptr pc_transformed(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::transformPointCloud(pc, *pc_transformed, affine);
 
-  pcl::fromROSMsg(transformed_msg, *no_ground_pointcloud);
-
-  planner_data_.no_ground_pointcloud = no_ground_pointcloud;
+  planner_data_.no_ground_pointcloud = pc_transformed;
 }
 
 void BehaviorVelocityPlannerNode::onVehicleVelocity(
-  const geometry_msgs::msg::TwistStamped::ConstSharedPtr & msg)
+  const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
 {
   planner_data_.current_velocity = msg;
 }
 
-void BehaviorVelocityPlannerNode::onLaneletMap(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr & msg)
+void BehaviorVelocityPlannerNode::onLaneletMap(
+  const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr msg)
 {
   // Load map
   planner_data_.lanelet_map = std::make_shared<lanelet::LaneletMap>();
@@ -253,7 +200,7 @@ void BehaviorVelocityPlannerNode::onLaneletMap(const autoware_lanelet2_msgs::msg
 }
 
 void BehaviorVelocityPlannerNode::onTrafficLightStates(
-  const autoware_perception_msgs::msg::TrafficLightStateArray::ConstSharedPtr & msg)
+  const autoware_perception_msgs::msg::TrafficLightStateArray::ConstSharedPtr msg)
 {
   for (const auto & state : msg->states) {
     autoware_perception_msgs::msg::TrafficLightStateStamped traffic_light_state;
@@ -264,23 +211,31 @@ void BehaviorVelocityPlannerNode::onTrafficLightStates(
 }
 
 void BehaviorVelocityPlannerNode::onTrigger(
-  const autoware_planning_msgs::msg::PathWithLaneId & input_path_msg)
+  const autoware_planning_msgs::msg::PathWithLaneId::ConstSharedPtr input_path_msg)
 {
   // Check ready
-  planner_data_.current_pose = getCurrentPose();
+  try {
+    planner_data_.current_pose =
+      transform2pose(tf_buffer_.lookupTransform("map", "base_link", tf2::TimePointZero));
+  } catch (tf2::LookupException & e) {
+    RCLCPP_INFO(get_logger(), "waiting for transform from `map` to `base_link`");
+    return;
+  }
+
   if (!isDataReady()) {
     return;
   }
 
   // Plan path velocity
   const auto velocity_planned_path = planner_manager_.planPathVelocity(
-    std::make_shared<const PlannerData>(planner_data_), input_path_msg);
+    std::make_shared<const PlannerData>(planner_data_), *input_path_msg);
 
   // screening
   const auto filtered_path = filterLitterPathPoint(to_path(velocity_planned_path));
 
   // interpolation
-  const auto interpolated_path_msg = interpolatePath(filtered_path, forward_path_length_);
+  const auto interpolated_path_msg =
+    interpolatePath(filtered_path, forward_path_length_, this->get_logger());
 
   // check stop point
   auto output_path_msg = filterStopPathPoint(interpolated_path_msg);
@@ -288,20 +243,20 @@ void BehaviorVelocityPlannerNode::onTrigger(
   output_path_msg.header.stamp = this->now();
 
   // TODO: This must be updated in each scene module, but copy from input message for now.
-  output_path_msg.drivable_area = input_path_msg.drivable_area;
+  output_path_msg.drivable_area = input_path_msg->drivable_area;
 
   path_pub_->publish(output_path_msg);
-  stop_reason_diag_pub_.publish(planner_manager_.getStopReasonDiag());
-  publishDebugMarker(output_path_msg, debug_viz_pub_);
+  stop_reason_diag_pub_->publish(planner_manager_.getStopReasonDiag());
+
+  if (debug_viz_pub_->get_subscription_count() > 0) {
+    publishDebugMarker(output_path_msg);
+  }
 
   return;
-};
+}
 
-void BehaviorVelocityPlannerNode::publishDebugMarker(
-  const autoware_planning_msgs::msg::Path & path, const rclcpp::Publisher & pub)
+void BehaviorVelocityPlannerNode::publishDebugMarker(const autoware_planning_msgs::msg::Path & path)
 {
-  if (pub.getNumSubscribers() < 1) return;
-
   visualization_msgs::msg::MarkerArray output_msg;
   for (size_t i = 0; i < path.points.size(); ++i) {
     visualization_msgs::msg::Marker marker;
@@ -319,5 +274,5 @@ void BehaviorVelocityPlannerNode::publishDebugMarker(
     marker.color.b = 1.0;
     output_msg.markers.push_back(marker);
   }
-  pub->publish(output_msg);
+  debug_viz_pub_->publish(output_msg);
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/node.cpp
@@ -22,8 +22,8 @@
 #include <lanelet2_extension/utility/message_conversion.h>
 #include <lanelet2_routing/Route.h>
 
-#include <diagnostic_msgs/DiagnosticStatus.h>
-#include <visualization_msgs/MarkerArray.h>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 #include <utilization/path_utilization.h>
 
@@ -38,7 +38,7 @@
 namespace
 {
 template <class T>
-T getParam(const ros::NodeHandle & nh, const std::string & key, const T & default_value)
+T getParam(const rclcpp::NodeHandle & nh, const std::string & key, const T & default_value)
 {
   T value;
   nh.param<T>(key, value, default_value);
@@ -46,12 +46,12 @@ T getParam(const ros::NodeHandle & nh, const std::string & key, const T & defaul
 }
 
 template <class T>
-T waitForParam(const ros::NodeHandle & nh, const std::string & key)
+T waitForParam(const rclcpp::NodeHandle & nh, const std::string & key)
 {
   T value;
 
-  ros::Rate rate(1.0);
-  while (ros::ok()) {
+  rclcpp::Rate rate(1.0);
+  while (rclcpp::ok()) {
     const auto result = nh.getParam(key, value);
     if (result) {
       return value;
@@ -64,24 +64,24 @@ T waitForParam(const ros::NodeHandle & nh, const std::string & key)
   return {};
 }
 
-std::shared_ptr<geometry_msgs::TransformStamped> getTransform(
+std::shared_ptr<geometry_msgs::msg::TransformStamped> getTransform(
   const tf2_ros::Buffer & tf_buffer, const std::string & from, const std::string & to,
-  const ros::Time & time = ros::Time(0), const ros::Duration & duration = ros::Duration(0.1))
+  const rclcpp::Time & time = rclcpp::Time(0), const rclcpp::Duration & duration = rclcpp::Duration(0.1))
 {
   try {
-    return std::make_shared<geometry_msgs::TransformStamped>(
+    return std::make_shared<geometry_msgs::msg::TransformStamped>(
       tf_buffer.lookupTransform(from, to, time, duration));
   } catch (tf2::TransformException & ex) {
     return {};
   }
 }
 
-geometry_msgs::TransformStamped waitForTransform(
+geometry_msgs::msg::TransformStamped waitForTransform(
   const tf2_ros::Buffer & tf_buffer, const std::string & from, const std::string & to,
-  const ros::Time & time = ros::Time(0), const ros::Duration & duration = ros::Duration(0.1))
+  const rclcpp::Time & time = rclcpp::Time(0), const rclcpp::Duration & duration = rclcpp::Duration(0.1))
 {
-  ros::Rate rate(1.0);
-  while (ros::ok()) {
+  rclcpp::Rate rate(1.0);
+  while (rclcpp::ok()) {
     const auto transform = getTransform(tf_buffer, from, to, time, duration);
     if (transform) {
       return *transform;
@@ -89,14 +89,14 @@ geometry_msgs::TransformStamped waitForTransform(
 
     ROS_INFO(
       "waiting for transform from `%s` to `%s` ... (time = %f, now = %f)", from.c_str(), to.c_str(),
-      time.toSec(), ros::Time::now().toSec());
+      time.toSec(), this->now().toSec());
     rate.sleep();
   }
 }
 
-geometry_msgs::PoseStamped transform2pose(const geometry_msgs::TransformStamped & transform)
+geometry_msgs::msg::PoseStamped transform2pose(const geometry_msgs::msg::TransformStamped & transform)
 {
-  geometry_msgs::PoseStamped pose;
+  geometry_msgs::msg::PoseStamped pose;
   pose.header = transform.header;
   pose.pose.position.x = transform.transform.translation.x;
   pose.pose.position.y = transform.transform.translation.y;
@@ -105,9 +105,9 @@ geometry_msgs::PoseStamped transform2pose(const geometry_msgs::TransformStamped 
   return pose;
 }
 
-autoware_planning_msgs::Path to_path(const autoware_planning_msgs::PathWithLaneId & path_with_id)
+autoware_planning_msgs::msg::Path to_path(const autoware_planning_msgs::msg::PathWithLaneId & path_with_id)
 {
-  autoware_planning_msgs::Path path;
+  autoware_planning_msgs::msg::Path path;
   for (const auto & path_point : path_with_id.points) {
     path.points.push_back(path_point.point);
   }
@@ -120,25 +120,21 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode()
 {
   // Trigger Subscriber
   trigger_sub_path_with_lane_id_ =
-    pnh_.subscribe("input/path_with_lane_id", 1, &BehaviorVelocityPlannerNode::onTrigger, this);
+    this->create_subscription<TODO>("input/path_with_lane_id", 1, &BehaviorVelocityPlannerNode::onTrigger, this);
 
   // Subscribers
-  sub_dynamic_objects_ = pnh_.subscribe(
-    "input/dynamic_objects", 1, &BehaviorVelocityPlannerNode::onDynamicObjects, this);
-  sub_no_ground_pointcloud_ = pnh_.subscribe(
-    "input/no_ground_pointcloud", 1, &BehaviorVelocityPlannerNode::onNoGroundPointCloud, this);
-  sub_vehicle_velocity_ = pnh_.subscribe(
-    "input/vehicle_velocity", 1, &BehaviorVelocityPlannerNode::onVehicleVelocity, this);
+  sub_dynamic_objects_ = this->create_subscription<TODO>("input/dynamic_objects", 1, &BehaviorVelocityPlannerNode::onDynamicObjects, this);
+  sub_no_ground_pointcloud_ = this->create_subscription<TODO>("input/no_ground_pointcloud", 1, &BehaviorVelocityPlannerNode::onNoGroundPointCloud, this);
+  sub_vehicle_velocity_ = this->create_subscription<TODO>("input/vehicle_velocity", 1, &BehaviorVelocityPlannerNode::onVehicleVelocity, this);
   sub_lanelet_map_ =
-    pnh_.subscribe("input/vector_map", 10, &BehaviorVelocityPlannerNode::onLaneletMap, this);
-  sub_traffic_light_states_ = pnh_.subscribe(
-    "input/traffic_light_states", 10, &BehaviorVelocityPlannerNode::onTrafficLightStates, this);
+    this->create_subscription<TODO>("input/vector_map", 10, &BehaviorVelocityPlannerNode::onLaneletMap, this);
+  sub_traffic_light_states_ = this->create_subscription<TODO>("input/traffic_light_states", 10, &BehaviorVelocityPlannerNode::onTrafficLightStates, this);
 
   // Publishers
-  path_pub_ = pnh_.advertise<autoware_planning_msgs::Path>("output/path", 1);
+  path_pub_ = this->create_publisher<autoware_planning_msgs::msg::Path>("output/path", 1);
   stop_reason_diag_pub_ =
-    pnh_.advertise<diagnostic_msgs::DiagnosticStatus>("output/stop_reason", 1);
-  debug_viz_pub_ = pnh_.advertise<visualization_msgs::MarkerArray>("debug/path", 1);
+    this->create_publisher<diagnostic_msgs::msg::DiagnosticStatus>("output/stop_reason", 1);
+  debug_viz_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("debug/path", 1);
 
   // Parameters
   pnh_.param("forward_path_length", forward_path_length_, 1000.0);
@@ -171,7 +167,7 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode()
     planner_manager_.launchSceneModule(std::make_shared<DetectionAreaModuleManager>());
 }
 
-geometry_msgs::PoseStamped BehaviorVelocityPlannerNode::getCurrentPose()
+geometry_msgs::msg::PoseStamped BehaviorVelocityPlannerNode::getCurrentPose()
 {
   return transform2pose(waitForTransform(tf_buffer_, "map", "base_link"));
 }
@@ -193,16 +189,16 @@ bool BehaviorVelocityPlannerNode::isDataReady()
 }
 
 void BehaviorVelocityPlannerNode::onDynamicObjects(
-  const autoware_perception_msgs::DynamicObjectArray::ConstPtr & msg)
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr & msg)
 {
   planner_data_.dynamic_objects = msg;
 }
 
 void BehaviorVelocityPlannerNode::onNoGroundPointCloud(
-  const sensor_msgs::PointCloud2::ConstPtr & msg)
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)
 {
   const auto transform =
-    getTransform(tf_buffer_, "map", msg->header.frame_id, msg->header.stamp, ros::Duration(0.1));
+    getTransform(tf_buffer_, "map", msg->header.frame_id, msg->header.stamp, rclcpp::Duration(0.1));
   if (!transform) {
     ROS_WARN("no transform found for no_ground_pointcloud");
     return;
@@ -211,7 +207,7 @@ void BehaviorVelocityPlannerNode::onNoGroundPointCloud(
   pcl::PointCloud<pcl::PointXYZ>::Ptr no_ground_pointcloud(new pcl::PointCloud<pcl::PointXYZ>);
 
   Eigen::Matrix4f affine = tf2::transformToEigen(transform->transform).matrix().cast<float>();
-  sensor_msgs::PointCloud2 transformed_msg;
+  sensor_msgs::msg::PointCloud2 transformed_msg;
   pcl_ros::transformPointCloud(affine, *msg, transformed_msg);
 
   pcl::fromROSMsg(transformed_msg, *no_ground_pointcloud);
@@ -220,12 +216,12 @@ void BehaviorVelocityPlannerNode::onNoGroundPointCloud(
 }
 
 void BehaviorVelocityPlannerNode::onVehicleVelocity(
-  const geometry_msgs::TwistStamped::ConstPtr & msg)
+  const geometry_msgs::msg::TwistStamped::ConstSharedPtr & msg)
 {
   planner_data_.current_velocity = msg;
 }
 
-void BehaviorVelocityPlannerNode::onLaneletMap(const autoware_lanelet2_msgs::MapBin::ConstPtr & msg)
+void BehaviorVelocityPlannerNode::onLaneletMap(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr & msg)
 {
   // Load map
   planner_data_.lanelet_map = std::make_shared<lanelet::LaneletMap>();
@@ -257,10 +253,10 @@ void BehaviorVelocityPlannerNode::onLaneletMap(const autoware_lanelet2_msgs::Map
 }
 
 void BehaviorVelocityPlannerNode::onTrafficLightStates(
-  const autoware_perception_msgs::TrafficLightStateArray::ConstPtr & msg)
+  const autoware_perception_msgs::msg::TrafficLightStateArray::ConstSharedPtr & msg)
 {
   for (const auto & state : msg->states) {
-    autoware_perception_msgs::TrafficLightStateStamped traffic_light_state;
+    autoware_perception_msgs::msg::TrafficLightStateStamped traffic_light_state;
     traffic_light_state.header = msg->header;
     traffic_light_state.state = state;
     planner_data_.traffic_light_id_map_[state.id] = traffic_light_state;
@@ -268,7 +264,7 @@ void BehaviorVelocityPlannerNode::onTrafficLightStates(
 }
 
 void BehaviorVelocityPlannerNode::onTrigger(
-  const autoware_planning_msgs::PathWithLaneId & input_path_msg)
+  const autoware_planning_msgs::msg::PathWithLaneId & input_path_msg)
 {
   // Check ready
   planner_data_.current_pose = getCurrentPose();
@@ -289,12 +285,12 @@ void BehaviorVelocityPlannerNode::onTrigger(
   // check stop point
   auto output_path_msg = filterStopPathPoint(interpolated_path_msg);
   output_path_msg.header.frame_id = "map";
-  output_path_msg.header.stamp = ros::Time::now();
+  output_path_msg.header.stamp = this->now();
 
   // TODO: This must be updated in each scene module, but copy from input message for now.
   output_path_msg.drivable_area = input_path_msg.drivable_area;
 
-  path_pub_.publish(output_path_msg);
+  path_pub_->publish(output_path_msg);
   stop_reason_diag_pub_.publish(planner_manager_.getStopReasonDiag());
   publishDebugMarker(output_path_msg, debug_viz_pub_);
 
@@ -302,26 +298,26 @@ void BehaviorVelocityPlannerNode::onTrigger(
 };
 
 void BehaviorVelocityPlannerNode::publishDebugMarker(
-  const autoware_planning_msgs::Path & path, const ros::Publisher & pub)
+  const autoware_planning_msgs::msg::Path & path, const rclcpp::Publisher & pub)
 {
   if (pub.getNumSubscribers() < 1) return;
 
-  visualization_msgs::MarkerArray output_msg;
+  visualization_msgs::msg::MarkerArray output_msg;
   for (size_t i = 0; i < path.points.size(); ++i) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header = path.header;
     marker.id = i;
-    marker.type = visualization_msgs::Marker::ARROW;
+    marker.type = visualization_msgs::msg::Marker::ARROW;
     marker.pose = path.points.at(i).pose;
     marker.scale.y = marker.scale.z = 0.05;
     marker.scale.x = 0.25;
-    marker.action = visualization_msgs::Marker::ADD;
-    marker.lifetime = ros::Duration(0.5);
+    marker.action = visualization_msgs::msg::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
     marker.color.a = 0.999;  // Don't forget to set the alpha!
     marker.color.r = 1.0;
     marker.color.g = 1.0;
     marker.color.b = 1.0;
     output_msg.markers.push_back(marker);
   }
-  pub.publish(output_msg);
+  pub->publish(output_msg);
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/planner_manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/planner_manager.cpp
@@ -19,7 +19,7 @@
 
 namespace
 {
-std::string jsonDumpsPose(const geometry_msgs::Pose & pose)
+std::string jsonDumpsPose(const geometry_msgs::msg::Pose & pose)
 {
   const std::string json_dumps_pose =
     (boost::format(
@@ -30,12 +30,12 @@ std::string jsonDumpsPose(const geometry_msgs::Pose & pose)
   return json_dumps_pose;
 }
 
-diagnostic_msgs::DiagnosticStatus makeStopReasonDiag(
-  const std::string stop_reason, const geometry_msgs::Pose & stop_pose)
+diagnostic_msgs::msg::DiagnosticStatus makeStopReasonDiag(
+  const std::string stop_reason, const geometry_msgs::msg::Pose & stop_pose)
 {
-  diagnostic_msgs::DiagnosticStatus stop_reason_diag;
-  diagnostic_msgs::KeyValue stop_reason_diag_kv;
-  stop_reason_diag.level = diagnostic_msgs::DiagnosticStatus::OK;
+  diagnostic_msgs::msg::DiagnosticStatus stop_reason_diag;
+  diagnostic_msgs::msg::KeyValue stop_reason_diag_kv;
+  stop_reason_diag.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
   stop_reason_diag.name = "stop_reason";
   stop_reason_diag.message = stop_reason;
   stop_reason_diag_kv.key = "stop_pose";
@@ -51,11 +51,11 @@ void BehaviorVelocityPlannerManager::launchSceneModule(
   scene_manager_ptrs_.push_back(scene_module_manager_ptr);
 }
 
-autoware_planning_msgs::PathWithLaneId BehaviorVelocityPlannerManager::planPathVelocity(
+autoware_planning_msgs::msg::PathWithLaneId BehaviorVelocityPlannerManager::planPathVelocity(
   const std::shared_ptr<const PlannerData> & planner_data,
-  const autoware_planning_msgs::PathWithLaneId & input_path_msg)
+  const autoware_planning_msgs::msg::PathWithLaneId & input_path_msg)
 {
-  autoware_planning_msgs::PathWithLaneId output_path_msg = input_path_msg;
+  autoware_planning_msgs::msg::PathWithLaneId output_path_msg = input_path_msg;
 
   int first_stop_path_point_index = static_cast<int>(output_path_msg.points.size() - 1);
   std::string stop_reason_msg("path_end");
@@ -79,7 +79,7 @@ autoware_planning_msgs::PathWithLaneId BehaviorVelocityPlannerManager::planPathV
   return output_path_msg;
 }
 
-diagnostic_msgs::DiagnosticStatus BehaviorVelocityPlannerManager::getStopReasonDiag()
+diagnostic_msgs::msg::DiagnosticStatus BehaviorVelocityPlannerManager::getStopReasonDiag()
 {
   return stop_reason_diag_;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/debug.cpp
@@ -15,35 +15,35 @@
  */
 #include <scene_module/blind_spot/scene.h>
 
-#include "utilization/marker_helper.h"
-#include "utilization/util.h"
+#include <utilization/marker_helper.h>
+#include <utilization/util.h>
 
 namespace
 {
 using State = BlindSpotModule::State;
 
-visualization_msgs::MarkerArray createLaneletsAreaMarkerArray(
+visualization_msgs::msg::MarkerArray createLaneletsAreaMarkerArray(
   const std::vector<lanelet::ConstLanelet> & lanelets, const std::string & ns,
   const int64_t lane_id)
 {
-  const auto current_time = ros::Time::now();
-  visualization_msgs::MarkerArray msg;
+  const auto current_time = this->now();
+  visualization_msgs::msg::MarkerArray msg;
 
   for (const auto & lanelet : lanelets) {
-    visualization_msgs::Marker marker{};
+    visualization_msgs::msg::Marker marker{};
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
 
     marker.ns = ns;
     marker.id = lanelet.id();
-    marker.lifetime = ros::Duration(0.3);
-    marker.type = visualization_msgs::Marker::LINE_STRIP;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.3);
+    marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
     marker.scale = createMarkerScale(0.1, 0.0, 0.0);
     marker.color = createMarkerColor(0.0, 1.0, 0.0, 0.999);
     for (const auto & p : lanelet.polygon3d()) {
-      geometry_msgs::Point point;
+      geometry_msgs::msg::Point point;
       point.x = p.x();
       point.y = p.y();
       point.z = p.z();
@@ -56,28 +56,28 @@ visualization_msgs::MarkerArray createLaneletsAreaMarkerArray(
   return msg;
 }
 
-visualization_msgs::MarkerArray createPolygonMarkerArray(
+visualization_msgs::msg::MarkerArray createPolygonMarkerArray(
   const lanelet::CompoundPolygon3d & polygon, const std::string & ns, const int64_t lane_id,
   const double r, const double g, const double b)
 {
-  const auto current_time = ros::Time::now();
-  visualization_msgs::MarkerArray msg;
+  const auto current_time = this->now();
+  visualization_msgs::msg::MarkerArray msg;
 
   int32_t uid = planning_utils::bitShift(lane_id);
-  visualization_msgs::Marker marker{};
+  visualization_msgs::msg::Marker marker{};
   marker.header.frame_id = "map";
   marker.header.stamp = current_time;
 
   marker.ns = ns;
   marker.id = uid;
-  marker.lifetime = ros::Duration(0.3);
-  marker.type = visualization_msgs::Marker::LINE_STRIP;
-  marker.action = visualization_msgs::Marker::ADD;
+  marker.lifetime = rclcpp::Duration(0.3);
+  marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+  marker.action = visualization_msgs::msg::Marker::ADD;
   marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
   marker.scale = createMarkerScale(0.3, 0.0, 0.0);
   marker.color = createMarkerColor(r, g, b, 0.8);
   for (const auto & p : polygon) {
-    geometry_msgs::Point point;
+    geometry_msgs::msg::Point point;
     point.x = p.x();
     point.y = p.y();
     point.z = p.z();
@@ -91,14 +91,14 @@ visualization_msgs::MarkerArray createPolygonMarkerArray(
   return msg;
 }
 
-visualization_msgs::MarkerArray createObjectsMarkerArray(
-  const autoware_perception_msgs::DynamicObjectArray & objects, const std::string & ns,
+visualization_msgs::msg::MarkerArray createObjectsMarkerArray(
+  const autoware_perception_msgs::msg::DynamicObjectArray & objects, const std::string & ns,
   const int64_t lane_id, const double r, const double g, const double b)
 {
-  const auto current_time = ros::Time::now();
-  visualization_msgs::MarkerArray msg;
+  const auto current_time = this->now();
+  visualization_msgs::msg::MarkerArray msg;
 
-  visualization_msgs::Marker marker{};
+  visualization_msgs::msg::Marker marker{};
   marker.header.frame_id = "map";
   marker.header.stamp = current_time;
   marker.ns = ns;
@@ -107,9 +107,9 @@ visualization_msgs::MarkerArray createObjectsMarkerArray(
   int32_t i = 0;
   for (const auto & object : objects.objects) {
     marker.id = uid + i++;
-    marker.lifetime = ros::Duration(1.0);
-    marker.type = visualization_msgs::Marker::SPHERE;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(1.0);
+    marker.type = visualization_msgs::msg::Marker::SPHERE;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose = object.state.pose_covariance.pose;
     marker.scale = createMarkerScale(1.0, 1.0, 1.0);
     marker.color = createMarkerColor(r, g, b, 0.8);
@@ -119,21 +119,21 @@ visualization_msgs::MarkerArray createObjectsMarkerArray(
   return msg;
 }
 
-visualization_msgs::MarkerArray createPathMarkerArray(
-  const autoware_planning_msgs::PathWithLaneId & path, const std::string & ns,
+visualization_msgs::msg::MarkerArray createPathMarkerArray(
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const std::string & ns,
   const int64_t lane_id, const double r, const double g, const double b)
 {
-  const auto current_time = ros::Time::now();
-  visualization_msgs::MarkerArray msg;
+  const auto current_time = this->now();
+  visualization_msgs::msg::MarkerArray msg;
 
-  visualization_msgs::Marker marker{};
+  visualization_msgs::msg::Marker marker{};
   marker.header.frame_id = "map";
   marker.header.stamp = current_time;
   marker.ns = ns;
   marker.id = lane_id;
-  marker.lifetime = ros::Duration(0.3);
-  marker.type = visualization_msgs::Marker::LINE_STRIP;
-  marker.action = visualization_msgs::Marker::ADD;
+  marker.lifetime = rclcpp::Duration(0.3);
+  marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+  marker.action = visualization_msgs::msg::Marker::ADD;
   marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
   marker.scale = createMarkerScale(0.3, 0.0, 0.0);
   marker.color = createMarkerColor(r, g, b, 0.999);
@@ -147,33 +147,33 @@ visualization_msgs::MarkerArray createPathMarkerArray(
   return msg;
 }
 
-visualization_msgs::MarkerArray createVirtualWallMarkerArray(
-  const geometry_msgs::Pose & pose, const int64_t lane_id)
+visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray(
+  const geometry_msgs::msg::Pose & pose, const int64_t lane_id)
 {
-  visualization_msgs::MarkerArray msg;
+  visualization_msgs::msg::MarkerArray msg;
 
-  visualization_msgs::Marker marker_virtual_wall{};
+  visualization_msgs::msg::Marker marker_virtual_wall{};
   marker_virtual_wall.header.frame_id = "map";
-  marker_virtual_wall.header.stamp = ros::Time::now();
+  marker_virtual_wall.header.stamp = this->now();
   marker_virtual_wall.ns = "stop_virtual_wall";
   marker_virtual_wall.id = lane_id;
-  marker_virtual_wall.lifetime = ros::Duration(0.5);
-  marker_virtual_wall.type = visualization_msgs::Marker::CUBE;
-  marker_virtual_wall.action = visualization_msgs::Marker::ADD;
+  marker_virtual_wall.lifetime = rclcpp::Duration(0.5);
+  marker_virtual_wall.type = visualization_msgs::msg::Marker::CUBE;
+  marker_virtual_wall.action = visualization_msgs::msg::Marker::ADD;
   marker_virtual_wall.pose = pose;
   marker_virtual_wall.pose.position.z += 1.0;
   marker_virtual_wall.scale = createMarkerScale(0.1, 5.0, 2.0);
   marker_virtual_wall.color = createMarkerColor(1.0, 0.0, 0.0, 0.5);
   msg.markers.push_back(marker_virtual_wall);
 
-  visualization_msgs::Marker marker_factor_text{};
+  visualization_msgs::msg::Marker marker_factor_text{};
   marker_factor_text.header.frame_id = "map";
-  marker_factor_text.header.stamp = ros::Time::now();
+  marker_factor_text.header.stamp = this->now();
   marker_factor_text.ns = "factor_text";
   marker_factor_text.id = lane_id;
-  marker_factor_text.lifetime = ros::Duration(0.5);
-  marker_factor_text.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
-  marker_factor_text.action = visualization_msgs::Marker::ADD;
+  marker_factor_text.lifetime = rclcpp::Duration(0.5);
+  marker_factor_text.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+  marker_factor_text.action = visualization_msgs::msg::Marker::ADD;
   marker_factor_text.pose = pose;
   marker_factor_text.pose.position.z += 2.0;
   marker_factor_text.scale = createMarkerScale(0.0, 0.0, 1.0);
@@ -184,22 +184,22 @@ visualization_msgs::MarkerArray createVirtualWallMarkerArray(
   return msg;
 }
 
-visualization_msgs::MarkerArray createPoseMarkerArray(
-  const geometry_msgs::Pose & pose, const State & state, const std::string & ns, const int64_t id,
+visualization_msgs::msg::MarkerArray createPoseMarkerArray(
+  const geometry_msgs::msg::Pose & pose, const State & state, const std::string & ns, const int64_t id,
   const double r, const double g, const double b)
 {
-  const auto current_time = ros::Time::now();
-  visualization_msgs::MarkerArray msg;
+  const auto current_time = this->now();
+  visualization_msgs::msg::MarkerArray msg;
 
   if (state == State::STOP) {
-    visualization_msgs::Marker marker_line{};
+    visualization_msgs::msg::Marker marker_line{};
     marker_line.header.frame_id = "map";
     marker_line.header.stamp = current_time;
     marker_line.ns = ns + "_line";
     marker_line.id = id;
-    marker_line.lifetime = ros::Duration(0.3);
-    marker_line.type = visualization_msgs::Marker::LINE_STRIP;
-    marker_line.action = visualization_msgs::Marker::ADD;
+    marker_line.lifetime = rclcpp::Duration(0.3);
+    marker_line.type = visualization_msgs::msg::Marker::LINE_STRIP;
+    marker_line.action = visualization_msgs::msg::Marker::ADD;
     marker_line.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
     marker_line.scale = createMarkerScale(0.1, 0.0, 0.0);
     marker_line.color = createMarkerColor(r, g, b, 0.999);
@@ -207,13 +207,13 @@ visualization_msgs::MarkerArray createPoseMarkerArray(
     const double yaw = tf2::getYaw(pose.orientation);
 
     const double a = 3.0;
-    geometry_msgs::Point p0;
+    geometry_msgs::msg::Point p0;
     p0.x = pose.position.x - a * std::sin(yaw);
     p0.y = pose.position.y + a * std::cos(yaw);
     p0.z = pose.position.z;
     marker_line.points.push_back(p0);
 
-    geometry_msgs::Point p1;
+    geometry_msgs::msg::Point p1;
     p1.x = pose.position.x + a * std::sin(yaw);
     p1.y = pose.position.y - a * std::cos(yaw);
     p1.z = pose.position.z;
@@ -227,9 +227,9 @@ visualization_msgs::MarkerArray createPoseMarkerArray(
 
 }  // namespace
 
-visualization_msgs::MarkerArray BlindSpotModule::createDebugMarkerArray()
+visualization_msgs::msg::MarkerArray BlindSpotModule::createDebugMarkerArray()
 {
-  visualization_msgs::MarkerArray debug_marker_array;
+  visualization_msgs::msg::MarkerArray debug_marker_array;
 
   const auto state = state_machine_.getState();
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/manager.cpp
@@ -17,13 +17,13 @@
 
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 
-#include "utilization/boost_geometry_helper.h"
-#include "utilization/util.h"
+#include <utilization/boost_geometry_helper.h>
+#include <utilization/util.h>
 
 namespace
 {
 std::vector<lanelet::ConstLanelet> getLaneletsOnPath(
-  const autoware_planning_msgs::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
 {
   std::vector<lanelet::ConstLanelet> lanelets;
 
@@ -35,7 +35,7 @@ std::vector<lanelet::ConstLanelet> getLaneletsOnPath(
   return lanelets;
 }
 
-std::set<int64_t> getLaneIdSetOnPath(const autoware_planning_msgs::PathWithLaneId & path)
+std::set<int64_t> getLaneIdSetOnPath(const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   std::set<int64_t> lane_id_set;
 
@@ -51,7 +51,7 @@ std::set<int64_t> getLaneIdSetOnPath(const autoware_planning_msgs::PathWithLaneI
 
 BlindSpotModuleManager::BlindSpotModuleManager() : SceneModuleManagerInterface(getModuleName())
 {
-  ros::NodeHandle pnh("~");
+  rclcpp::NodeHandle pnh("~");
   const std::string ns(getModuleName());
   auto & p = planner_param_;
   pnh.param(ns + "/stop_line_margin", p.stop_line_margin, 1.0);
@@ -59,7 +59,7 @@ BlindSpotModuleManager::BlindSpotModuleManager() : SceneModuleManagerInterface(g
   pnh.param(ns + "/max_future_movement_time", p.max_future_movement_time, 10.0);
 }
 
-void BlindSpotModuleManager::launchNewModules(const autoware_planning_msgs::PathWithLaneId & path)
+void BlindSpotModuleManager::launchNewModules(const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   for (const auto & ll : getLaneletsOnPath(path, planner_data_->lanelet_map)) {
     const auto lane_id = ll.id();
@@ -82,7 +82,7 @@ void BlindSpotModuleManager::launchNewModules(const autoware_planning_msgs::Path
 
 std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
 BlindSpotModuleManager::getModuleExpiredFunction(
-  const autoware_planning_msgs::PathWithLaneId & path)
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto lane_id_set = getLaneIdSetOnPath(path);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/manager.cpp
@@ -78,7 +78,7 @@ void BlindSpotModuleManager::launchNewModules(
     }
 
     registerModule(std::make_shared<BlindSpotModule>(
-      module_id, lane_id, planner_data_, planner_param_, logger_, clock_));
+      module_id, lane_id, planner_data_, planner_param_, logger_.get_child("blind_spot_module"), clock_));
   }
 }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -62,7 +62,7 @@ bool BlindSpotModule::modifyPathVelocity(
 
   State current_state = state_machine_.getState();
   RCLCPP_DEBUG(
-    logger_, "[Blind Spot] lane_id = %ld, state = %s", lane_id_, toString(current_state).c_str());
+    logger_, "lane_id = %ld, state = %s", lane_id_, toString(current_state).c_str());
 
   /* get current pose */
   geometry_msgs::msg::PoseStamped current_pose = planner_data_->current_pose;
@@ -77,20 +77,20 @@ bool BlindSpotModule::modifyPathVelocity(
   const auto straight_lanelets = getStraightLanelets(lanelet_map_ptr, routing_graph_ptr, lane_id_);
   if (!generateStopLine(straight_lanelets, path, &stop_line_idx, &pass_judge_line_idx)) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
-      logger_, *clock_, 1000, "[BlindSpotModule::run] setStopLineIdx fail");
+      logger_, *clock_, 1000, "setStopLineIdx fail");
     return false;
   }
 
   if (stop_line_idx <= 0 || pass_judge_line_idx <= 0) {
     RCLCPP_DEBUG(
-      logger_, "[Blind Spot] stop line or pass judge line is at path[0], ignore planning.");
+      logger_, "stop line or pass judge line is at path[0], ignore planning.");
     return true;
   }
 
   /* calc closest index */
   int closest_idx = -1;
   if (!planning_utils::calcClosestIndex(input_path, current_pose.pose, closest_idx)) {
-    RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1000, "[Blind Spot] calcClosestIndex fail");
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1000, "calcClosestIndex fail");
     return false;
   }
 
@@ -107,7 +107,7 @@ bool BlindSpotModule::modifyPathVelocity(
     is_over_pass_judge_line = util::isAheadOf(current_pose.pose, pass_judge_line);
   }
   if (current_state == State::GO && is_over_pass_judge_line) {
-    RCLCPP_DEBUG(logger_, "[Blind Spot] over the pass judge line. no plan needed.");
+    RCLCPP_DEBUG(logger_, "over the pass judge line. no plan needed.");
     return true;  // no plan needed.
   }
 
@@ -117,7 +117,7 @@ bool BlindSpotModule::modifyPathVelocity(
   /* calculate dynamic collision around detection area */
   bool has_obstacle =
     checkObstacleInBlindSpot(lanelet_map_ptr, routing_graph_ptr, *path, objects_ptr, closest_idx);
-  state_machine_.setStateWithMarginTime(has_obstacle ? State::STOP : State::GO, logger_, *clock_);
+  state_machine_.setStateWithMarginTime(has_obstacle ? State::STOP : State::GO, logger_.get_child("state_machine"), *clock_);
 
   /* set stop speed */
   if (state_machine_.getState() == State::STOP) {
@@ -234,7 +234,7 @@ bool BlindSpotModule::generateStopLine(
 
   RCLCPP_DEBUG(
     logger_,
-    "[Blind Spot] generateStopLine() : stop_idx = %d, pass_judge_idx = %d, stop_idx_ip = %d, "
+    "generateStopLine() : stop_idx = %d, pass_judge_idx = %d, stop_idx_ip = %d, "
     "pass_judge_idx_ip = %d, has_prior_stopline = %d",
     *stop_line_idx, *pass_judge_line_idx, stop_idx_ip, pass_judge_idx_ip, has_prior_stopline);
 
@@ -496,7 +496,7 @@ void BlindSpotModule::StateMachine::setStateWithMarginTime(
     return;
   }
 
-  RCLCPP_ERROR(logger, "[StateMachine] : Unsuitable state. ignore request.");
+  RCLCPP_ERROR(logger, "Unsuitable state. ignore request.");
   return;
 }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -77,7 +77,7 @@ bool BlindSpotModule::modifyPathVelocity(
   const auto straight_lanelets = getStraightLanelets(lanelet_map_ptr, routing_graph_ptr, lane_id_);
   if (!generateStopLine(straight_lanelets, path, &stop_line_idx, &pass_judge_line_idx)) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
-      logger_, *clock_, 1000, "setStopLineIdx fail");
+      logger_, *clock_, 1000 /* ms */, "setStopLineIdx fail");
     return false;
   }
 
@@ -90,7 +90,7 @@ bool BlindSpotModule::modifyPathVelocity(
   /* calc closest index */
   int closest_idx = -1;
   if (!planning_utils::calcClosestIndex(input_path, current_pose.pose, closest_idx)) {
-    RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1000, "calcClosestIndex fail");
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1000 /* ms */, "calcClosestIndex fail");
     return false;
   }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/debug.cpp
@@ -16,16 +16,16 @@
 #include <scene_module/crosswalk/scene_crosswalk.h>
 #include <scene_module/crosswalk/scene_walkway.h>
 
-#include "utilization/marker_helper.h"
-#include "utilization/util.h"
+#include <utilization/marker_helper.h>
+#include <utilization/util.h>
 
 namespace
 {
-visualization_msgs::MarkerArray createCrosswalkMarkers(
+visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   const DebugData & debug_data, const int64_t module_id)
 {
-  visualization_msgs::MarkerArray msg;
-  ros::Time current_time = ros::Time::now();
+  visualization_msgs::msg::MarkerArray msg;
+  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
@@ -34,15 +34,15 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
   for (size_t i = 0; i < debug_data.crosswalk_polygons.size(); ++i) {
     std::vector<Eigen::Vector3d> polygon = debug_data.crosswalk_polygons.at(i);
 
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
 
     marker.ns = "crosswalk polygon line";
     marker.id = uid + i;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::LINE_STRIP;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
     marker.pose.position.y = 0;
     marker.pose.position.z = 0;
@@ -56,7 +56,7 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
     marker.color.g = 1.0;
     marker.color.b = 0.0;
     for (size_t j = 0; j < polygon.size(); ++j) {
-      geometry_msgs::Point point;
+      geometry_msgs::msg::Point point;
       point.x = polygon.at(j).x();
       point.y = polygon.at(j).y();
       point.z = polygon.at(j).z();
@@ -67,9 +67,9 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
 
     marker.ns = "crosswalk polygon point";
     marker.id = i;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::POINTS;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::POINTS;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
     marker.pose.position.y = 0;
     marker.pose.position.z = 0;
@@ -84,7 +84,7 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
     marker.color.g = 1.0;
     marker.color.b = 0.0;
     for (size_t j = 0; j < polygon.size(); ++j) {
-      geometry_msgs::Point point;
+      geometry_msgs::msg::Point point;
       point.x = polygon.at(j).x();
       point.y = polygon.at(j).y();
       point.z = polygon.at(j).z();
@@ -95,14 +95,14 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
 
   // Collision line
   for (size_t i = 0; i < debug_data.collision_lines.size(); ++i) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "collision line";
     marker.id = uid + i;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::LINE_STRIP;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
     marker.pose.position.y = 0;
     marker.pose.position.z = 0;
@@ -116,7 +116,7 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
     marker.color.g = 1.0;
     marker.color.b = 0.0;
     for (size_t j = 0; j < debug_data.collision_lines.at(i).size(); ++j) {
-      geometry_msgs::Point point;
+      geometry_msgs::msg::Point point;
       point.x = debug_data.collision_lines.at(i).at(j).x();
       point.y = debug_data.collision_lines.at(i).at(j).y();
       point.z = debug_data.collision_lines.at(i).at(j).z();
@@ -127,14 +127,14 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
 
   // Collision point
   if (!debug_data.collision_points.empty()) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "collision point";
     marker.id = 0;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::POINTS;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::POINTS;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
     marker.pose.position.y = 0;
     marker.pose.position.z = 0;
@@ -149,7 +149,7 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
     marker.color.g = 1.0;
     marker.color.b = 0.0;
     for (size_t j = 0; j < debug_data.collision_points.size(); ++j) {
-      geometry_msgs::Point point;
+      geometry_msgs::msg::Point point;
       point.x = debug_data.collision_points.at(j).x();
       point.y = debug_data.collision_points.at(j).y();
       point.z = debug_data.collision_points.at(j).z();
@@ -162,15 +162,15 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
   for (size_t i = 0; i < debug_data.slow_polygons.size(); ++i) {
     std::vector<Eigen::Vector3d> polygon = debug_data.slow_polygons.at(i);
 
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
 
     marker.ns = "slow polygon line";
     marker.id = uid + i;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::LINE_STRIP;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
     marker.pose.position.y = 0;
     marker.pose.position.z = 0;
@@ -184,7 +184,7 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
     marker.color.g = 1.0;
     marker.color.b = 0.0;
     for (size_t j = 0; j < polygon.size(); ++j) {
-      geometry_msgs::Point point;
+      geometry_msgs::msg::Point point;
       point.x = polygon.at(j).x();
       point.y = polygon.at(j).y();
       point.z = polygon.at(j).z();
@@ -196,14 +196,14 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
 
   // Slow point
   if (!debug_data.slow_poses.empty()) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "slow point";
     marker.id = 0;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::POINTS;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::POINTS;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
     marker.pose.position.y = 0;
     marker.pose.position.z = 0;
@@ -218,7 +218,7 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
     marker.color.g = 1.0;
     marker.color.b = 0.0;
     for (size_t j = 0; j < debug_data.slow_poses.size(); ++j) {
-      geometry_msgs::Point point;
+      geometry_msgs::msg::Point point;
       point.x = debug_data.slow_poses.at(j).position.x;
       point.y = debug_data.slow_poses.at(j).position.y;
       point.z = debug_data.slow_poses.at(j).position.z;
@@ -231,15 +231,15 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
   for (size_t i = 0; i < debug_data.stop_polygons.size(); ++i) {
     std::vector<Eigen::Vector3d> polygon = debug_data.stop_polygons.at(i);
 
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
 
     marker.ns = "stop polygon line";
     marker.id = uid + i;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::LINE_STRIP;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
     marker.pose.position.y = 0;
     marker.pose.position.z = 0;
@@ -253,7 +253,7 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
     marker.color.g = 0.0;
     marker.color.b = 0.0;
     for (size_t j = 0; j < polygon.size(); ++j) {
-      geometry_msgs::Point point;
+      geometry_msgs::msg::Point point;
       point.x = polygon.at(j).x();
       point.y = polygon.at(j).y();
       point.z = polygon.at(j).z();
@@ -265,14 +265,14 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
 
   // Stop point
   if (!debug_data.stop_poses.empty()) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "stop point";
     marker.id = module_id;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::POINTS;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::POINTS;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
     marker.pose.position.y = 0;
     marker.pose.position.z = 0;
@@ -287,7 +287,7 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
     marker.color.g = 0.0;
     marker.color.b = 0.0;
     for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
-      geometry_msgs::Point point;
+      geometry_msgs::msg::Point point;
       point.x = debug_data.stop_poses.at(j).position.x;
       point.y = debug_data.stop_poses.at(j).position.y;
       point.z = debug_data.stop_poses.at(j).position.z;
@@ -298,14 +298,14 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
 
   // Stop VirtualWall
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::CUBE;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::CUBE;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.stop_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -322,14 +322,14 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
   }
   // Factor Text
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = uid + j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.stop_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -348,14 +348,14 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
 
   // Slow VirtualWall
   for (size_t j = 0; j < debug_data.slow_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "slow virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::CUBE;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::CUBE;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.slow_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -372,14 +372,14 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
   }
   // Slow Factor Text
   for (size_t j = 0; j < debug_data.slow_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "slow factor_text";
     marker.id = uid + j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.slow_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -399,25 +399,25 @@ visualization_msgs::MarkerArray createCrosswalkMarkers(
   return msg;
 }
 
-visualization_msgs::MarkerArray createWalkwayMarkers(
+visualization_msgs::msg::MarkerArray createWalkwayMarkers(
   const DebugData & debug_data, const int64_t module_id)
 {
   int32_t uid = planning_utils::bitShift(module_id);
-  visualization_msgs::MarkerArray msg;
-  ros::Time current_time = ros::Time::now();
+  visualization_msgs::msg::MarkerArray msg;
+  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
   // Stop point
   if (!debug_data.stop_poses.empty()) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "stop point";
     marker.id = module_id;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::POINTS;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::POINTS;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
     marker.pose.position.y = 0;
     marker.pose.position.z = 0;
@@ -432,7 +432,7 @@ visualization_msgs::MarkerArray createWalkwayMarkers(
     marker.color.g = 0.0;
     marker.color.b = 0.0;
     for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
-      geometry_msgs::Point point;
+      geometry_msgs::msg::Point point;
       point.x = debug_data.stop_poses.at(j).position.x;
       point.y = debug_data.stop_poses.at(j).position.y;
       point.z = debug_data.stop_poses.at(j).position.z;
@@ -443,14 +443,14 @@ visualization_msgs::MarkerArray createWalkwayMarkers(
 
   // Stop VirtualWall
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::CUBE;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::CUBE;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.stop_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -467,14 +467,14 @@ visualization_msgs::MarkerArray createWalkwayMarkers(
   }
   // Factor Text
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = uid + j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.stop_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -496,18 +496,18 @@ visualization_msgs::MarkerArray createWalkwayMarkers(
 
 }  // namespace
 
-visualization_msgs::MarkerArray CrosswalkModule::createDebugMarkerArray()
+visualization_msgs::msg::MarkerArray CrosswalkModule::createDebugMarkerArray()
 {
-  visualization_msgs::MarkerArray debug_marker_array;
+  visualization_msgs::msg::MarkerArray debug_marker_array;
 
   appendMarkerArray(createCrosswalkMarkers(debug_data_, module_id_), &debug_marker_array);
 
   return debug_marker_array;
 }
 
-visualization_msgs::MarkerArray WalkwayModule::createDebugMarkerArray()
+visualization_msgs::msg::MarkerArray WalkwayModule::createDebugMarkerArray()
 {
-  visualization_msgs::MarkerArray debug_marker_array;
+  visualization_msgs::msg::MarkerArray debug_marker_array;
 
   appendMarkerArray(createWalkwayMarkers(debug_data_, module_id_), &debug_marker_array);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/debug.cpp
@@ -25,7 +25,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   const DebugData & debug_data, const int64_t module_id)
 {
   visualization_msgs::msg::MarkerArray msg;
-  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
@@ -36,7 +35,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
 
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
 
     marker.ns = "crosswalk polygon line";
     marker.id = uid + i;
@@ -97,7 +95,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   for (size_t i = 0; i < debug_data.collision_lines.size(); ++i) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "collision line";
     marker.id = uid + i;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -129,7 +126,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   if (!debug_data.collision_points.empty()) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "collision point";
     marker.id = 0;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -164,7 +160,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
 
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
 
     marker.ns = "slow polygon line";
     marker.id = uid + i;
@@ -198,7 +193,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   if (!debug_data.slow_poses.empty()) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "slow point";
     marker.id = 0;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -233,7 +227,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
 
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
 
     marker.ns = "stop polygon line";
     marker.id = uid + i;
@@ -267,7 +260,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   if (!debug_data.stop_poses.empty()) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "stop point";
     marker.id = module_id;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -300,7 +292,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -324,7 +315,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -350,7 +340,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   for (size_t j = 0; j < debug_data.slow_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "slow virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -374,7 +363,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   for (size_t j = 0; j < debug_data.slow_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "slow factor_text";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -404,7 +392,6 @@ visualization_msgs::msg::MarkerArray createWalkwayMarkers(
 {
   int32_t uid = planning_utils::bitShift(module_id);
   visualization_msgs::msg::MarkerArray msg;
-  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
@@ -412,7 +399,6 @@ visualization_msgs::msg::MarkerArray createWalkwayMarkers(
   if (!debug_data.stop_poses.empty()) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "stop point";
     marker.id = module_id;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -445,7 +431,6 @@ visualization_msgs::msg::MarkerArray createWalkwayMarkers(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -469,7 +454,6 @@ visualization_msgs::msg::MarkerArray createWalkwayMarkers(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -500,7 +484,8 @@ visualization_msgs::msg::MarkerArray CrosswalkModule::createDebugMarkerArray()
 {
   visualization_msgs::msg::MarkerArray debug_marker_array;
 
-  appendMarkerArray(createCrosswalkMarkers(debug_data_, module_id_), &debug_marker_array);
+  appendMarkerArray(
+    createCrosswalkMarkers(debug_data_, module_id_), this->clock_->now(), &debug_marker_array);
 
   return debug_marker_array;
 }
@@ -509,7 +494,8 @@ visualization_msgs::msg::MarkerArray WalkwayModule::createDebugMarkerArray()
 {
   visualization_msgs::msg::MarkerArray debug_marker_array;
 
-  appendMarkerArray(createWalkwayMarkers(debug_data_, module_id_), &debug_marker_array);
+  appendMarkerArray(
+    createWalkwayMarkers(debug_data_, module_id_), this->clock_->now(), &debug_marker_array);
 
   return debug_marker_array;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
@@ -18,7 +18,8 @@
 namespace
 {
 std::vector<lanelet::ConstLanelet> getCrosswalksOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map,
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map,
   const std::shared_ptr<const lanelet::routing::RoutingGraphContainer> & overall_graphs)
 {
   std::vector<lanelet::ConstLanelet> crosswalks;
@@ -37,7 +38,8 @@ std::vector<lanelet::ConstLanelet> getCrosswalksOnPath(
 }
 
 std::set<int64_t> getCrosswalkIdSetOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map,
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map,
   const std::shared_ptr<const lanelet::routing::RoutingGraphContainer> & overall_graphs)
 {
   std::set<int64_t> crosswalk_id_set;
@@ -51,38 +53,37 @@ std::set<int64_t> getCrosswalkIdSetOnPath(
 
 }  // namespace
 
-CrosswalkModuleManager::CrosswalkModuleManager() : SceneModuleManagerInterface(getModuleName())
+CrosswalkModuleManager::CrosswalkModuleManager(rclcpp::Node & node)
+: SceneModuleManagerInterface(node, getModuleName())
 {
-  rclcpp::NodeHandle pnh("~");
   const std::string ns(getModuleName());
 
   // for crosswalk parameters
   auto & cp = crosswalk_planner_param_;
-  pnh.param(ns + "/crosswalk/stop_margin", cp.stop_margin, 1.0);
-  pnh.param(ns + "/crosswalk/slow_margin", cp.slow_margin, 2.0);
-  pnh.param(ns + "/crosswalk/slow_velocity", cp.slow_velocity, 5.0 / 3.6);
-  pnh.param(
-    ns + "/crosswalk/stop_dynamic_object_prediction_time_margin",
-    cp.stop_dynamic_object_prediction_time_margin, 3.0);
+  cp.stop_margin = node.declare_parameter(ns + "/crosswalk/stop_margin", 1.0);
+  cp.slow_margin = node.declare_parameter(ns + "/crosswalk/slow_margin", 2.0);
+  cp.slow_velocity = node.declare_parameter(ns + "/crosswalk/slow_velocity", 5.0 / 3.6);
+  cp.stop_dynamic_object_prediction_time_margin =
+    node.declare_parameter(ns + "/crosswalk/stop_dynamic_object_prediction_time_margin", 3.0);
 
   // for walkway parameters
-  auto & wp = walkway_planner_param_;
-  pnh.param(ns + "/walkway/stop_margin", wp.stop_margin, 1.0);
+  walkway_planner_param_.stop_margin = node.declare_parameter(ns + "/walkway/stop_margin", 1.0);
 }
 
-void CrosswalkModuleManager::launchNewModules(const autoware_planning_msgs::msg::PathWithLaneId & path)
+void CrosswalkModuleManager::launchNewModules(
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   for (const auto & crosswalk :
        getCrosswalksOnPath(path, planner_data_->lanelet_map, planner_data_->overall_graphs)) {
     const auto module_id = crosswalk.id();
     if (!isModuleRegistered(module_id)) {
-      registerModule(
-        std::make_shared<CrosswalkModule>(module_id, crosswalk, crosswalk_planner_param_));
+      registerModule(std::make_shared<CrosswalkModule>(
+        module_id, crosswalk, crosswalk_planner_param_, logger_, clock_));
       if (
         crosswalk.attributeOr(lanelet::AttributeNamesString::Subtype, std::string("")) ==
         lanelet::AttributeValueString::Walkway) {
-        registerModule(
-          std::make_shared<WalkwayModule>(module_id, crosswalk, walkway_planner_param_));
+        registerModule(std::make_shared<WalkwayModule>(
+          module_id, crosswalk, walkway_planner_param_, logger_, clock_));
       }
     }
   }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
@@ -18,7 +18,7 @@
 namespace
 {
 std::vector<lanelet::ConstLanelet> getCrosswalksOnPath(
-  const autoware_planning_msgs::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map,
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map,
   const std::shared_ptr<const lanelet::routing::RoutingGraphContainer> & overall_graphs)
 {
   std::vector<lanelet::ConstLanelet> crosswalks;
@@ -37,7 +37,7 @@ std::vector<lanelet::ConstLanelet> getCrosswalksOnPath(
 }
 
 std::set<int64_t> getCrosswalkIdSetOnPath(
-  const autoware_planning_msgs::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map,
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map,
   const std::shared_ptr<const lanelet::routing::RoutingGraphContainer> & overall_graphs)
 {
   std::set<int64_t> crosswalk_id_set;
@@ -53,7 +53,7 @@ std::set<int64_t> getCrosswalkIdSetOnPath(
 
 CrosswalkModuleManager::CrosswalkModuleManager() : SceneModuleManagerInterface(getModuleName())
 {
-  ros::NodeHandle pnh("~");
+  rclcpp::NodeHandle pnh("~");
   const std::string ns(getModuleName());
 
   // for crosswalk parameters
@@ -70,7 +70,7 @@ CrosswalkModuleManager::CrosswalkModuleManager() : SceneModuleManagerInterface(g
   pnh.param(ns + "/walkway/stop_margin", wp.stop_margin, 1.0);
 }
 
-void CrosswalkModuleManager::launchNewModules(const autoware_planning_msgs::PathWithLaneId & path)
+void CrosswalkModuleManager::launchNewModules(const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   for (const auto & crosswalk :
        getCrosswalksOnPath(path, planner_data_->lanelet_map, planner_data_->overall_graphs)) {
@@ -90,7 +90,7 @@ void CrosswalkModuleManager::launchNewModules(const autoware_planning_msgs::Path
 
 std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
 CrosswalkModuleManager::getModuleExpiredFunction(
-  const autoware_planning_msgs::PathWithLaneId & path)
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto crosswalk_id_set =
     getCrosswalkIdSetOnPath(path, planner_data_->lanelet_map, planner_data_->overall_graphs);

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
@@ -78,12 +78,12 @@ void CrosswalkModuleManager::launchNewModules(
     const auto module_id = crosswalk.id();
     if (!isModuleRegistered(module_id)) {
       registerModule(std::make_shared<CrosswalkModule>(
-        module_id, crosswalk, crosswalk_planner_param_, logger_, clock_));
+        module_id, crosswalk, crosswalk_planner_param_, logger_.get_child("crosswalk_module"), clock_));
       if (
         crosswalk.attributeOr(lanelet::AttributeNamesString::Subtype, std::string("")) ==
         lanelet::AttributeValueString::Walkway) {
         registerModule(std::make_shared<WalkwayModule>(
-          module_id, crosswalk, walkway_planner_param_, logger_, clock_));
+          module_id, crosswalk, walkway_planner_param_, logger_.get_child("walkway_module"), clock_));
       }
     }
   }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -35,13 +35,13 @@ CrosswalkModule::CrosswalkModule(
 }
 
 bool CrosswalkModule::modifyPathVelocity(
-  autoware_planning_msgs::PathWithLaneId * path, autoware_planning_msgs::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
 {
   debug_data_ = {};
   debug_data_.base_link2front = planner_data_->base_link2front;
   first_stop_path_point_index_ = static_cast<int>(path->points.size()) - 1;
   *stop_reason =
-    planning_utils::initializeStopReason(autoware_planning_msgs::StopReason::CROSSWALK);
+    planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::CROSSWALK);
 
   const auto input = *path;
 
@@ -54,7 +54,7 @@ bool CrosswalkModule::modifyPathVelocity(
   polygon.outer().push_back(polygon.outer().front());
 
   // check state
-  geometry_msgs::PoseStamped self_pose = planner_data_->current_pose;
+  geometry_msgs::msg::PoseStamped self_pose = planner_data_->current_pose;
   if (bg::within(Point(self_pose.pose.position.x, self_pose.pose.position.y), polygon))
     state_ = State::INSIDE;
   else if (state_ == State::INSIDE)
@@ -65,7 +65,7 @@ bool CrosswalkModule::modifyPathVelocity(
     const auto objects_ptr = planner_data_->dynamic_objects;
     const auto no_ground_pointcloud_ptr = planner_data_->no_ground_pointcloud;
 
-    autoware_planning_msgs::PathWithLaneId slow_path, stop_path;
+    autoware_planning_msgs::msg::PathWithLaneId slow_path, stop_path;
     if (!checkSlowArea(input, polygon, objects_ptr, no_ground_pointcloud_ptr, slow_path)) {
       return false;
     }
@@ -80,7 +80,7 @@ bool CrosswalkModule::modifyPathVelocity(
 
     if (insert_stop) {
       /* get stop point and stop factor */
-      autoware_planning_msgs::StopFactor stop_factor;
+      autoware_planning_msgs::msg::StopFactor stop_factor;
       stop_factor.stop_pose = debug_data_.first_stop_pose;
       stop_factor.stop_factor_points = debug_data_.stop_factor_points;
       planning_utils::appendStopReason(stop_factor, stop_reason);
@@ -90,18 +90,18 @@ bool CrosswalkModule::modifyPathVelocity(
 }
 
 bool CrosswalkModule::checkStopArea(
-  const autoware_planning_msgs::PathWithLaneId & input,
+  const autoware_planning_msgs::msg::PathWithLaneId & input,
   const boost::geometry::model::polygon<boost::geometry::model::d2::point_xy<double>, false> &
     crosswalk_polygon,
-  const autoware_perception_msgs::DynamicObjectArray::ConstPtr & objects_ptr,
-  const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & no_ground_pointcloud_ptr,
-  autoware_planning_msgs::PathWithLaneId & output, bool * insert_stop)
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr & objects_ptr,
+  const pcl::PointCloud<pcl::PointXYZ>::ConstSharedPtr & no_ground_pointcloud_ptr,
+  autoware_planning_msgs::msg::PathWithLaneId & output, bool * insert_stop)
 {
   output = input;
   *insert_stop = false;
   bool pedestrian_found = false;
   bool object_found = false;
-  ros::Time current_time = ros::Time::now();
+  rclcpp::Time current_time = this->now();
 
   // create stop area
   std::vector<Point> path_collision_points;
@@ -204,10 +204,10 @@ bool CrosswalkModule::checkStopArea(
 }
 
 bool CrosswalkModule::checkSlowArea(
-  const autoware_planning_msgs::PathWithLaneId & input, const Polygon & polygon,
-  const autoware_perception_msgs::DynamicObjectArray::ConstPtr & objects_ptr,
-  const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & no_ground_pointcloud_ptr,
-  autoware_planning_msgs::PathWithLaneId & output)
+  const autoware_planning_msgs::msg::PathWithLaneId & input, const Polygon & polygon,
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr & objects_ptr,
+  const pcl::PointCloud<pcl::PointXYZ>::ConstSharedPtr & no_ground_pointcloud_ptr,
+  autoware_planning_msgs::msg::PathWithLaneId & output)
 {
   output = input;
   bool pedestrian_found = false;
@@ -242,11 +242,11 @@ bool CrosswalkModule::checkSlowArea(
   return true;
 }
 
-bool CrosswalkModule::isTargetType(const autoware_perception_msgs::DynamicObject & obj)
+bool CrosswalkModule::isTargetType(const autoware_perception_msgs::msg::DynamicObject & obj)
 {
   if (
-    obj.semantic.type == autoware_perception_msgs::Semantic::PEDESTRIAN ||
-    obj.semantic.type == autoware_perception_msgs::Semantic::BICYCLE) {
+    obj.semantic.type == autoware_perception_msgs::msg::Semantic::PEDESTRIAN ||
+    obj.semantic.type == autoware_perception_msgs::msg::Semantic::BICYCLE) {
     return true;
   }
   return false;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
@@ -32,12 +32,12 @@ WalkwayModule::WalkwayModule(
 }
 
 bool WalkwayModule::modifyPathVelocity(
-  autoware_planning_msgs::PathWithLaneId * path, autoware_planning_msgs::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
 {
   debug_data_ = {};
   debug_data_.base_link2front = planner_data_->base_link2front;
   first_stop_path_point_index_ = static_cast<int>(path->points.size()) - 1;
-  *stop_reason = planning_utils::initializeStopReason(autoware_planning_msgs::StopReason::WALKWAY);
+  *stop_reason = planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::WALKWAY);
 
   const auto input = *path;
 
@@ -65,7 +65,7 @@ bool WalkwayModule::modifyPathVelocity(
     return true;
   } else if (state_ == State::STOP) {
     /* get stop point and stop factor */
-    autoware_planning_msgs::StopFactor stop_factor;
+    autoware_planning_msgs::msg::StopFactor stop_factor;
     stop_factor.stop_pose = debug_data_.first_stop_pose;
     stop_factor.stop_factor_points.emplace_back(debug_data_.nearest_collision_point);
     planning_utils::appendStopReason(stop_factor, stop_reason);

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
@@ -25,19 +25,25 @@ using Line = bg::model::linestring<Point>;
 
 WalkwayModule::WalkwayModule(
   const int64_t module_id, const lanelet::ConstLanelet & walkway,
-  const PlannerParam & planner_param)
-: SceneModuleInterface(module_id), module_id_(module_id), walkway_(walkway), state_(State::APPROACH)
+  const PlannerParam & planner_param, const rclcpp::Logger logger,
+  const rclcpp::Clock::SharedPtr clock)
+: SceneModuleInterface(module_id, logger, clock),
+  module_id_(module_id),
+  walkway_(walkway),
+  state_(State::APPROACH)
 {
   planner_param_ = planner_param;
 }
 
 bool WalkwayModule::modifyPathVelocity(
-  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path,
+  autoware_planning_msgs::msg::StopReason * stop_reason)
 {
-  debug_data_ = {};
-  debug_data_.base_link2front = planner_data_->base_link2front;
+  debug_data_ = DebugData();
+  debug_data_.base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m_;
   first_stop_path_point_index_ = static_cast<int>(path->points.size()) - 1;
-  *stop_reason = planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::WALKWAY);
+  *stop_reason =
+    planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::WALKWAY);
 
   const auto input = *path;
 
@@ -60,9 +66,8 @@ bool WalkwayModule::modifyPathVelocity(
       planner_data_->current_pose.pose.position.x, planner_data_->current_pose.pose.position.y};
     const double distance = bg::distance(polygon, self_pose);
     const double distance_threshold =
-      planner_param_.stop_margin + planner_data_->base_link2front + 1.0;
+      planner_param_.stop_margin + planner_data_->vehicle_info_.max_longitudinal_offset_m_ + 1.0;
     if (distance < distance_threshold && planner_data_->isVehicleStopping()) state_ = State::STOP;
-    return true;
   } else if (state_ == State::STOP) {
     /* get stop point and stop factor */
     autoware_planning_msgs::msg::StopFactor stop_factor;
@@ -73,8 +78,7 @@ bool WalkwayModule::modifyPathVelocity(
     if (planner_data_->isVehicleStopping()) {
       state_ = State::SURPASSED;
     }
-    return true;
   } else if (state_ == State::SURPASSED) {
-    return true;
   }
+  return true;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/util.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/util.cpp
@@ -88,7 +88,7 @@ bool insertTargetVelocityPoint(
 
     // search target point index
     size_t insert_target_point_idx = 0;
-    const double base_link2front = planner_data.base_link2front;
+    const double base_link2front = planner_data.vehicle_info_.max_longitudinal_offset_m_;
     double length_sum = 0;
 
     const double target_length = margin + base_link2front;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/util.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/util.cpp
@@ -30,7 +30,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <autoware_perception_msgs/DynamicObjectArray.h>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
 
 namespace bg = boost::geometry;
 using Point = bg::model::d2::point_xy<double>;
@@ -48,9 +48,9 @@ bool getBackwordPointFromBasePoint(
 }
 
 bool insertTargetVelocityPoint(
-  const autoware_planning_msgs::PathWithLaneId & input, const Polygon & polygon,
+  const autoware_planning_msgs::msg::PathWithLaneId & input, const Polygon & polygon,
   const double & margin, const double & velocity, const PlannerData & planner_data,
-  autoware_planning_msgs::PathWithLaneId & output, DebugData & debug_data,
+  autoware_planning_msgs::msg::PathWithLaneId & output, DebugData & debug_data,
   boost::optional<int> & first_stop_path_point_index)
 {
   output = input;
@@ -110,7 +110,7 @@ bool insertTargetVelocityPoint(
 
     // create target point
     Eigen::Vector2d target_point;
-    autoware_planning_msgs::PathPointWithLaneId target_point_with_lane_id;
+    autoware_planning_msgs::msg::PathPointWithLaneId target_point_with_lane_id;
     getBackwordPointFromBasePoint(point2, point1, point2, length_sum - target_length, target_point);
     const int target_velocity_point_idx =
       std::max(static_cast<int>(insert_target_point_idx) - 1, 0);

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
@@ -17,32 +17,32 @@
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
-#include "utilization/marker_helper.h"
-#include "utilization/util.h"
+#include <utilization/marker_helper.h>
+#include <utilization/util.h>
 
 namespace
 {
 using DebugData = DetectionAreaModule::DebugData;
 
-visualization_msgs::MarkerArray createMarkerArray(
+visualization_msgs::msg::MarkerArray createMarkerArray(
   const DebugData & debug_data, const int64_t module_id)
 {
-  visualization_msgs::MarkerArray msg;
-  ros::Time current_time = ros::Time::now();
+  visualization_msgs::msg::MarkerArray msg;
+  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
   // Stop VirtualWall
   int32_t uid = planning_utils::bitShift(module_id);
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::CUBE;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::CUBE;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.stop_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -59,14 +59,14 @@ visualization_msgs::MarkerArray createMarkerArray(
   }
   // Dead VirtualWall
   for (size_t j = 0; j < debug_data.dead_line_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "dead_line_virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::CUBE;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::CUBE;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.dead_line_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -83,14 +83,14 @@ visualization_msgs::MarkerArray createMarkerArray(
   }
   // Facto Text
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.stop_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -112,9 +112,9 @@ visualization_msgs::MarkerArray createMarkerArray(
 
 }  // namespace
 
-visualization_msgs::MarkerArray DetectionAreaModule::createDebugMarkerArray()
+visualization_msgs::msg::MarkerArray DetectionAreaModule::createDebugMarkerArray()
 {
-  visualization_msgs::MarkerArray debug_marker_array;
+  visualization_msgs::msg::MarkerArray debug_marker_array;
 
   appendMarkerArray(createMarkerArray(debug_data_, module_id_), &debug_marker_array);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
@@ -28,7 +28,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   const DebugData & debug_data, const int64_t module_id)
 {
   visualization_msgs::msg::MarkerArray msg;
-  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
@@ -37,7 +36,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -61,7 +59,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   for (size_t j = 0; j < debug_data.dead_line_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "dead_line_virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -85,7 +82,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -116,7 +112,7 @@ visualization_msgs::msg::MarkerArray DetectionAreaModule::createDebugMarkerArray
 {
   visualization_msgs::msg::MarkerArray debug_marker_array;
 
-  appendMarkerArray(createMarkerArray(debug_data_, module_id_), &debug_marker_array);
-
+  appendMarkerArray(
+    createMarkerArray(debug_data_, module_id_), this->clock_->now(), &debug_marker_array);
   return debug_marker_array;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
@@ -20,7 +20,7 @@
 namespace
 {
 std::unordered_map<int64_t, lanelet::DetectionAreaConstPtr> getDetectionAreaRegElemsOnPath(
-  const autoware_planning_msgs::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
 {
   std::unordered_map<int64_t, lanelet::DetectionAreaConstPtr> detection_area_reg_elems;
 
@@ -37,7 +37,7 @@ std::unordered_map<int64_t, lanelet::DetectionAreaConstPtr> getDetectionAreaRegE
 }
 
 std::set<int64_t> getLaneletIdSetOnPath(
-  const autoware_planning_msgs::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
 {
   std::set<int64_t> lanelet_id_set;
   for (const auto & regelem : getDetectionAreaRegElemsOnPath(path, lanelet_map)) {
@@ -50,14 +50,14 @@ std::set<int64_t> getLaneletIdSetOnPath(
 DetectionAreaModuleManager::DetectionAreaModuleManager()
 : SceneModuleManagerInterface(getModuleName())
 {
-  ros::NodeHandle pnh("~");
+  rclcpp::NodeHandle pnh("~");
   const std::string ns(getModuleName());
   auto & p = planner_param_;
   pnh.param(ns + "/stop_margin", p.stop_margin, 0.0);
 }
 
 void DetectionAreaModuleManager::launchNewModules(
-  const autoware_planning_msgs::PathWithLaneId & path)
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   for (const auto & detection_area_reg_elem :
        getDetectionAreaRegElemsOnPath(path, planner_data_->lanelet_map)) {
@@ -72,7 +72,7 @@ void DetectionAreaModuleManager::launchNewModules(
 
 std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
 DetectionAreaModuleManager::getModuleExpiredFunction(
-  const autoware_planning_msgs::PathWithLaneId & path)
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto lanelet_id_set = getLaneletIdSetOnPath(path, planner_data_->lanelet_map);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
@@ -20,7 +20,8 @@
 namespace
 {
 std::unordered_map<int64_t, lanelet::DetectionAreaConstPtr> getDetectionAreaRegElemsOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map)
 {
   std::unordered_map<int64_t, lanelet::DetectionAreaConstPtr> detection_area_reg_elems;
 
@@ -37,7 +38,8 @@ std::unordered_map<int64_t, lanelet::DetectionAreaConstPtr> getDetectionAreaRegE
 }
 
 std::set<int64_t> getLaneletIdSetOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map)
 {
   std::set<int64_t> lanelet_id_set;
   for (const auto & regelem : getDetectionAreaRegElemsOnPath(path, lanelet_map)) {
@@ -47,13 +49,11 @@ std::set<int64_t> getLaneletIdSetOnPath(
 }
 }  // namespace
 
-DetectionAreaModuleManager::DetectionAreaModuleManager()
-: SceneModuleManagerInterface(getModuleName())
+DetectionAreaModuleManager::DetectionAreaModuleManager(rclcpp::Node & node)
+: SceneModuleManagerInterface(node, getModuleName())
 {
-  rclcpp::NodeHandle pnh("~");
   const std::string ns(getModuleName());
-  auto & p = planner_param_;
-  pnh.param(ns + "/stop_margin", p.stop_margin, 0.0);
+  planner_param_.stop_margin = node.declare_parameter(ns + "/stop_margin", 0.0);
 }
 
 void DetectionAreaModuleManager::launchNewModules(
@@ -65,7 +65,7 @@ void DetectionAreaModuleManager::launchNewModules(
     const auto module_id = detection_area_reg_elem.first;
     if (!isModuleRegistered(module_id)) {
       registerModule(std::make_shared<DetectionAreaModule>(
-        module_id, *(detection_area_reg_elem.second), planner_param_));
+        module_id, *(detection_area_reg_elem.second), planner_param_, logger_, clock_));
     }
   }
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
@@ -65,7 +65,7 @@ void DetectionAreaModuleManager::launchNewModules(
     const auto module_id = detection_area_reg_elem.first;
     if (!isModuleRegistered(module_id)) {
       registerModule(std::make_shared<DetectionAreaModule>(
-        module_id, *(detection_area_reg_elem.second), planner_param_, logger_, clock_));
+        module_id, *(detection_area_reg_elem.second), planner_param_, logger_.get_child("detection_area_module"), clock_));
     }
   }
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/scene.cpp
@@ -22,7 +22,7 @@
 namespace
 {
 std::pair<int, double> findWayPointAndDistance(
-  const autoware_planning_msgs::PathWithLaneId & input_path, const Eigen::Vector2d & p)
+  const autoware_planning_msgs::msg::PathWithLaneId & input_path, const Eigen::Vector2d & p)
 {
   constexpr double max_lateral_dist = 3.0;
   for (size_t i = 0; i < input_path.points.size() - 1; ++i) {
@@ -60,7 +60,7 @@ std::pair<int, double> findWayPointAndDistance(
 }
 
 double calcArcLengthFromWayPoint(
-  const autoware_planning_msgs::PathWithLaneId & input_path, const int & src, const int & dst)
+  const autoware_planning_msgs::msg::PathWithLaneId & input_path, const int & src, const int & dst)
 {
   double length = 0;
   const size_t src_idx = src >= 0 ? static_cast<size_t>(src) : 0;
@@ -76,7 +76,7 @@ double calcArcLengthFromWayPoint(
 }
 
 double calcSignedArcLength(
-  const autoware_planning_msgs::PathWithLaneId & input_path, const geometry_msgs::Pose & p1,
+  const autoware_planning_msgs::msg::PathWithLaneId & input_path, const geometry_msgs::msg::Pose & p1,
   const Eigen::Vector2d & p2)
 {
   std::pair<int, double> src =
@@ -98,7 +98,7 @@ double calcSignedArcLength(
   }
 }
 
-double calcSignedDistance(const geometry_msgs::Pose & p1, const Eigen::Vector2d & p2)
+double calcSignedDistance(const geometry_msgs::msg::Pose & p1, const Eigen::Vector2d & p2)
 {
   Eigen::Affine3d map2p1;
   tf2::fromMsg(p1, map2p1);
@@ -121,14 +121,14 @@ DetectionAreaModule::DetectionAreaModule(
 }
 
 bool DetectionAreaModule::modifyPathVelocity(
-  autoware_planning_msgs::PathWithLaneId * path, autoware_planning_msgs::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
 {
   const auto input_path = *path;
 
   debug_data_ = {};
   debug_data_.base_link2front = planner_data_->base_link2front;
   *stop_reason =
-    planning_utils::initializeStopReason(autoware_planning_msgs::StopReason::DETECTION_AREA);
+    planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::DETECTION_AREA);
 
   if (state_ == State::PASS) {
     return true;
@@ -146,13 +146,13 @@ bool DetectionAreaModule::modifyPathVelocity(
   }
 
   // get vehicle info and compute pass_judge_line_distance
-  geometry_msgs::TwistStamped::ConstPtr self_twist_ptr = planner_data_->current_velocity;
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr self_twist_ptr = planner_data_->current_velocity;
   const double max_acc = planner_data_->max_stop_acceleration_threshold_;
   const double delay_response_time = planner_data_->delay_response_time_;
   const double pass_judge_line_distance =
     planning_utils::calcJudgeLineDist(self_twist_ptr->twist.linear.x, max_acc, delay_response_time);
 
-  geometry_msgs::PoseStamped self_pose = planner_data_->current_pose;
+  geometry_msgs::msg::PoseStamped self_pose = planner_data_->current_pose;
 
   // insert stop point
   for (size_t stop_line_id = 0; stop_line_id < lanelet_stop_line.size() - 1; ++stop_line_id) {
@@ -204,7 +204,7 @@ bool DetectionAreaModule::modifyPathVelocity(
 
     state_ = State::STOP;
     /* get stop point and stop factor */
-    autoware_planning_msgs::StopFactor stop_factor;
+    autoware_planning_msgs::msg::StopFactor stop_factor;
     stop_factor.stop_pose = debug_data_.first_stop_pose;
     stop_factor.stop_factor_points = debug_data_.detection_points;
     planning_utils::appendStopReason(stop_factor, stop_reason);
@@ -215,7 +215,7 @@ bool DetectionAreaModule::modifyPathVelocity(
 }
 
 bool DetectionAreaModule::isOverDeadLine(
-  const geometry_msgs::Pose & self_pose, const autoware_planning_msgs::PathWithLaneId & input_path,
+  const geometry_msgs::msg::Pose & self_pose, const autoware_planning_msgs::msg::PathWithLaneId & input_path,
   const size_t & dead_line_point_idx, const Eigen::Vector2d & dead_line_point,
   const double dead_line_range)
 {
@@ -245,7 +245,7 @@ bool DetectionAreaModule::isOverDeadLine(
     tf_dead_line_pose2self_pose = tf_map2dead_line_pose.inverse() * tf_map2self_pose;
 
     // debug code
-    geometry_msgs::Pose dead_line_pose;
+    geometry_msgs::msg::Pose dead_line_pose;
     tf2::toMsg(tf_map2dead_line_pose, dead_line_pose);
     debug_data_.dead_line_poses.push_back(dead_line_pose);
   }
@@ -259,7 +259,7 @@ bool DetectionAreaModule::isOverDeadLine(
 }
 
 bool DetectionAreaModule::isPointsWithinDetectionArea(
-  const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & no_ground_pointcloud_ptr,
+  const pcl::PointCloud<pcl::PointXYZ>::ConstSharedPtr & no_ground_pointcloud_ptr,
   const lanelet::ConstPolygons3d & detection_areas)
 {
   for (const auto & da : detection_areas) {
@@ -284,15 +284,15 @@ bool DetectionAreaModule::isPointsWithinDetectionArea(
 }
 
 bool DetectionAreaModule::insertTargetVelocityPoint(
-  const autoware_planning_msgs::PathWithLaneId & input,
+  const autoware_planning_msgs::msg::PathWithLaneId & input,
   const boost::geometry::model::linestring<boost::geometry::model::d2::point_xy<double>> &
     stop_line,
-  const double & margin, const double & velocity, autoware_planning_msgs::PathWithLaneId & output)
+  const double & margin, const double & velocity, autoware_planning_msgs::msg::PathWithLaneId & output)
 {
   // create target point
   Eigen::Vector2d target_point;
   size_t insert_target_point_idx;
-  autoware_planning_msgs::PathPointWithLaneId target_point_with_lane_id;
+  autoware_planning_msgs::msg::PathPointWithLaneId target_point_with_lane_id;
 
   if (!createTargetPoint(input, stop_line, margin, insert_target_point_idx, target_point))
     return false;
@@ -321,7 +321,7 @@ bool DetectionAreaModule::insertTargetVelocityPoint(
 }
 
 bool DetectionAreaModule::createTargetPoint(
-  const autoware_planning_msgs::PathWithLaneId & input,
+  const autoware_planning_msgs::msg::PathWithLaneId & input,
   const boost::geometry::model::linestring<boost::geometry::model::d2::point_xy<double>> &
     stop_line,
   const double & margin, size_t & target_point_idx, Eigen::Vector2d & target_point)

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/scene.cpp
@@ -194,7 +194,7 @@ bool DetectionAreaModule::modifyPathVelocity(
         state_ != State::STOP &&
         calcSignedDistance(self_pose.pose, stop_line_point) < pass_judge_line_distance) {
         RCLCPP_WARN_THROTTLE(
-          logger_, *clock_, 1000, "[detection_area] vehicle is over stop border");
+          logger_, *clock_, 1000, "vehicle is over stop border");
         state_ = State::PASS;
         return true;
       }
@@ -255,7 +255,7 @@ bool DetectionAreaModule::isOverDeadLine(
   }
 
   if (0 < tf_dead_line_pose2self_pose.getOrigin().x()) {
-    RCLCPP_WARN(logger_, "[traffic_light] vehicle is over dead line");
+    RCLCPP_WARN(logger_, "vehicle is over dead line");
     return true;
   }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/scene.cpp
@@ -194,7 +194,7 @@ bool DetectionAreaModule::modifyPathVelocity(
         state_ != State::STOP &&
         calcSignedDistance(self_pose.pose, stop_line_point) < pass_judge_line_distance) {
         RCLCPP_WARN_THROTTLE(
-          logger_, *clock_, 1000, "vehicle is over stop border");
+          logger_, *clock_, 1000 /* ms */, "vehicle is over stop border");
         state_ = State::PASS;
         return true;
       }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
@@ -23,45 +23,10 @@ namespace
 {
 using State = IntersectionModule::State;
 
-visualization_msgs::msg::MarkerArray createLaneletsAreaMarkerArray(
-  const std::vector<lanelet::ConstLanelet> & lanelets, const std::string & ns,
-  const int64_t lane_id)
-{
-  const auto current_time = this->now();
-  visualization_msgs::msg::MarkerArray msg;
-
-  for (const auto & lanelet : lanelets) {
-    visualization_msgs::msg::Marker marker{};
-    marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
-
-    marker.ns = ns;
-    marker.id = lanelet.id();
-    marker.lifetime = rclcpp::Duration(0.3);
-    marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
-    marker.action = visualization_msgs::msg::Marker::ADD;
-    marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
-    marker.scale = createMarkerScale(0.1, 0.0, 0.0);
-    marker.color = createMarkerColor(0.0, 1.0, 0.0, 0.999);
-    for (const auto & p : lanelet.polygon3d()) {
-      geometry_msgs::msg::Point point;
-      point.x = p.x();
-      point.y = p.y();
-      point.z = p.z();
-      marker.points.push_back(point);
-    }
-    if (!marker.points.empty()) marker.points.push_back(marker.points.front());
-    msg.markers.push_back(marker);
-  }
-
-  return msg;
-}
-
 visualization_msgs::msg::MarkerArray createLaneletPolygonsMarkerArray(
   const std::vector<lanelet::CompoundPolygon3d> & polygons, const std::string & ns,
   const int64_t lane_id)
 {
-  const auto current_time = this->now();
   visualization_msgs::msg::MarkerArray msg;
 
   int32_t i = 0;
@@ -69,7 +34,6 @@ visualization_msgs::msg::MarkerArray createLaneletPolygonsMarkerArray(
   for (const auto & polygon : polygons) {
     visualization_msgs::msg::Marker marker{};
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
 
     marker.ns = ns;
     marker.id = uid + i++;
@@ -97,12 +61,10 @@ visualization_msgs::msg::MarkerArray createPolygonMarkerArray(
   const geometry_msgs::msg::Polygon & polygon, const std::string & ns, const int64_t lane_id,
   const double r, const double g, const double b)
 {
-  const auto current_time = this->now();
   visualization_msgs::msg::MarkerArray msg;
 
   visualization_msgs::msg::Marker marker{};
   marker.header.frame_id = "map";
-  marker.header.stamp = current_time;
 
   marker.ns = ns;
   marker.id = lane_id;
@@ -129,12 +91,10 @@ visualization_msgs::msg::MarkerArray createObjectsMarkerArray(
   const autoware_perception_msgs::msg::DynamicObjectArray & objects, const std::string & ns,
   const int64_t lane_id, const double r, const double g, const double b)
 {
-  const auto current_time = this->now();
   visualization_msgs::msg::MarkerArray msg;
 
   visualization_msgs::msg::Marker marker{};
   marker.header.frame_id = "map";
-  marker.header.stamp = current_time;
   marker.ns = ns;
 
   int32_t uid = planning_utils::bitShift(lane_id);
@@ -157,14 +117,12 @@ visualization_msgs::msg::MarkerArray createPathMarkerArray(
   const autoware_planning_msgs::msg::PathWithLaneId & path, const std::string & ns,
   const int64_t lane_id, const double r, const double g, const double b)
 {
-  const auto current_time = this->now();
   visualization_msgs::msg::MarkerArray msg;
   int32_t uid = planning_utils::bitShift(lane_id);
   int32_t i = 0;
   for (const auto & p : path.points) {
     visualization_msgs::msg::Marker marker{};
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = ns;
     marker.id = uid + i++;
     marker.lifetime = rclcpp::Duration(0.3);
@@ -191,7 +149,6 @@ visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray(
 
   visualization_msgs::msg::Marker marker_virtual_wall{};
   marker_virtual_wall.header.frame_id = "map";
-  marker_virtual_wall.header.stamp = this->now();
   marker_virtual_wall.ns = "stop_virtual_wall";
   marker_virtual_wall.id = lane_id;
   marker_virtual_wall.lifetime = rclcpp::Duration(0.5);
@@ -205,7 +162,6 @@ visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray(
 
   visualization_msgs::msg::Marker marker_factor_text{};
   marker_factor_text.header.frame_id = "map";
-  marker_factor_text.header.stamp = this->now();
   marker_factor_text.ns = "factor_text";
   marker_factor_text.id = lane_id;
   marker_factor_text.lifetime = rclcpp::Duration(0.5);
@@ -225,12 +181,10 @@ visualization_msgs::msg::MarkerArray createPoseMarkerArray(
   const geometry_msgs::msg::Pose & pose, const std::string & ns, const int64_t id, const double r,
   const double g, const double b)
 {
-  const auto current_time = this->now();
   visualization_msgs::msg::MarkerArray msg;
 
   visualization_msgs::msg::Marker marker_line{};
   marker_line.header.frame_id = "map";
-  marker_line.header.stamp = current_time;
   marker_line.ns = ns + "_line";
   marker_line.id = id;
   marker_line.lifetime = rclcpp::Duration(0.3);
@@ -267,47 +221,48 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createDebugMarkerArray(
   visualization_msgs::msg::MarkerArray debug_marker_array;
 
   const auto state = state_machine_.getState();
+  const auto current_time = this->clock_->now();
 
   appendMarkerArray(
-    createPathMarkerArray(debug_data_.path_raw, "path_raw", lane_id_, 0.0, 1.0, 1.0),
+    createPathMarkerArray(debug_data_.path_raw, "path_raw", lane_id_, 0.0, 1.0, 1.0), current_time,
     &debug_marker_array);
 
   appendMarkerArray(
     createLaneletPolygonsMarkerArray(debug_data_.detection_area, "detection_area", lane_id_),
-    &debug_marker_array);
+    current_time, &debug_marker_array);
 
   appendMarkerArray(
     createPolygonMarkerArray(debug_data_.ego_lane_polygon, "ego_lane", lane_id_, 0.0, 0.3, 0.7),
-    &debug_marker_array);
+    current_time, &debug_marker_array);
 
   appendMarkerArray(
     createPolygonMarkerArray(
       debug_data_.stuck_vehicle_detect_area, "stuck_vehicle_detect_area", lane_id_, 0.0, 0.5, 0.5),
-    &debug_marker_array);
+    current_time, &debug_marker_array);
 
   appendMarkerArray(
     createObjectsMarkerArray(
       debug_data_.conflicting_targets, "conflicting_targets", lane_id_, 0.99, 0.4, 0.0),
-    &debug_marker_array);
+    current_time, &debug_marker_array);
 
   appendMarkerArray(
     createObjectsMarkerArray(debug_data_.stuck_targets, "stuck_targets", lane_id_, 0.99, 0.99, 0.2),
-    &debug_marker_array);
+    current_time, &debug_marker_array);
 
   if (state == IntersectionModule::State::STOP) {
     appendMarkerArray(
       createPoseMarkerArray(
         debug_data_.stop_point_pose, "stop_point_pose", lane_id_, 1.0, 0.0, 0.0),
-      &debug_marker_array);
+      current_time, &debug_marker_array);
 
     appendMarkerArray(
       createPoseMarkerArray(
         debug_data_.judge_point_pose, "judge_point_pose", lane_id_, 1.0, 1.0, 0.5),
-      &debug_marker_array);
+      current_time, &debug_marker_array);
 
     appendMarkerArray(
       createVirtualWallMarkerArray(debug_data_.virtual_wall_pose, lane_id_, "intersection"),
-      &debug_marker_array);
+      current_time, &debug_marker_array);
   }
 
   return debug_marker_array;
@@ -319,16 +274,17 @@ visualization_msgs::msg::MarkerArray MergeFromPrivateRoadModule::createDebugMark
 
   const auto state = state_machine_.getState();
 
+  const auto current_time = this->clock_->now();
   if (state == MergeFromPrivateRoadModule::State::STOP) {
     appendMarkerArray(
       createPoseMarkerArray(
         debug_data_.stop_point_pose, "stop_point_pose", lane_id_, 1.0, 0.0, 0.0),
-      &debug_marker_array);
+      current_time, &debug_marker_array);
 
     appendMarkerArray(
       createVirtualWallMarkerArray(
         debug_data_.virtual_wall_pose, lane_id_, "merge_from_private_road"),
-      &debug_marker_array);
+      current_time, &debug_marker_array);
   }
 
   return debug_marker_array;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
@@ -16,35 +16,35 @@
 #include <scene_module/intersection/scene_intersection.h>
 #include <scene_module/intersection/scene_merge_from_private_road.h>
 
-#include "utilization/marker_helper.h"
-#include "utilization/util.h"
+#include <utilization/marker_helper.h>
+#include <utilization/util.h>
 
 namespace
 {
 using State = IntersectionModule::State;
 
-visualization_msgs::MarkerArray createLaneletsAreaMarkerArray(
+visualization_msgs::msg::MarkerArray createLaneletsAreaMarkerArray(
   const std::vector<lanelet::ConstLanelet> & lanelets, const std::string & ns,
   const int64_t lane_id)
 {
-  const auto current_time = ros::Time::now();
-  visualization_msgs::MarkerArray msg;
+  const auto current_time = this->now();
+  visualization_msgs::msg::MarkerArray msg;
 
   for (const auto & lanelet : lanelets) {
-    visualization_msgs::Marker marker{};
+    visualization_msgs::msg::Marker marker{};
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
 
     marker.ns = ns;
     marker.id = lanelet.id();
-    marker.lifetime = ros::Duration(0.3);
-    marker.type = visualization_msgs::Marker::LINE_STRIP;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.3);
+    marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
     marker.scale = createMarkerScale(0.1, 0.0, 0.0);
     marker.color = createMarkerColor(0.0, 1.0, 0.0, 0.999);
     for (const auto & p : lanelet.polygon3d()) {
-      geometry_msgs::Point point;
+      geometry_msgs::msg::Point point;
       point.x = p.x();
       point.y = p.y();
       point.z = p.z();
@@ -57,30 +57,30 @@ visualization_msgs::MarkerArray createLaneletsAreaMarkerArray(
   return msg;
 }
 
-visualization_msgs::MarkerArray createLaneletPolygonsMarkerArray(
+visualization_msgs::msg::MarkerArray createLaneletPolygonsMarkerArray(
   const std::vector<lanelet::CompoundPolygon3d> & polygons, const std::string & ns,
   const int64_t lane_id)
 {
-  const auto current_time = ros::Time::now();
-  visualization_msgs::MarkerArray msg;
+  const auto current_time = this->now();
+  visualization_msgs::msg::MarkerArray msg;
 
   int32_t i = 0;
   int32_t uid = planning_utils::bitShift(lane_id);
   for (const auto & polygon : polygons) {
-    visualization_msgs::Marker marker{};
+    visualization_msgs::msg::Marker marker{};
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
 
     marker.ns = ns;
     marker.id = uid + i++;
-    marker.lifetime = ros::Duration(0.3);
-    marker.type = visualization_msgs::Marker::LINE_STRIP;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.3);
+    marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
     marker.scale = createMarkerScale(0.1, 0.0, 0.0);
     marker.color = createMarkerColor(0.0, 1.0, 0.0, 0.999);
     for (const auto & p : polygon) {
-      geometry_msgs::Point point;
+      geometry_msgs::msg::Point point;
       point.x = p.x();
       point.y = p.y();
       point.z = p.z();
@@ -93,27 +93,27 @@ visualization_msgs::MarkerArray createLaneletPolygonsMarkerArray(
   return msg;
 }
 
-visualization_msgs::MarkerArray createPolygonMarkerArray(
-  const geometry_msgs::Polygon & polygon, const std::string & ns, const int64_t lane_id,
+visualization_msgs::msg::MarkerArray createPolygonMarkerArray(
+  const geometry_msgs::msg::Polygon & polygon, const std::string & ns, const int64_t lane_id,
   const double r, const double g, const double b)
 {
-  const auto current_time = ros::Time::now();
-  visualization_msgs::MarkerArray msg;
+  const auto current_time = this->now();
+  visualization_msgs::msg::MarkerArray msg;
 
-  visualization_msgs::Marker marker{};
+  visualization_msgs::msg::Marker marker{};
   marker.header.frame_id = "map";
   marker.header.stamp = current_time;
 
   marker.ns = ns;
   marker.id = lane_id;
-  marker.lifetime = ros::Duration(0.3);
-  marker.type = visualization_msgs::Marker::LINE_STRIP;
-  marker.action = visualization_msgs::Marker::ADD;
+  marker.lifetime = rclcpp::Duration(0.3);
+  marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+  marker.action = visualization_msgs::msg::Marker::ADD;
   marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
   marker.scale = createMarkerScale(0.3, 0.0, 0.0);
   marker.color = createMarkerColor(r, g, b, 0.8);
   for (const auto & p : polygon.points) {
-    geometry_msgs::Point point;
+    geometry_msgs::msg::Point point;
     point.x = p.x;
     point.y = p.y;
     point.z = p.z;
@@ -125,14 +125,14 @@ visualization_msgs::MarkerArray createPolygonMarkerArray(
   return msg;
 }
 
-visualization_msgs::MarkerArray createObjectsMarkerArray(
-  const autoware_perception_msgs::DynamicObjectArray & objects, const std::string & ns,
+visualization_msgs::msg::MarkerArray createObjectsMarkerArray(
+  const autoware_perception_msgs::msg::DynamicObjectArray & objects, const std::string & ns,
   const int64_t lane_id, const double r, const double g, const double b)
 {
-  const auto current_time = ros::Time::now();
-  visualization_msgs::MarkerArray msg;
+  const auto current_time = this->now();
+  visualization_msgs::msg::MarkerArray msg;
 
-  visualization_msgs::Marker marker{};
+  visualization_msgs::msg::Marker marker{};
   marker.header.frame_id = "map";
   marker.header.stamp = current_time;
   marker.ns = ns;
@@ -141,9 +141,9 @@ visualization_msgs::MarkerArray createObjectsMarkerArray(
   int32_t i = 0;
   for (const auto & object : objects.objects) {
     marker.id = uid + i++;
-    marker.lifetime = ros::Duration(1.0);
-    marker.type = visualization_msgs::Marker::CUBE;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(1.0);
+    marker.type = visualization_msgs::msg::Marker::CUBE;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose = object.state.pose_covariance.pose;
     marker.scale = createMarkerScale(3.0, 1.0, 1.0);
     marker.color = createMarkerColor(r, g, b, 0.8);
@@ -153,23 +153,23 @@ visualization_msgs::MarkerArray createObjectsMarkerArray(
   return msg;
 }
 
-visualization_msgs::MarkerArray createPathMarkerArray(
-  const autoware_planning_msgs::PathWithLaneId & path, const std::string & ns,
+visualization_msgs::msg::MarkerArray createPathMarkerArray(
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const std::string & ns,
   const int64_t lane_id, const double r, const double g, const double b)
 {
-  const auto current_time = ros::Time::now();
-  visualization_msgs::MarkerArray msg;
+  const auto current_time = this->now();
+  visualization_msgs::msg::MarkerArray msg;
   int32_t uid = planning_utils::bitShift(lane_id);
   int32_t i = 0;
   for (const auto & p : path.points) {
-    visualization_msgs::Marker marker{};
+    visualization_msgs::msg::Marker marker{};
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = ns;
     marker.id = uid + i++;
-    marker.lifetime = ros::Duration(0.3);
-    marker.type = visualization_msgs::Marker::ARROW;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.3);
+    marker.type = visualization_msgs::msg::Marker::ARROW;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose = p.point.pose;
     marker.scale = createMarkerScale(0.6, 0.3, 0.3);
     if (std::find(p.lane_ids.begin(), p.lane_ids.end(), lane_id) != p.lane_ids.end()) {
@@ -184,33 +184,33 @@ visualization_msgs::MarkerArray createPathMarkerArray(
   return msg;
 }
 
-visualization_msgs::MarkerArray createVirtualWallMarkerArray(
-  const geometry_msgs::Pose & pose, const int64_t lane_id, const std::string & stop_factor)
+visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray(
+  const geometry_msgs::msg::Pose & pose, const int64_t lane_id, const std::string & stop_factor)
 {
-  visualization_msgs::MarkerArray msg;
+  visualization_msgs::msg::MarkerArray msg;
 
-  visualization_msgs::Marker marker_virtual_wall{};
+  visualization_msgs::msg::Marker marker_virtual_wall{};
   marker_virtual_wall.header.frame_id = "map";
-  marker_virtual_wall.header.stamp = ros::Time::now();
+  marker_virtual_wall.header.stamp = this->now();
   marker_virtual_wall.ns = "stop_virtual_wall";
   marker_virtual_wall.id = lane_id;
-  marker_virtual_wall.lifetime = ros::Duration(0.5);
-  marker_virtual_wall.type = visualization_msgs::Marker::CUBE;
-  marker_virtual_wall.action = visualization_msgs::Marker::ADD;
+  marker_virtual_wall.lifetime = rclcpp::Duration(0.5);
+  marker_virtual_wall.type = visualization_msgs::msg::Marker::CUBE;
+  marker_virtual_wall.action = visualization_msgs::msg::Marker::ADD;
   marker_virtual_wall.pose = pose;
   marker_virtual_wall.pose.position.z += 1.0;
   marker_virtual_wall.scale = createMarkerScale(0.1, 5.0, 2.0);
   marker_virtual_wall.color = createMarkerColor(1.0, 0.0, 0.0, 0.5);
   msg.markers.push_back(marker_virtual_wall);
 
-  visualization_msgs::Marker marker_factor_text{};
+  visualization_msgs::msg::Marker marker_factor_text{};
   marker_factor_text.header.frame_id = "map";
-  marker_factor_text.header.stamp = ros::Time::now();
+  marker_factor_text.header.stamp = this->now();
   marker_factor_text.ns = "factor_text";
   marker_factor_text.id = lane_id;
-  marker_factor_text.lifetime = ros::Duration(0.5);
-  marker_factor_text.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
-  marker_factor_text.action = visualization_msgs::Marker::ADD;
+  marker_factor_text.lifetime = rclcpp::Duration(0.5);
+  marker_factor_text.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+  marker_factor_text.action = visualization_msgs::msg::Marker::ADD;
   marker_factor_text.pose = pose;
   marker_factor_text.pose.position.z += 2.0;
   marker_factor_text.scale = createMarkerScale(0.0, 0.0, 1.0);
@@ -221,21 +221,21 @@ visualization_msgs::MarkerArray createVirtualWallMarkerArray(
   return msg;
 }
 
-visualization_msgs::MarkerArray createPoseMarkerArray(
-  const geometry_msgs::Pose & pose, const std::string & ns, const int64_t id, const double r,
+visualization_msgs::msg::MarkerArray createPoseMarkerArray(
+  const geometry_msgs::msg::Pose & pose, const std::string & ns, const int64_t id, const double r,
   const double g, const double b)
 {
-  const auto current_time = ros::Time::now();
-  visualization_msgs::MarkerArray msg;
+  const auto current_time = this->now();
+  visualization_msgs::msg::MarkerArray msg;
 
-  visualization_msgs::Marker marker_line{};
+  visualization_msgs::msg::Marker marker_line{};
   marker_line.header.frame_id = "map";
   marker_line.header.stamp = current_time;
   marker_line.ns = ns + "_line";
   marker_line.id = id;
-  marker_line.lifetime = ros::Duration(0.3);
-  marker_line.type = visualization_msgs::Marker::LINE_STRIP;
-  marker_line.action = visualization_msgs::Marker::ADD;
+  marker_line.lifetime = rclcpp::Duration(0.3);
+  marker_line.type = visualization_msgs::msg::Marker::LINE_STRIP;
+  marker_line.action = visualization_msgs::msg::Marker::ADD;
   marker_line.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
   marker_line.scale = createMarkerScale(0.1, 0.0, 0.0);
   marker_line.color = createMarkerColor(r, g, b, 0.999);
@@ -243,13 +243,13 @@ visualization_msgs::MarkerArray createPoseMarkerArray(
   const double yaw = tf2::getYaw(pose.orientation);
 
   const double a = 3.0;
-  geometry_msgs::Point p0;
+  geometry_msgs::msg::Point p0;
   p0.x = pose.position.x - a * std::sin(yaw);
   p0.y = pose.position.y + a * std::cos(yaw);
   p0.z = pose.position.z;
   marker_line.points.push_back(p0);
 
-  geometry_msgs::Point p1;
+  geometry_msgs::msg::Point p1;
   p1.x = pose.position.x + a * std::sin(yaw);
   p1.y = pose.position.y - a * std::cos(yaw);
   p1.z = pose.position.z;
@@ -262,9 +262,9 @@ visualization_msgs::MarkerArray createPoseMarkerArray(
 
 }  // namespace
 
-visualization_msgs::MarkerArray IntersectionModule::createDebugMarkerArray()
+visualization_msgs::msg::MarkerArray IntersectionModule::createDebugMarkerArray()
 {
-  visualization_msgs::MarkerArray debug_marker_array;
+  visualization_msgs::msg::MarkerArray debug_marker_array;
 
   const auto state = state_machine_.getState();
 
@@ -313,9 +313,9 @@ visualization_msgs::MarkerArray IntersectionModule::createDebugMarkerArray()
   return debug_marker_array;
 }
 
-visualization_msgs::MarkerArray MergeFromPrivateRoadModule::createDebugMarkerArray()
+visualization_msgs::msg::MarkerArray MergeFromPrivateRoadModule::createDebugMarkerArray()
 {
-  visualization_msgs::MarkerArray debug_marker_array;
+  visualization_msgs::msg::MarkerArray debug_marker_array;
 
   const auto state = state_machine_.getState();
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -17,13 +17,13 @@
 
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 
-#include "utilization/boost_geometry_helper.h"
-#include "utilization/util.h"
+#include <utilization/boost_geometry_helper.h>
+#include <utilization/util.h>
 
 namespace
 {
 std::vector<lanelet::ConstLanelet> getLaneletsOnPath(
-  const autoware_planning_msgs::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
 {
   std::vector<lanelet::ConstLanelet> lanelets;
 
@@ -38,7 +38,7 @@ std::vector<lanelet::ConstLanelet> getLaneletsOnPath(
   return lanelets;
 }
 
-std::set<int64_t> getLaneIdSetOnPath(const autoware_planning_msgs::PathWithLaneId & path)
+std::set<int64_t> getLaneIdSetOnPath(const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   std::set<int64_t> lane_id_set;
 
@@ -56,7 +56,7 @@ std::set<int64_t> getLaneIdSetOnPath(const autoware_planning_msgs::PathWithLaneI
 IntersectionModuleManager::IntersectionModuleManager()
 : SceneModuleManagerInterface(getModuleName())
 {
-  ros::NodeHandle pnh("~");
+  rclcpp::NodeHandle pnh("~");
   const std::string ns(getModuleName());
   auto & p = planner_param_;
   pnh.param(ns + "/state_transit_mergin_time", p.state_transit_mergin_time, 2.0);
@@ -72,7 +72,7 @@ IntersectionModuleManager::IntersectionModuleManager()
 }
 
 void IntersectionModuleManager::launchNewModules(
-  const autoware_planning_msgs::PathWithLaneId & path)
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto lanelets = getLaneletsOnPath(path, planner_data_->lanelet_map);
   for (size_t i = 0; i < lanelets.size(); i++) {
@@ -110,7 +110,7 @@ void IntersectionModuleManager::launchNewModules(
 
 std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
 IntersectionModuleManager::getModuleExpiredFunction(
-  const autoware_planning_msgs::PathWithLaneId & path)
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto lane_id_set = getLaneIdSetOnPath(path);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -23,7 +23,8 @@
 namespace
 {
 std::vector<lanelet::ConstLanelet> getLaneletsOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map)
 {
   std::vector<lanelet::ConstLanelet> lanelets;
 
@@ -53,22 +54,21 @@ std::set<int64_t> getLaneIdSetOnPath(const autoware_planning_msgs::msg::PathWith
 
 }  // namespace
 
-IntersectionModuleManager::IntersectionModuleManager()
-: SceneModuleManagerInterface(getModuleName())
+IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
+: SceneModuleManagerInterface(node, getModuleName())
 {
-  rclcpp::NodeHandle pnh("~");
   const std::string ns(getModuleName());
   auto & p = planner_param_;
-  pnh.param(ns + "/state_transit_mergin_time", p.state_transit_mergin_time, 2.0);
-  pnh.param(ns + "/decel_velocoity", p.decel_velocoity, 30.0 / 3.6);
-  pnh.param(ns + "/path_expand_width", p.path_expand_width, 2.0);
-  pnh.param(ns + "/stop_line_margin", p.stop_line_margin, 1.0);
-  pnh.param(ns + "/stuck_vehicle_detect_dist", p.stuck_vehicle_detect_dist, 5.0);
-  pnh.param(ns + "/stuck_vehicle_ignore_dist", p.stuck_vehicle_ignore_dist, 5.0) +
-    planner_data_->base_link2front;
-  pnh.param(ns + "/stuck_vehicle_vel_thr", p.stuck_vehicle_vel_thr, 3.0 / 3.6);
-  pnh.param(ns + "/intersection_velocity", p.intersection_velocity, 10.0 / 3.6);
-  pnh.param(ns + "/detection_area_length", p.detection_area_length, 200.0);
+  p.state_transit_mergin_time = node.declare_parameter(ns + "/state_transit_mergin_time", 2.0);
+  p.decel_velocoity = node.declare_parameter(ns + "/decel_velocoity", 30.0 / 3.6);
+  p.path_expand_width = node.declare_parameter(ns + "/path_expand_width", 2.0);
+  p.stop_line_margin = node.declare_parameter(ns + "/stop_line_margin", 1.0);
+  p.stuck_vehicle_detect_dist = node.declare_parameter(ns + "/stuck_vehicle_detect_dist", 5.0);
+  p.stuck_vehicle_ignore_dist = node.declare_parameter(ns + "/stuck_vehicle_ignore_dist", 5.0) +
+                                planner_data_->vehicle_info_.max_longitudinal_offset_m_;
+  p.stuck_vehicle_vel_thr = node.declare_parameter(ns + "/stuck_vehicle_vel_thr", 3.0 / 3.6);
+  p.intersection_velocity = node.declare_parameter(ns + "/intersection_velocity", 10.0 / 3.6);
+  p.detection_area_length = node.declare_parameter(ns + "/detection_area_length", 200.0);
 }
 
 void IntersectionModuleManager::launchNewModules(
@@ -99,12 +99,12 @@ void IntersectionModuleManager::launchNewModules(
       const std::string next_lane_location = next_lane.attributeOr("location", "else");
       if (lane_location == "private" && next_lane_location != "private") {
         registerModule(std::make_shared<MergeFromPrivateRoadModule>(
-          module_id, lane_id, planner_data_, planner_param_));
+          module_id, lane_id, planner_data_, planner_param_, logger_, clock_));
       }
     }
 
-    registerModule(
-      std::make_shared<IntersectionModule>(module_id, lane_id, planner_data_, planner_param_));
+    registerModule(std::make_shared<IntersectionModule>(
+      module_id, lane_id, planner_data_, planner_param_, logger_, clock_));
   }
 }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -99,12 +99,12 @@ void IntersectionModuleManager::launchNewModules(
       const std::string next_lane_location = next_lane.attributeOr("location", "else");
       if (lane_location == "private" && next_lane_location != "private") {
         registerModule(std::make_shared<MergeFromPrivateRoadModule>(
-          module_id, lane_id, planner_data_, planner_param_, logger_, clock_));
+          module_id, lane_id, planner_data_, planner_param_, logger_.get_child("merge_from_private_road_module"), clock_));
       }
     }
 
     registerModule(std::make_shared<IntersectionModule>(
-      module_id, lane_id, planner_data_, planner_param_, logger_, clock_));
+      module_id, lane_id, planner_data_, planner_param_, logger_.get_child("intersection_module"), clock_));
   }
 }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -79,9 +79,9 @@ bool IntersectionModule::modifyPathVelocity(
   int first_idx_inside_lane = -1;
   if (!util::generateStopLine(
         lane_id_, detection_areas, planner_data_, planner_param_, path, &stop_line_idx,
-        &pass_judge_line_idx, &first_idx_inside_lane, logger_)) {
+        &pass_judge_line_idx, &first_idx_inside_lane, logger_.get_child("util"))) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
-      logger_, *clock_, 1000, "[IntersectionModule::run] setStopLineIdx fail");
+      logger_, *clock_, 1000, "setStopLineIdx fail");
     RCLCPP_DEBUG(logger_, "===== plan end =====");
     return false;
   }
@@ -95,7 +95,7 @@ bool IntersectionModule::modifyPathVelocity(
   /* calc closest index */
   int closest_idx = -1;
   if (!planning_utils::calcClosestIndex(input_path, current_pose.pose, closest_idx)) {
-    RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1000, "[Intersection] calcClosestIndex fail");
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1000, "calcClosestIndex fail");
     RCLCPP_DEBUG(logger_, "===== plan end =====");
     return false;
   }
@@ -125,7 +125,7 @@ bool IntersectionModule::modifyPathVelocity(
   bool is_stuck = checkStuckVehicleInIntersection(*path, closest_idx, stop_line_idx, objects_ptr);
   bool is_entry_prohibited = (has_collision || is_stuck);
   state_machine_.setStateWithMarginTime(
-    is_entry_prohibited ? State::STOP : State::GO, logger_, *clock_);
+    is_entry_prohibited ? State::STOP : State::GO, logger_.get_child("state_machine"), *clock_);
 
   /* set stop speed : TODO behavior on straight lane should be improved*/
   if (state_machine_.getState() == State::STOP) {
@@ -393,7 +393,7 @@ void IntersectionModule::StateMachine::setStateWithMarginTime(
     return;
   }
 
-  RCLCPP_ERROR(logger, "[StateMachine] : Unsuitable state. ignore request.");
+  RCLCPP_ERROR(logger, "Unsuitable state. ignore request.");
   return;
 }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -30,8 +30,9 @@ namespace bg = boost::geometry;
 
 IntersectionModule::IntersectionModule(
   const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-  const PlannerParam & planner_param)
-: SceneModuleInterface(module_id), lane_id_(lane_id)
+  const PlannerParam & planner_param, const rclcpp::Logger logger,
+  const rclcpp::Clock::SharedPtr clock)
+: SceneModuleInterface(module_id, logger, clock), lane_id_(lane_id)
 {
   planner_param_ = planner_param;
   const auto & assigned_lanelet = planner_data->lanelet_map->laneletLayer.get(lane_id);
@@ -41,10 +42,11 @@ IntersectionModule::IntersectionModule(
 }
 
 bool IntersectionModule::modifyPathVelocity(
-  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path,
+  autoware_planning_msgs::msg::StopReason * stop_reason)
 {
-  ROS_DEBUG("[intersection] ===== plan start =====");
-  debug_data_ = {};
+  RCLCPP_DEBUG(logger_, "===== plan start =====");
+  debug_data_ = DebugData();
   *stop_reason =
     planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::INTERSECTION);
 
@@ -52,7 +54,7 @@ bool IntersectionModule::modifyPathVelocity(
   debug_data_.path_raw = input_path;
 
   State current_state = state_machine_.getState();
-  ROS_DEBUG("[Intersection] lane_id = %ld, state = %s", lane_id_, toString(current_state).c_str());
+  RCLCPP_DEBUG(logger_, "lane_id = %ld, state = %s", lane_id_, toString(current_state).c_str());
 
   /* get current pose */
   geometry_msgs::msg::PoseStamped current_pose = planner_data_->current_pose;
@@ -64,9 +66,9 @@ bool IntersectionModule::modifyPathVelocity(
   /* get detection area */
   std::vector<lanelet::CompoundPolygon3d> detection_areas;
   util::getObjectivePolygons(
-    lanelet_map_ptr, routing_graph_ptr, lane_id_, planner_param_, &detection_areas);
+    lanelet_map_ptr, routing_graph_ptr, lane_id_, planner_param_, &detection_areas, logger_);
   if (detection_areas.empty()) {
-    ROS_DEBUG("[Intersection] no detection area. skip computation.");
+    RCLCPP_DEBUG(logger_, "no detection area. skip computation.");
     return true;
   }
   debug_data_.detection_area = detection_areas;
@@ -77,28 +79,29 @@ bool IntersectionModule::modifyPathVelocity(
   int first_idx_inside_lane = -1;
   if (!util::generateStopLine(
         lane_id_, detection_areas, planner_data_, planner_param_, path, &stop_line_idx,
-        &pass_judge_line_idx, &first_idx_inside_lane)) {
-    ROS_WARN_DELAYED_THROTTLE(1.0, "[IntersectionModule::run] setStopLineIdx fail");
-    ROS_DEBUG("[intersection] ===== plan end =====");
+        &pass_judge_line_idx, &first_idx_inside_lane, logger_)) {
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(
+      logger_, *clock_, 1000, "[IntersectionModule::run] setStopLineIdx fail");
+    RCLCPP_DEBUG(logger_, "===== plan end =====");
     return false;
   }
 
   if (stop_line_idx <= 0 || pass_judge_line_idx <= 0) {
-    ROS_DEBUG("[Intersection] stop line or pass judge line is at path[0], ignore planning.");
-    ROS_DEBUG("[intersection] ===== plan end =====");
+    RCLCPP_DEBUG(logger_, "stop line or pass judge line is at path[0], ignore planning.");
+    RCLCPP_DEBUG(logger_, "===== plan end =====");
     return true;
   }
 
   /* calc closest index */
   int closest_idx = -1;
   if (!planning_utils::calcClosestIndex(input_path, current_pose.pose, closest_idx)) {
-    ROS_WARN_DELAYED_THROTTLE(1.0, "[Intersection] calcClosestIndex fail");
-    ROS_DEBUG("[intersection] ===== plan end =====");
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1000, "[Intersection] calcClosestIndex fail");
+    RCLCPP_DEBUG(logger_, "===== plan end =====");
     return false;
   }
 
-  debug_data_.virtual_wall_pose =
-    util::getAheadPose(stop_line_idx, planner_data_->base_link2front, *path);
+  debug_data_.virtual_wall_pose = util::getAheadPose(
+    stop_line_idx, planner_data_->vehicle_info_.max_longitudinal_offset_m_, *path);
   debug_data_.stop_point_pose = path->points.at(stop_line_idx).point.pose;
   debug_data_.judge_point_pose = path->points.at(pass_judge_line_idx).point.pose;
 
@@ -109,8 +112,8 @@ bool IntersectionModule::modifyPathVelocity(
     is_over_pass_judge_line = util::isAheadOf(current_pose.pose, pass_judge_line);
   }
   if (current_state == State::GO && is_over_pass_judge_line) {
-    ROS_DEBUG("[Intersection] over the pass judge line. no plan needed.");
-    ROS_DEBUG("[intersection] ===== plan end =====");
+    RCLCPP_DEBUG(logger_, "over the pass judge line. no plan needed.");
+    RCLCPP_DEBUG(logger_, "===== plan end =====");
     return true;  // no plan needed.
   }
 
@@ -121,7 +124,8 @@ bool IntersectionModule::modifyPathVelocity(
   bool has_collision = checkCollision(*path, detection_areas, objects_ptr, closest_idx);
   bool is_stuck = checkStuckVehicleInIntersection(*path, closest_idx, stop_line_idx, objects_ptr);
   bool is_entry_prohibited = (has_collision || is_stuck);
-  state_machine_.setStateWithMarginTime(is_entry_prohibited ? State::STOP : State::GO);
+  state_machine_.setStateWithMarginTime(
+    is_entry_prohibited ? State::STOP : State::GO, logger_, *clock_);
 
   /* set stop speed : TODO behavior on straight lane should be improved*/
   if (state_machine_.getState() == State::STOP) {
@@ -141,19 +145,19 @@ bool IntersectionModule::modifyPathVelocity(
     planning_utils::appendStopReason(stop_factor, stop_reason);
   }
 
-  ROS_DEBUG("[intersection] ===== plan end =====");
+  RCLCPP_DEBUG(logger_, "===== plan end =====");
   return true;
 }
 
 void IntersectionModule::cutPredictPathWithDuration(
   autoware_perception_msgs::msg::DynamicObjectArray * objects_ptr, const double time_thr) const
 {
-  const rclcpp::Time current_time = this->now();
+  const rclcpp::Time current_time = clock_->now();
   for (auto & object : objects_ptr->objects) {                    // each objects
     for (auto & predicted_path : object.state.predicted_paths) {  // each predicted paths
       std::vector<geometry_msgs::msg::PoseWithCovarianceStamped> vp;
       for (auto & predicted_pose : predicted_path.path) {  // each path points
-        if ((predicted_pose.header.stamp - current_time).toSec() < time_thr) {
+        if ((rclcpp::Time(predicted_pose.header.stamp) - current_time).seconds() < time_thr) {
           vp.push_back(predicted_pose);
         }
       }
@@ -165,7 +169,8 @@ void IntersectionModule::cutPredictPathWithDuration(
 bool IntersectionModule::checkCollision(
   const autoware_planning_msgs::msg::PathWithLaneId & path,
   const std::vector<lanelet::CompoundPolygon3d> & detection_areas,
-  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr objects_ptr, const int closest_idx)
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr objects_ptr,
+  const int closest_idx)
 {
   /* generate ego-lane polygon */
   const Polygon2d ego_poly = generateEgoIntersectionLanePolygon(
@@ -229,8 +234,8 @@ bool IntersectionModule::checkCollision(
 }
 
 Polygon2d IntersectionModule::generateEgoIntersectionLanePolygon(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx, const int start_idx,
-  const double extra_dist, const double ignore_dist) const
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
+  const int start_idx, const double extra_dist, const double ignore_dist) const
 {
   const size_t assigned_lane_start_idx = start_idx;
   size_t assigned_lane_end_idx = 0;
@@ -248,14 +253,14 @@ Polygon2d IntersectionModule::generateEgoIntersectionLanePolygon(
   {
     //decide start idx with considering ignore_dist
     double dist_sum = 0.0;
-    for (int i = assigned_lane_start_idx + 1; i < assigned_lane_end_idx; ++i) {
+    for (size_t i = assigned_lane_start_idx + 1; i < assigned_lane_end_idx; ++i) {
       dist_sum += planning_utils::calcDist2d(path.points.at(i), path.points.at(i - 1));
       ++ego_area_start_idx;
       if (dist_sum > ignore_dist) break;
     }
   }
 
-  if (ego_area_start_idx < closest_idx) {
+  if (static_cast<int>(ego_area_start_idx) < closest_idx) {
     //If ego-position is over the start_idx, use closest_idx as start
     ego_area_start_idx = closest_idx;
   }
@@ -273,13 +278,13 @@ Polygon2d IntersectionModule::generateEgoIntersectionLanePolygon(
 
   Polygon2d ego_area;  // open polygon
   const auto width = planner_param_.path_expand_width;
-  for (int i = ego_area_start_idx; i <= ego_area_end_idx; ++i) {
+  for (int i = ego_area_start_idx; i <= static_cast<int>(ego_area_end_idx); ++i) {
     double yaw = tf2::getYaw(path.points.at(i).point.pose.orientation);
     double x = path.points.at(i).point.pose.position.x + width * std::sin(yaw);
     double y = path.points.at(i).point.pose.position.y - width * std::cos(yaw);
     ego_area.outer().push_back(Point2d(x, y));
   }
-  for (int i = ego_area_end_idx; i >= ego_area_start_idx; --i) {
+  for (int i = ego_area_end_idx; i >= static_cast<int>(ego_area_start_idx); --i) {
     if (i < 0) break;
     double yaw = tf2::getYaw(path.points.at(i).point.pose.orientation);
     double x = path.points.at(i).point.pose.position.x - width * std::sin(yaw);
@@ -297,7 +302,7 @@ double IntersectionModule::calcIntersectionPassingTime(
   double dist_sum = 0.0;
   int assigned_lane_found = false;
 
-  for (int i = closest_idx + 1; i < path.points.size(); ++i) {
+  for (size_t i = closest_idx + 1; i < path.points.size(); ++i) {
     dist_sum += planning_utils::calcDist2d(path.points.at(i - 1), path.points.at(i));
     bool has_objective_lane_id = util::hasLaneId(path.points.at(i), objective_lane_id);
 
@@ -311,13 +316,14 @@ double IntersectionModule::calcIntersectionPassingTime(
   // TODO set to be reasonable
   const double passing_time = dist_sum / planner_param_.intersection_velocity;
 
-  ROS_DEBUG("[intersection] intersection dist = %f, passing_time = %f", dist_sum, passing_time);
+  RCLCPP_DEBUG(logger_, "intersection dist = %f, passing_time = %f", dist_sum, passing_time);
 
   return passing_time;
 }
 
 bool IntersectionModule::checkStuckVehicleInIntersection(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx, const int stop_idx,
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
+  const int stop_idx,
   const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr objects_ptr) const
 {
   const Polygon2d stuck_vehicle_detect_area = generateEgoIntersectionLanePolygon(
@@ -335,7 +341,7 @@ bool IntersectionModule::checkStuckVehicleInIntersection(
     }
     const auto object_pos = object.state.pose_covariance.pose.position;
     if (bg::within(to_bg2d(object_pos), stuck_vehicle_detect_area)) {
-      ROS_DEBUG("[intersection] stuck vehicle found.");
+      RCLCPP_DEBUG(logger_, "stuck vehicle found.");
       debug_data_.stuck_targets.objects.push_back(object);
       return true;
     }
@@ -357,7 +363,8 @@ bool IntersectionModule::isTargetVehicleType(
   return false;
 }
 
-void IntersectionModule::StateMachine::setStateWithMarginTime(State state)
+void IntersectionModule::StateMachine::setStateWithMarginTime(
+  State state, rclcpp::Logger logger, rclcpp::Clock & clock)
 {
   /* same state request */
   if (state_ == state) {
@@ -375,9 +382,9 @@ void IntersectionModule::StateMachine::setStateWithMarginTime(State state)
   /* STOP -> GO */
   if (state == State::GO) {
     if (start_time_ == nullptr) {
-      start_time_ = std::make_shared<rclcpp::Time>(this->now());
+      start_time_ = std::make_shared<rclcpp::Time>(clock.now());
     } else {
-      const double duration = (this->now() - *start_time_).toSec();
+      const double duration = (clock.now() - *start_time_).seconds();
       if (duration > margin_time_) {
         state_ = State::GO;
         start_time_ = nullptr;  // reset timer
@@ -386,7 +393,7 @@ void IntersectionModule::StateMachine::setStateWithMarginTime(State state)
     return;
   }
 
-  ROS_ERROR("[StateMachine] : Unsuitable state. ignore request.");
+  RCLCPP_ERROR(logger, "[StateMachine] : Unsuitable state. ignore request.");
   return;
 }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -81,7 +81,7 @@ bool IntersectionModule::modifyPathVelocity(
         lane_id_, detection_areas, planner_data_, planner_param_, path, &stop_line_idx,
         &pass_judge_line_idx, &first_idx_inside_lane, logger_.get_child("util"))) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
-      logger_, *clock_, 1000, "setStopLineIdx fail");
+      logger_, *clock_, 1000 /* ms */, "setStopLineIdx fail");
     RCLCPP_DEBUG(logger_, "===== plan end =====");
     return false;
   }
@@ -95,7 +95,7 @@ bool IntersectionModule::modifyPathVelocity(
   /* calc closest index */
   int closest_idx = -1;
   if (!planning_utils::calcClosestIndex(input_path, current_pose.pose, closest_idx)) {
-    RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1000, "calcClosestIndex fail");
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1000 /* ms */, "calcClosestIndex fail");
     RCLCPP_DEBUG(logger_, "===== plan end =====");
     return false;
   }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
@@ -21,10 +21,10 @@
 #include <lanelet2_extension/utility/query.h>
 #include <lanelet2_extension/utility/utilities.h>
 
-#include "scene_module/intersection/util.h"
-#include "utilization/boost_geometry_helper.h"
-#include "utilization/interpolate.h"
-#include "utilization/util.h"
+#include <scene_module/intersection/util.h>
+#include <utilization/boost_geometry_helper.h>
+#include <utilization/interpolate.h>
+#include <utilization/util.h>
 
 namespace bg = boost::geometry;
 
@@ -39,11 +39,11 @@ MergeFromPrivateRoadModule::MergeFromPrivateRoadModule(
 }
 
 bool MergeFromPrivateRoadModule::modifyPathVelocity(
-  autoware_planning_msgs::PathWithLaneId * path, autoware_planning_msgs::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
 {
   debug_data_ = {};
   *stop_reason = planning_utils::initializeStopReason(
-    autoware_planning_msgs::StopReason::MERGE_FROM_PRIVATE_ROAD);
+    autoware_planning_msgs::msg::StopReason::MERGE_FROM_PRIVATE_ROAD);
 
   const auto input_path = *path;
   debug_data_.path_raw = input_path;
@@ -53,7 +53,7 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
     "[MergeFromPrivateRoad] lane_id = %ld, state = %s", lane_id_, toString(current_state).c_str());
 
   /* get current pose */
-  geometry_msgs::PoseStamped current_pose = planner_data_->current_pose;
+  geometry_msgs::msg::PoseStamped current_pose = planner_data_->current_pose;
 
   /* get lanelet map */
   const auto lanelet_map_ptr = planner_data_->lanelet_map;
@@ -101,7 +101,7 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
 
     /* get stop point and stop factor */
     if (v == stop_vel) {
-      autoware_planning_msgs::StopFactor stop_factor;
+      autoware_planning_msgs::msg::StopFactor stop_factor;
       stop_factor.stop_pose = debug_data_.stop_point_pose;
       stop_factor.stop_factor_points.emplace_back(debug_data_.first_collision_point);
       planning_utils::appendStopReason(stop_factor, stop_reason);
@@ -137,9 +137,9 @@ void MergeFromPrivateRoadModule::StateMachine::setStateWithMarginTime(State stat
   /* STOP -> GO */
   if (state == State::GO) {
     if (start_time_ == nullptr) {
-      start_time_ = std::make_shared<ros::Time>(ros::Time::now());
+      start_time_ = std::make_shared<rclcpp::Time>(this->now());
     } else {
-      const double duration = (ros::Time::now() - *start_time_).toSec();
+      const double duration = (this->now() - *start_time_).toSec();
       if (duration > margin_time_) {
         state_ = State::GO;
         start_time_ = nullptr;  // reset timer

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
@@ -30,8 +30,9 @@ namespace bg = boost::geometry;
 
 MergeFromPrivateRoadModule::MergeFromPrivateRoadModule(
   const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-  const IntersectionModule::PlannerParam & planner_param)
-: SceneModuleInterface(module_id), lane_id_(lane_id)
+  const IntersectionModule::PlannerParam & planner_param, const rclcpp::Logger logger,
+  const rclcpp::Clock::SharedPtr clock)
+: SceneModuleInterface(module_id, logger, clock), lane_id_(lane_id)
 {
   planner_param_ = planner_param;
   const auto & assigned_lanelet = planner_data->lanelet_map->laneletLayer.get(lane_id);
@@ -39,9 +40,10 @@ MergeFromPrivateRoadModule::MergeFromPrivateRoadModule(
 }
 
 bool MergeFromPrivateRoadModule::modifyPathVelocity(
-  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path,
+  autoware_planning_msgs::msg::StopReason * stop_reason)
 {
-  debug_data_ = {};
+  debug_data_ = DebugData();
   *stop_reason = planning_utils::initializeStopReason(
     autoware_planning_msgs::msg::StopReason::MERGE_FROM_PRIVATE_ROAD);
 
@@ -49,8 +51,9 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
   debug_data_.path_raw = input_path;
 
   State current_state = state_machine_.getState();
-  ROS_DEBUG(
-    "[MergeFromPrivateRoad] lane_id = %ld, state = %s", lane_id_, toString(current_state).c_str());
+  RCLCPP_DEBUG(
+    logger_, "[MergeFromPrivateRoad] lane_id = %ld, state = %s", lane_id_,
+    toString(current_state).c_str());
 
   /* get current pose */
   geometry_msgs::msg::PoseStamped current_pose = planner_data_->current_pose;
@@ -62,9 +65,9 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
   /* get detection area */
   std::vector<lanelet::CompoundPolygon3d> detection_areas;
   util::getObjectivePolygons(
-    lanelet_map_ptr, routing_graph_ptr, lane_id_, planner_param_, &detection_areas);
+    lanelet_map_ptr, routing_graph_ptr, lane_id_, planner_param_, &detection_areas, logger_);
   if (detection_areas.empty()) {
-    ROS_DEBUG("[MergeFromPrivateRoad] no detection area. skip computation.");
+    RCLCPP_DEBUG(logger_, "[MergeFromPrivateRoad] no detection area. skip computation.");
     return true;
   }
   debug_data_.detection_area = detection_areas;
@@ -75,18 +78,20 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
   int first_idx_inside_lane = -1;
   if (!util::generateStopLine(
         lane_id_, detection_areas, planner_data_, planner_param_, path, &stop_line_idx,
-        &judge_line_idx, &first_idx_inside_lane)) {
-    ROS_WARN_DELAYED_THROTTLE(1.0, "[MergeFromPrivateRoadModule::run] setStopLineIdx fail");
+        &judge_line_idx, &first_idx_inside_lane, logger_)) {
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(
+      logger_, *clock_, 1000, "[MergeFromPrivateRoadModule::run] setStopLineIdx fail");
     return false;
   }
 
   if (stop_line_idx <= 0 || judge_line_idx <= 0) {
-    ROS_DEBUG("[MergeFromPrivateRoad] stop line or judge line is at path[0], ignore planning.");
+    RCLCPP_DEBUG(
+      logger_, "[MergeFromPrivateRoad] stop line or judge line is at path[0], ignore planning.");
     return true;
   }
 
-  debug_data_.virtual_wall_pose =
-    util::getAheadPose(stop_line_idx, planner_data_->base_link2front, *path);
+  debug_data_.virtual_wall_pose = util::getAheadPose(
+    stop_line_idx, planner_data_->vehicle_info_.max_longitudinal_offset_m_, *path);
   debug_data_.stop_point_pose = path->points.at(stop_line_idx).point.pose;
   if (first_idx_inside_lane != -1) {
     debug_data_.first_collision_point = path->points.at(first_idx_inside_lane).point.pose.position;
@@ -119,7 +124,8 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
   return true;
 }
 
-void MergeFromPrivateRoadModule::StateMachine::setStateWithMarginTime(State state)
+void MergeFromPrivateRoadModule::StateMachine::setStateWithMarginTime(
+  State state, rclcpp::Logger logger, rclcpp::Clock & clock)
 {
   /* same state request */
   if (state_ == state) {
@@ -137,9 +143,9 @@ void MergeFromPrivateRoadModule::StateMachine::setStateWithMarginTime(State stat
   /* STOP -> GO */
   if (state == State::GO) {
     if (start_time_ == nullptr) {
-      start_time_ = std::make_shared<rclcpp::Time>(this->now());
+      start_time_ = std::make_shared<rclcpp::Time>(clock.now());
     } else {
-      const double duration = (this->now() - *start_time_).toSec();
+      const double duration = (clock.now() - *start_time_).seconds();
       if (duration > margin_time_) {
         state_ = State::GO;
         start_time_ = nullptr;  // reset timer
@@ -148,7 +154,7 @@ void MergeFromPrivateRoadModule::StateMachine::setStateWithMarginTime(State stat
     return;
   }
 
-  ROS_ERROR("[StateMachine] : Unsuitable state. ignore request.");
+  RCLCPP_ERROR(logger, "[StateMachine] : Unsuitable state. ignore request.");
   return;
 }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
@@ -80,7 +80,7 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
         lane_id_, detection_areas, planner_data_, planner_param_, path, &stop_line_idx,
         &judge_line_idx, &first_idx_inside_lane, logger_.get_child("util"))) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
-      logger_, *clock_, 1000, "setStopLineIdx fail");
+      logger_, *clock_, 1000 /* ms */, "setStopLineIdx fail");
     return false;
   }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -263,8 +263,7 @@ bool generateStopLine(
       RCLCPP_DEBUG(
         logger,
         "[Intersection Util] path[0] is already in the detection area. This happens if you have "
-        "already "
-        "crossed the stop line or are very far from the intersection. Ignore computation.");
+        "already crossed the stop line or are very far from the intersection. Ignore computation.");
       *stop_line_idx = 0;
       *pass_judge_line_idx = 0;
       return true;
@@ -298,8 +297,7 @@ bool generateStopLine(
   RCLCPP_DEBUG(
     logger,
     "[Intersection Util] generateStopLine() : stop_idx = %d, pass_judge_idx = %d, stop_idx_ip = "
-    "%d, "
-    "pass_judge_idx_ip = %d, has_prior_stopline = %d",
+    "%d, pass_judge_idx_ip = %d, has_prior_stopline = %d",
     *stop_line_idx, *pass_judge_line_idx, stop_idx_ip, pass_judge_idx_ip, has_prior_stopline);
 
   return true;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -106,7 +106,7 @@ bool splineInterpolate(
       base_s, base_y, resampled_s, resampled_y, spline_interpolation::Method::PCG) ||
     !spline.interpolate(
       base_s, base_z, resampled_s, resampled_z, spline_interpolation::Method::PCG)) {
-    RCLCPP_ERROR(logger, "[IntersectionModule::splineInterpolate] spline interpolation failed.");
+    RCLCPP_ERROR(logger, "spline interpolation failed.");
     return false;
   }
 
@@ -253,7 +253,7 @@ bool generateStopLine(
     // get idx of first_inside_lane point
     first_idx_ip_inside_lane = getFirstPointInsidePolygons(path_ip, detection_areas);
     if (first_idx_ip_inside_lane == -1) {
-      RCLCPP_DEBUG(logger, "[Intersection Util] generate stopline, but no intersect line found.");
+      RCLCPP_DEBUG(logger, "generate stopline, but no intersect line found.");
       return false;
     }
     // only for visualization
@@ -262,7 +262,7 @@ bool generateStopLine(
     if (*first_idx_inside_lane == 0) {
       RCLCPP_DEBUG(
         logger,
-        "[Intersection Util] path[0] is already in the detection area. This happens if you have "
+        "path[0] is already in the detection area. This happens if you have "
         "already crossed the stop line or are very far from the intersection. Ignore computation.");
       *stop_line_idx = 0;
       *pass_judge_line_idx = 0;
@@ -296,7 +296,7 @@ bool generateStopLine(
 
   RCLCPP_DEBUG(
     logger,
-    "[Intersection Util] generateStopLine() : stop_idx = %d, pass_judge_idx = %d, stop_idx_ip = "
+    "generateStopLine() : stop_idx = %d, pass_judge_idx = %d, stop_idx_ip = "
     "%d, pass_judge_idx_ip = %d, has_prior_stopline = %d",
     *stop_line_idx, *pass_judge_line_idx, stop_idx_ip, pass_judge_idx_ip, has_prior_stopline);
 
@@ -414,10 +414,10 @@ bool getObjectivePolygons(
     for (const auto ll : l) ss_os << ll.id() << ", ";
   }
   RCLCPP_DEBUG(
-    logger, "[Intersection Util] getObjectivePolygons() conflict = %s yield = %s ego = %s",
+    logger, "getObjectivePolygons() conflict = %s yield = %s ego = %s",
     ss_c.str().c_str(), ss_y.str().c_str(), ss_e.str().c_str());
   RCLCPP_DEBUG(
-    logger, "[Intersection Util] getObjectivePolygons() object = %s object_sequences = %s",
+    logger, "getObjectivePolygons() object = %s object_sequences = %s",
     ss_o.str().c_str(), ss_os.str().c_str());
   return true;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
@@ -15,8 +15,8 @@
  */
 #include <scene_module/stop_line/scene.h>
 
-#include "utilization/marker_helper.h"
-#include "utilization/util.h"
+#include <utilization/marker_helper.h>
+#include <utilization/util.h>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
@@ -24,24 +24,24 @@ namespace
 {
 using DebugData = StopLineModule::DebugData;
 
-visualization_msgs::MarkerArray createMarkers(const DebugData & debug_data, const int64_t module_id)
+visualization_msgs::msg::MarkerArray createMarkers(const DebugData & debug_data, const int64_t module_id)
 {
   int32_t uid = planning_utils::bitShift(module_id);
-  visualization_msgs::MarkerArray msg;
-  ros::Time current_time = ros::Time::now();
+  visualization_msgs::msg::MarkerArray msg;
+  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
   // Stop VirtualWall
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::CUBE;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::CUBE;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.stop_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -58,14 +58,14 @@ visualization_msgs::MarkerArray createMarkers(const DebugData & debug_data, cons
   }
   // Factor Text
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = uid + j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.stop_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -87,9 +87,9 @@ visualization_msgs::MarkerArray createMarkers(const DebugData & debug_data, cons
 
 }  // namespace
 
-visualization_msgs::MarkerArray StopLineModule::createDebugMarkerArray()
+visualization_msgs::msg::MarkerArray StopLineModule::createDebugMarkerArray()
 {
-  visualization_msgs::MarkerArray debug_marker_array;
+  visualization_msgs::msg::MarkerArray debug_marker_array;
 
   appendMarkerArray(createMarkers(debug_data_, module_id_), &debug_marker_array);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
@@ -24,11 +24,11 @@ namespace
 {
 using DebugData = StopLineModule::DebugData;
 
-visualization_msgs::msg::MarkerArray createMarkers(const DebugData & debug_data, const int64_t module_id)
+visualization_msgs::msg::MarkerArray createMarkers(
+  const DebugData & debug_data, const int64_t module_id)
 {
   int32_t uid = planning_utils::bitShift(module_id);
   visualization_msgs::msg::MarkerArray msg;
-  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
@@ -36,7 +36,6 @@ visualization_msgs::msg::MarkerArray createMarkers(const DebugData & debug_data,
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -60,7 +59,6 @@ visualization_msgs::msg::MarkerArray createMarkers(const DebugData & debug_data,
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -91,7 +89,8 @@ visualization_msgs::msg::MarkerArray StopLineModule::createDebugMarkerArray()
 {
   visualization_msgs::msg::MarkerArray debug_marker_array;
 
-  appendMarkerArray(createMarkers(debug_data_, module_id_), &debug_marker_array);
+  appendMarkerArray(
+    createMarkers(debug_data_, module_id_), this->clock_->now(), &debug_marker_array);
 
   return debug_marker_array;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
@@ -18,7 +18,7 @@
 namespace
 {
 std::vector<lanelet::TrafficSignConstPtr> getTrafficSignRegElemsOnPath(
-  const autoware_planning_msgs::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
 {
   std::vector<lanelet::TrafficSignConstPtr> traffic_sign_reg_elems;
 
@@ -36,7 +36,7 @@ std::vector<lanelet::TrafficSignConstPtr> getTrafficSignRegElemsOnPath(
 }
 
 std::vector<lanelet::ConstLineString3d> getStopLinesOnPath(
-  const autoware_planning_msgs::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
 {
   std::vector<lanelet::ConstLineString3d> stop_lines;
 
@@ -55,7 +55,7 @@ std::vector<lanelet::ConstLineString3d> getStopLinesOnPath(
 }
 
 std::set<int64_t> getStopLineIdSetOnPath(
-  const autoware_planning_msgs::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
 {
   std::set<int64_t> stop_line_id_set;
 
@@ -69,14 +69,14 @@ std::set<int64_t> getStopLineIdSetOnPath(
 }  // namespace
 
 StopLineModuleManager::StopLineModuleManager() : SceneModuleManagerInterface(getModuleName()) {
-  ros::NodeHandle pnh("~");
+  rclcpp::NodeHandle pnh("~");
   const std::string ns(getModuleName());
   auto & p = planner_param_;
   pnh.param(ns + "/stop_margin", p.stop_margin, 0.0);
   pnh.param(ns + "/stop_check_dist", p.stop_check_dist, 2.0);
 }
 
-void StopLineModuleManager::launchNewModules(const autoware_planning_msgs::PathWithLaneId & path)
+void StopLineModuleManager::launchNewModules(const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   for (const auto & stop_line : getStopLinesOnPath(path, planner_data_->lanelet_map)) {
     const auto module_id = stop_line.id();
@@ -87,7 +87,7 @@ void StopLineModuleManager::launchNewModules(const autoware_planning_msgs::PathW
 }
 
 std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
-StopLineModuleManager::getModuleExpiredFunction(const autoware_planning_msgs::PathWithLaneId & path)
+StopLineModuleManager::getModuleExpiredFunction(const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto stop_line_id_set = getStopLineIdSetOnPath(path, planner_data_->lanelet_map);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
@@ -18,7 +18,8 @@
 namespace
 {
 std::vector<lanelet::TrafficSignConstPtr> getTrafficSignRegElemsOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map)
 {
   std::vector<lanelet::TrafficSignConstPtr> traffic_sign_reg_elems;
 
@@ -36,7 +37,8 @@ std::vector<lanelet::TrafficSignConstPtr> getTrafficSignRegElemsOnPath(
 }
 
 std::vector<lanelet::ConstLineString3d> getStopLinesOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map)
 {
   std::vector<lanelet::ConstLineString3d> stop_lines;
 
@@ -55,7 +57,8 @@ std::vector<lanelet::ConstLineString3d> getStopLinesOnPath(
 }
 
 std::set<int64_t> getStopLineIdSetOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map)
 {
   std::set<int64_t> stop_line_id_set;
 
@@ -68,26 +71,30 @@ std::set<int64_t> getStopLineIdSetOnPath(
 
 }  // namespace
 
-StopLineModuleManager::StopLineModuleManager() : SceneModuleManagerInterface(getModuleName()) {
-  rclcpp::NodeHandle pnh("~");
+StopLineModuleManager::StopLineModuleManager(rclcpp::Node & node)
+: SceneModuleManagerInterface(node, getModuleName())
+{
   const std::string ns(getModuleName());
   auto & p = planner_param_;
-  pnh.param(ns + "/stop_margin", p.stop_margin, 0.0);
-  pnh.param(ns + "/stop_check_dist", p.stop_check_dist, 2.0);
+  p.stop_margin = node.declare_parameter(ns + "/stop_margin", 0.0);
+  p.stop_check_dist = node.declare_parameter(ns + "/stop_check_dist", 2.0);
 }
 
-void StopLineModuleManager::launchNewModules(const autoware_planning_msgs::msg::PathWithLaneId & path)
+void StopLineModuleManager::launchNewModules(
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   for (const auto & stop_line : getStopLinesOnPath(path, planner_data_->lanelet_map)) {
     const auto module_id = stop_line.id();
     if (!isModuleRegistered(module_id)) {
-      registerModule(std::make_shared<StopLineModule>(module_id, stop_line, planner_param_));
+      registerModule(
+        std::make_shared<StopLineModule>(module_id, stop_line, planner_param_, logger_, clock_));
     }
   }
 }
 
 std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
-StopLineModuleManager::getModuleExpiredFunction(const autoware_planning_msgs::msg::PathWithLaneId & path)
+StopLineModuleManager::getModuleExpiredFunction(
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto stop_line_id_set = getStopLineIdSetOnPath(path, planner_data_->lanelet_map);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
@@ -87,7 +87,7 @@ void StopLineModuleManager::launchNewModules(
     const auto module_id = stop_line.id();
     if (!isModuleRegistered(module_id)) {
       registerModule(
-        std::make_shared<StopLineModule>(module_id, stop_line, planner_param_, logger_, clock_));
+        std::make_shared<StopLineModule>(module_id, stop_line, planner_param_, logger_.get_child("stop_line_module"), clock_));
     }
   }
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
@@ -32,13 +32,13 @@ StopLineModule::StopLineModule(
 }
 
 bool StopLineModule::modifyPathVelocity(
-  autoware_planning_msgs::PathWithLaneId * path, autoware_planning_msgs::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
 {
   debug_data_ = {};
   debug_data_.base_link2front = planner_data_->base_link2front;
   first_stop_path_point_index_ = static_cast<int>(path->points.size()) - 1;
   *stop_reason =
-    planning_utils::initializeStopReason(autoware_planning_msgs::StopReason::STOP_LINE);
+    planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::STOP_LINE);
 
   Eigen::Vector2d stop_point;
   bg::model::linestring<Point> stop_line = {
@@ -77,7 +77,7 @@ bool StopLineModule::modifyPathVelocity(
       }
 
       // create stop point
-      autoware_planning_msgs::PathPointWithLaneId stop_point_with_lane_id;
+      autoware_planning_msgs::msg::PathPointWithLaneId stop_point_with_lane_id;
       getBackwordPointFromBasePoint(point2, point1, point2, length_sum - stop_length, stop_point);
       const int stop_point_idx = std::max(static_cast<int>(insert_stop_point_idx - 1), 0);
       stop_point_with_lane_id = path->points.at(stop_point_idx);
@@ -100,7 +100,7 @@ bool StopLineModule::modifyPathVelocity(
     }
 
     // update state
-    geometry_msgs::PoseStamped self_pose = planner_data_->current_pose;
+    geometry_msgs::msg::PoseStamped self_pose = planner_data_->current_pose;
     const double x = stop_point.x() - self_pose.pose.position.x;
     const double y = stop_point.y() - self_pose.pose.position.y;
     const double dist = std::sqrt(x * x + y * y);
@@ -110,7 +110,7 @@ bool StopLineModule::modifyPathVelocity(
   } else if (state_ == State::STOP) {
     if (!planner_data_->isVehicleStopping()) state_ = State::START;
     /* get stop point and stop factor */
-    autoware_planning_msgs::StopFactor stop_factor;
+    autoware_planning_msgs::msg::StopFactor stop_factor;
     stop_factor.stop_pose = debug_data_.first_stop_pose;
     stop_factor.stop_factor_points.emplace_back(getCenterOfStopLine(stop_line_));
     planning_utils::appendStopReason(stop_factor, stop_reason);
@@ -128,10 +128,10 @@ bool StopLineModule::getBackwordPointFromBasePoint(
   return true;
 }
 
-geometry_msgs::Point StopLineModule::getCenterOfStopLine(
+geometry_msgs::msg::Point StopLineModule::getCenterOfStopLine(
   const lanelet::ConstLineString3d & stop_line)
 {
-  geometry_msgs::Point center_point;
+  geometry_msgs::msg::Point center_point;
   center_point.x = (stop_line[0].x() + stop_line[1].x()) / 2.0;
   center_point.y = (stop_line[0].y() + stop_line[1].y()) / 2.0;
   center_point.z = (stop_line[0].z() + stop_line[1].z()) / 2.0;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
@@ -22,8 +22,9 @@ using Polygon = bg::model::polygon<Point>;
 
 StopLineModule::StopLineModule(
   const int64_t module_id, const lanelet::ConstLineString3d & stop_line,
-  const PlannerParam & planner_param)
-: SceneModuleInterface(module_id),
+  const PlannerParam & planner_param, const rclcpp::Logger logger,
+  const rclcpp::Clock::SharedPtr clock)
+: SceneModuleInterface(module_id, logger, clock),
   module_id_(module_id),
   stop_line_(stop_line),
   state_(State::APPROACH)
@@ -32,10 +33,11 @@ StopLineModule::StopLineModule(
 }
 
 bool StopLineModule::modifyPathVelocity(
-  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path,
+  autoware_planning_msgs::msg::StopReason * stop_reason)
 {
-  debug_data_ = {};
-  debug_data_.base_link2front = planner_data_->base_link2front;
+  debug_data_ = DebugData();
+  debug_data_.base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m_;
   first_stop_path_point_index_ = static_cast<int>(path->points.size()) - 1;
   *stop_reason =
     planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::STOP_LINE);
@@ -56,7 +58,7 @@ bool StopLineModule::modifyPathVelocity(
 
       // search stop point index
       size_t insert_stop_point_idx = 0;
-      const double base_link2front = planner_data_->base_link2front;
+      const double base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m_;
       double length_sum = 0;
 
       const double stop_length = planner_param_.stop_margin + base_link2front;
@@ -106,7 +108,6 @@ bool StopLineModule::modifyPathVelocity(
     const double dist = std::sqrt(x * x + y * y);
     if (dist < planner_param_.stop_check_dist && planner_data_->isVehicleStopping())
       state_ = State::STOP;
-    return true;
   } else if (state_ == State::STOP) {
     if (!planner_data_->isVehicleStopping()) state_ = State::START;
     /* get stop point and stop factor */
@@ -114,8 +115,8 @@ bool StopLineModule::modifyPathVelocity(
     stop_factor.stop_pose = debug_data_.first_stop_pose;
     stop_factor.stop_factor_points.emplace_back(getCenterOfStopLine(stop_line_));
     planning_utils::appendStopReason(stop_factor, stop_reason);
-    return true;
   }
+  return true;
 }
 
 bool StopLineModule::getBackwordPointFromBasePoint(

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/debug.cpp
@@ -29,7 +29,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
 {
   int32_t uid = planning_utils::bitShift(lane_id);
   visualization_msgs::msg::MarkerArray msg;
-  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
@@ -37,7 +36,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -61,7 +59,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -86,7 +83,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   for (size_t j = 0; j < debug_data.dead_line_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "dead line virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -110,7 +106,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   for (size_t j = 0; j < debug_data.dead_line_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "dead line factor_text";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -141,7 +136,8 @@ visualization_msgs::msg::MarkerArray TrafficLightModule::createDebugMarkerArray(
 {
   visualization_msgs::msg::MarkerArray debug_marker_array;
 
-  appendMarkerArray(createMarkerArray(debug_data_, lane_id_), &debug_marker_array);
+  appendMarkerArray(
+    createMarkerArray(debug_data_, lane_id_), this->clock_->now(), &debug_marker_array);
 
   return debug_marker_array;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/debug.cpp
@@ -17,32 +17,32 @@
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
-#include "utilization/marker_helper.h"
-#include "utilization/util.h"
+#include <utilization/marker_helper.h>
+#include <utilization/util.h>
 
 namespace
 {
 using DebugData = TrafficLightModule::DebugData;
 
-visualization_msgs::MarkerArray createMarkerArray(
+visualization_msgs::msg::MarkerArray createMarkerArray(
   const DebugData & debug_data, const int64_t lane_id)
 {
   int32_t uid = planning_utils::bitShift(lane_id);
-  visualization_msgs::MarkerArray msg;
-  ros::Time current_time = ros::Time::now();
+  visualization_msgs::msg::MarkerArray msg;
+  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
   // Stop VirtualWall
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::CUBE;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::CUBE;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.stop_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -59,14 +59,14 @@ visualization_msgs::MarkerArray createMarkerArray(
   }
   // Factor Text
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = uid + j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.stop_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -84,14 +84,14 @@ visualization_msgs::MarkerArray createMarkerArray(
   }
   // Dead VirtualWall
   for (size_t j = 0; j < debug_data.dead_line_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "dead line virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::CUBE;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::CUBE;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.dead_line_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -108,14 +108,14 @@ visualization_msgs::MarkerArray createMarkerArray(
   }
   // Facto Text
   for (size_t j = 0; j < debug_data.dead_line_poses.size(); ++j) {
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
     marker.header.stamp = current_time;
     marker.ns = "dead line factor_text";
     marker.id = uid + j;
-    marker.lifetime = ros::Duration(0.5);
-    marker.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
-    marker.action = visualization_msgs::Marker::ADD;
+    marker.lifetime = rclcpp::Duration(0.5);
+    marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+    marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
     tf2::fromMsg(debug_data.dead_line_poses.at(j), tf_map2base_link);
     tf2::Transform tf_map2front = tf_map2base_link * tf_base_link2front;
@@ -137,9 +137,9 @@ visualization_msgs::MarkerArray createMarkerArray(
 
 }  // namespace
 
-visualization_msgs::MarkerArray TrafficLightModule::createDebugMarkerArray()
+visualization_msgs::msg::MarkerArray TrafficLightModule::createDebugMarkerArray()
 {
-  visualization_msgs::MarkerArray debug_marker_array;
+  visualization_msgs::msg::MarkerArray debug_marker_array;
 
   appendMarkerArray(createMarkerArray(debug_data_, lane_id_), &debug_marker_array);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
@@ -21,7 +21,7 @@ namespace
 {
 std::unordered_map<lanelet::TrafficLightConstPtr, lanelet::ConstLanelet>
 getTrafficLightRegElemsOnPath(
-  const autoware_planning_msgs::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
 {
   std::unordered_map<lanelet::TrafficLightConstPtr, lanelet::ConstLanelet> traffic_light_reg_elems;
 
@@ -39,7 +39,7 @@ getTrafficLightRegElemsOnPath(
 }
 
 std::set<int64_t> getLaneletIdSetOnPath(
-  const autoware_planning_msgs::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
 {
   std::set<int64_t> lanelet_id_set;
   for (const auto & traffic_light_reg_elem : getTrafficLightRegElemsOnPath(path, lanelet_map)) {
@@ -53,25 +53,24 @@ std::set<int64_t> getLaneletIdSetOnPath(
 TrafficLightModuleManager::TrafficLightModuleManager()
 : SceneModuleManagerInterface(getModuleName())
 {
-  ros::NodeHandle pnh("~");
+  rclcpp::NodeHandle pnh("~");
   const std::string ns(getModuleName());
   auto & p = planner_param_;
   pnh.param(ns + "/stop_margin", p.stop_margin, 0.0);
   pnh.param(ns + "/tl_state_timeout", p.tl_state_timeout, 1.0);
-  pub_tl_state_ = pnh.advertise<autoware_perception_msgs::TrafficLightStateStamped>(
-    "output/traffic_light_state", 1);
+  pub_tl_state_ = this->create_publisher<autoware_perception_msgs::msg::TrafficLightStateStamped>("output/traffic_light_state", 1);
 }
 
-void TrafficLightModuleManager::modifyPathVelocity(autoware_planning_msgs::PathWithLaneId * path)
+void TrafficLightModuleManager::modifyPathVelocity(autoware_planning_msgs::msg::PathWithLaneId * path)
 {
-  visualization_msgs::MarkerArray debug_marker_array;
-  autoware_planning_msgs::StopReasonArray stop_reason_array;
-  autoware_perception_msgs::TrafficLightStateStamped tl_state;
+  visualization_msgs::msg::MarkerArray debug_marker_array;
+  autoware_planning_msgs::msg::StopReasonArray stop_reason_array;
+  autoware_perception_msgs::msg::TrafficLightStateStamped tl_state;
   stop_reason_array.header.frame_id = "map";
-  stop_reason_array.header.stamp = ros::Time::now();
+  stop_reason_array.header.stamp = this->now();
   first_stop_path_point_index_ = static_cast<int>(path->points.size());
   for (const auto & scene_module : scene_modules_) {
-    autoware_planning_msgs::StopReason stop_reason;
+    autoware_planning_msgs::msg::StopReason stop_reason;
     std::shared_ptr<TrafficLightModule> traffc_light_scene_module(std::dynamic_pointer_cast<TrafficLightModule>(scene_module));
     traffc_light_scene_module->setPlannerData(planner_data_);
     traffc_light_scene_module->modifyPathVelocity(path, &stop_reason);
@@ -87,16 +86,16 @@ void TrafficLightModuleManager::modifyPathVelocity(autoware_planning_msgs::PathW
     }
   }
   if (!stop_reason_array.stop_reasons.empty()) {
-    pub_stop_reason_.publish(stop_reason_array);
+    pub_stop_reason_->publish(stop_reason_array);
   }
-  pub_debug_.publish(debug_marker_array);
+  pub_debug_->publish(debug_marker_array);
   if (!tl_state.state.lamp_states.empty()) {
-    pub_tl_state_.publish(tl_state);
+    pub_tl_state_->publish(tl_state);
   }
 }
 
 void TrafficLightModuleManager::launchNewModules(
-  const autoware_planning_msgs::PathWithLaneId & path)
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   for (const auto & traffic_light_reg_elem :
        getTrafficLightRegElemsOnPath(path, planner_data_->lanelet_map)) {
@@ -120,7 +119,7 @@ void TrafficLightModuleManager::launchNewModules(
 
 std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
 TrafficLightModuleManager::getModuleExpiredFunction(
-  const autoware_planning_msgs::PathWithLaneId & path)
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto lanelet_id_set = getLaneletIdSetOnPath(path, planner_data_->lanelet_map);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
@@ -118,7 +118,7 @@ void TrafficLightModuleManager::launchNewModules(
     if (!isModuleRegistered(module_id)) {
       registerModule(std::make_shared<TrafficLightModule>(
         module_id, *(traffic_light_reg_elem.first), traffic_light_reg_elem.second, planner_param_,
-        logger_, clock_));
+        logger_.get_child("traffic_light_module"), clock_));
     }
   }
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
@@ -25,7 +25,7 @@
 namespace
 {
 std::pair<int, double> findWayPointAndDistance(
-  const autoware_planning_msgs::PathWithLaneId & input_path, const Eigen::Vector2d & p)
+  const autoware_planning_msgs::msg::PathWithLaneId & input_path, const Eigen::Vector2d & p)
 {
   constexpr double max_lateral_dist = 3.0;
   for (size_t i = 0; i < input_path.points.size() - 1; ++i) {
@@ -63,7 +63,7 @@ std::pair<int, double> findWayPointAndDistance(
 }
 
 double calcArcLengthFromWayPoint(
-  const autoware_planning_msgs::PathWithLaneId & input_path, const int & src, const int & dst)
+  const autoware_planning_msgs::msg::PathWithLaneId & input_path, const int & src, const int & dst)
 {
   double length = 0;
   const size_t src_idx = src >= 0 ? static_cast<size_t>(src) : 0;
@@ -79,7 +79,7 @@ double calcArcLengthFromWayPoint(
 }
 
 double calcSignedArcLength(
-  const autoware_planning_msgs::PathWithLaneId & input_path, const geometry_msgs::Pose & p1,
+  const autoware_planning_msgs::msg::PathWithLaneId & input_path, const geometry_msgs::msg::Pose & p1,
   const Eigen::Vector2d & p2)
 {
   std::pair<int, double> src =
@@ -101,7 +101,7 @@ double calcSignedArcLength(
   }
 }
 
-double calcSignedDistance(const geometry_msgs::Pose & p1, const Eigen::Vector2d & p2)
+double calcSignedDistance(const geometry_msgs::msg::Pose & p1, const Eigen::Vector2d & p2)
 {
   Eigen::Affine3d map2p1;
   tf2::fromMsg(p1, map2p1);
@@ -128,13 +128,13 @@ TrafficLightModule::TrafficLightModule(
 }
 
 bool TrafficLightModule::modifyPathVelocity(
-  autoware_planning_msgs::PathWithLaneId * path, autoware_planning_msgs::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
 {
   debug_data_ = {};
   debug_data_.base_link2front = planner_data_->base_link2front;
   first_stop_path_point_index_ = static_cast<int>(path->points.size()) - 1;
   *stop_reason =
-    planning_utils::initializeStopReason(autoware_planning_msgs::StopReason::TRAFFIC_LIGHT);
+    planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::TRAFFIC_LIGHT);
 
   const auto input_path = *path;
 
@@ -143,13 +143,13 @@ bool TrafficLightModule::modifyPathVelocity(
   lanelet::ConstLineStringsOrPolygons3d traffic_lights = traffic_light_reg_elem_.trafficLights();
 
   // get vehicle info
-  geometry_msgs::TwistStamped::ConstPtr self_twist_ptr = planner_data_->current_velocity;
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr self_twist_ptr = planner_data_->current_velocity;
   const double max_acc = planner_data_->max_stop_acceleration_threshold_;
   const double delay_response_time = planner_data_->delay_response_time_;
   const double pass_judge_line_distance =
     planning_utils::calcJudgeLineDist(self_twist_ptr->twist.linear.x, max_acc, delay_response_time);
 
-  geometry_msgs::PoseStamped self_pose = planner_data_->current_pose;
+  geometry_msgs::msg::PoseStamped self_pose = planner_data_->current_pose;
 
   // check state
   if (state_ == State::GO_OUT) {
@@ -212,7 +212,7 @@ bool TrafficLightModule::modifyPathVelocity(
         }
 
         /* get stop point and stop factor */
-        autoware_planning_msgs::StopFactor stop_factor;
+        autoware_planning_msgs::msg::StopFactor stop_factor;
         stop_factor.stop_pose = debug_data_.first_stop_pose;
         stop_factor.stop_factor_points = debug_data_.traffic_light_points;
         planning_utils::appendStopReason(stop_factor, stop_reason);
@@ -227,7 +227,7 @@ bool TrafficLightModule::modifyPathVelocity(
 }
 
 bool TrafficLightModule::isOverDeadLine(
-  const geometry_msgs::Pose & self_pose, const autoware_planning_msgs::PathWithLaneId & input_path,
+  const geometry_msgs::msg::Pose & self_pose, const autoware_planning_msgs::msg::PathWithLaneId & input_path,
   const size_t & dead_line_point_idx, const Eigen::Vector2d & dead_line_point,
   const double dead_line_range)
 {
@@ -257,7 +257,7 @@ bool TrafficLightModule::isOverDeadLine(
     tf_dead_line_pose2self_pose = tf_map2dead_line_pose.inverse() * tf_map2self_pose;
 
     // debug code
-    geometry_msgs::Pose dead_line_pose;
+    geometry_msgs::msg::Pose dead_line_pose;
     tf2::toMsg(tf_map2dead_line_pose, dead_line_pose);
     debug_data_.dead_line_poses.push_back(dead_line_pose);
   }
@@ -271,9 +271,9 @@ bool TrafficLightModule::isOverDeadLine(
 }
 
 bool TrafficLightModule::isStopRequired(
-  const autoware_perception_msgs::TrafficLightState & tl_state)
+  const autoware_perception_msgs::msg::TrafficLightState & tl_state)
 {
-  if (hasLamp(tl_state, autoware_perception_msgs::LampState::GREEN)) {
+  if (hasLamp(tl_state, autoware_perception_msgs::msg::LampState::GREEN)) {
     return false;
   }
 
@@ -283,15 +283,15 @@ bool TrafficLightModule::isStopRequired(
     return true;
   }
 
-  if (turn_direction == "right" && hasLamp(tl_state, autoware_perception_msgs::LampState::RIGHT)) {
+  if (turn_direction == "right" && hasLamp(tl_state, autoware_perception_msgs::msg::LampState::RIGHT)) {
     return false;
   }
 
-  if (turn_direction == "left" && hasLamp(tl_state, autoware_perception_msgs::LampState::LEFT)) {
+  if (turn_direction == "left" && hasLamp(tl_state, autoware_perception_msgs::msg::LampState::LEFT)) {
     return false;
   }
 
-  if (turn_direction == "straight" && hasLamp(tl_state, autoware_perception_msgs::LampState::UP)) {
+  if (turn_direction == "straight" && hasLamp(tl_state, autoware_perception_msgs::msg::LampState::UP)) {
     return false;
   }
 
@@ -300,7 +300,7 @@ bool TrafficLightModule::isStopRequired(
 
 bool TrafficLightModule::getHighestConfidenceTrafficLightState(
   const lanelet::ConstLineStringsOrPolygons3d & traffic_lights,
-  autoware_perception_msgs::TrafficLightStateStamped & highest_confidence_tl_state)
+  autoware_perception_msgs::msg::TrafficLightStateStamped & highest_confidence_tl_state)
 {
   // search traffic light state
   bool found = false;
@@ -322,14 +322,14 @@ bool TrafficLightModule::getHighestConfidenceTrafficLightState(
 
     const auto header = tl_state_stamped->header;
     const auto tl_state = tl_state_stamped->state;
-    if (!((ros::Time::now() - header.stamp).toSec() < planner_param_.tl_state_timeout)) {
+    if (!((this->now() - header.stamp).toSec() < planner_param_.tl_state_timeout)) {
       reason = "TimeOut";
       continue;
     }
 
     if (
       tl_state.lamp_states.empty() ||
-      tl_state.lamp_states.front().type == autoware_perception_msgs::LampState::UNKNOWN) {
+      tl_state.lamp_states.front().type == autoware_perception_msgs::msg::LampState::UNKNOWN) {
       reason = "LampStateUnknown";
       continue;
     }
@@ -337,7 +337,7 @@ bool TrafficLightModule::getHighestConfidenceTrafficLightState(
     if (highest_confidence < tl_state.lamp_states.front().confidence) {
       highest_confidence = tl_state.lamp_states.front().confidence;
       highest_confidence_tl_state = *tl_state_stamped;
-      const std::vector<geometry_msgs::Point> highest_traffic_light{
+      const std::vector<geometry_msgs::msg::Point> highest_traffic_light{
         getTrafficLightPosition(traffic_light)};
       // store only highest confidence traffic light (not all traffic light)
       debug_data_.traffic_light_points = highest_traffic_light;
@@ -353,15 +353,15 @@ bool TrafficLightModule::getHighestConfidenceTrafficLightState(
 }
 
 bool TrafficLightModule::insertTargetVelocityPoint(
-  const autoware_planning_msgs::PathWithLaneId & input,
+  const autoware_planning_msgs::msg::PathWithLaneId & input,
   const boost::geometry::model::linestring<boost::geometry::model::d2::point_xy<double>> &
     stop_line,
-  const double & margin, const double & velocity, autoware_planning_msgs::PathWithLaneId & output)
+  const double & margin, const double & velocity, autoware_planning_msgs::msg::PathWithLaneId & output)
 {
   // create target point
   Eigen::Vector2d target_point;
   size_t insert_target_point_idx;
-  autoware_planning_msgs::PathPointWithLaneId target_point_with_lane_id;
+  autoware_planning_msgs::msg::PathPointWithLaneId target_point_with_lane_id;
 
   if (!createTargetPoint(input, stop_line, margin, insert_target_point_idx, target_point))
     return false;
@@ -390,7 +390,7 @@ bool TrafficLightModule::insertTargetVelocityPoint(
 }
 
 bool TrafficLightModule::createTargetPoint(
-  const autoware_planning_msgs::PathWithLaneId & input,
+  const autoware_planning_msgs::msg::PathWithLaneId & input,
   const boost::geometry::model::linestring<boost::geometry::model::d2::point_xy<double>> &
     stop_line,
   const double & margin, size_t & target_point_idx, Eigen::Vector2d & target_point)
@@ -475,7 +475,7 @@ bool TrafficLightModule::getBackwordPointFromBasePoint(
 }
 
 bool TrafficLightModule::hasLamp(
-  const autoware_perception_msgs::TrafficLightState & tl_state, const uint8_t & lamp_color)
+  const autoware_perception_msgs::msg::TrafficLightState & tl_state, const uint8_t & lamp_color)
 {
   const auto it_lamp = std::find_if(
     tl_state.lamp_states.begin(), tl_state.lamp_states.end(),
@@ -484,10 +484,10 @@ bool TrafficLightModule::hasLamp(
   return it_lamp != tl_state.lamp_states.end();
 }
 
-geometry_msgs::Point TrafficLightModule::getTrafficLightPosition(
+geometry_msgs::msg::Point TrafficLightModule::getTrafficLightPosition(
   const lanelet::ConstLineStringOrPolygon3d traffic_light)
 {
-  geometry_msgs::Point tl_center;
+  geometry_msgs::msg::Point tl_center;
   for (const auto tl_point : *traffic_light.lineString()) {
     tl_center.x += tl_point.x() / (*traffic_light.lineString()).size();
     tl_center.y += tl_point.y() / (*traffic_light.lineString()).size();

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
@@ -194,7 +194,7 @@ bool TrafficLightModule::modifyPathVelocity(
            pass_judge_line_distance + planner_data_->vehicle_info_.max_longitudinal_offset_m_) &&
           (3.0 /* =10.8km/h */ < self_twist_ptr->twist.linear.x)) {
           RCLCPP_WARN_THROTTLE(
-            logger_, *clock_, 1000, "vehicle is over stop border (%f m)",
+            logger_, *clock_, 1000 /* ms */, "vehicle is over stop border (%f m)",
             pass_judge_line_distance + planner_data_->vehicle_info_.max_longitudinal_offset_m_);
           return true;
         } else {
@@ -347,7 +347,7 @@ bool TrafficLightModule::getHighestConfidenceTrafficLightState(
   }
   if (!found) {
     RCLCPP_WARN_THROTTLE(
-      logger_, *clock_, 1000, "cannot find traffic light lamp state (%s).",
+      logger_, *clock_, 1000 /* ms */, "cannot find traffic light lamp state (%s).",
       reason.c_str());
     return false;
   }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
@@ -194,14 +194,14 @@ bool TrafficLightModule::modifyPathVelocity(
            pass_judge_line_distance + planner_data_->vehicle_info_.max_longitudinal_offset_m_) &&
           (3.0 /* =10.8km/h */ < self_twist_ptr->twist.linear.x)) {
           RCLCPP_WARN_THROTTLE(
-            logger_, *clock_, 1000, "[traffic_light] vehicle is over stop border (%f m)",
+            logger_, *clock_, 1000, "vehicle is over stop border (%f m)",
             pass_judge_line_distance + planner_data_->vehicle_info_.max_longitudinal_offset_m_);
           return true;
         } else {
           // Add Stop WayPoint
           if (!insertTargetVelocityPoint(
                 input_path, stop_line, planner_param_.stop_margin, 0.0, *path)) {
-            RCLCPP_WARN(logger_, "[traffic_light] cannot insert stop waypoint");
+            RCLCPP_WARN(logger_, "cannot insert stop waypoint");
             continue;
           }
         }
@@ -259,7 +259,7 @@ bool TrafficLightModule::isOverDeadLine(
   }
 
   if (0 < tf_dead_line_pose2self_pose.getOrigin().x()) {
-    RCLCPP_WARN(logger_, "[traffic_light] vehicle is over dead line");
+    RCLCPP_WARN(logger_, "vehicle is over dead line");
     return true;
   }
 
@@ -347,7 +347,7 @@ bool TrafficLightModule::getHighestConfidenceTrafficLightState(
   }
   if (!found) {
     RCLCPP_WARN_THROTTLE(
-      logger_, *clock_, 1000, "[traffic_light] cannot find traffic light lamp state (%s).",
+      logger_, *clock_, 1000, "cannot find traffic light lamp state (%s).",
       reason.c_str());
     return false;
   }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/interpolate.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/interpolate.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "utilization/interpolate.h"
-#include "utilization/util.h"
+#include <utilization/interpolate.h>
+#include <utilization/util.h>
 
 namespace interpolation
 {

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/interpolate.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/interpolate.cpp
@@ -69,7 +69,7 @@ bool isIncrease(const std::vector<double> & x)
     if (x[i] > x[i + 1]) return false;
   }
   return true;
-};
+}
 
 bool isValidInput(
   const std::vector<double> & base_index, const std::vector<double> & base_value,

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/path_utilization.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/path_utilization.cpp
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-#include "utilization/path_utilization.h"
+#include <utilization/path_utilization.h>
 
 #include <memory>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
-#include "utilization/interpolation/cubic_spline.hpp"
+#include <utilization/interpolation/cubic_spline.hpp>
 
-autoware_planning_msgs::Path interpolatePath(
-  const autoware_planning_msgs::Path & path, const double length)
+autoware_planning_msgs::msg::Path interpolatePath(
+  const autoware_planning_msgs::msg::Path & path, const double length)
 {
-  autoware_planning_msgs::Path interpolated_path;
+  autoware_planning_msgs::msg::Path interpolated_path;
 
   std::vector<double> x;
   std::vector<double> y;
@@ -63,7 +63,7 @@ autoware_planning_msgs::Path interpolatePath(
 
     // insert check point before interpolated point
     while (checkpoint_idx < spline_ptr->s.size() && spline_ptr->s.at(checkpoint_idx) < s_t) {
-      autoware_planning_msgs::PathPoint path_point;
+      autoware_planning_msgs::msg::PathPoint path_point;
       std::array<double, 4> state =
         spline_ptr->calc_trajectory_point(spline_ptr->s.at(checkpoint_idx));
       path_point.pose.position.x = state[0];
@@ -82,7 +82,7 @@ autoware_planning_msgs::Path interpolatePath(
       interpolated_path.points.push_back(path_point);
       ++checkpoint_idx;
     }
-    autoware_planning_msgs::PathPoint path_point;
+    autoware_planning_msgs::msg::PathPoint path_point;
     std::array<double, 4> state = spline_ptr->calc_trajectory_point(s_t);
     path_point.pose.position.x = state[0];
     path_point.pose.position.y = state[1];
@@ -100,9 +100,9 @@ autoware_planning_msgs::Path interpolatePath(
   return interpolated_path;
 }
 
-autoware_planning_msgs::Path filterLitterPathPoint(const autoware_planning_msgs::Path & path)
+autoware_planning_msgs::msg::Path filterLitterPathPoint(const autoware_planning_msgs::msg::Path & path)
 {
-  autoware_planning_msgs::Path filtered_path;
+  autoware_planning_msgs::msg::Path filtered_path;
 
   const double epsilon = 0.01;
   size_t latest_id = 0;
@@ -126,9 +126,9 @@ autoware_planning_msgs::Path filterLitterPathPoint(const autoware_planning_msgs:
 
   return filtered_path;
 }
-autoware_planning_msgs::Path filterStopPathPoint(const autoware_planning_msgs::Path & path)
+autoware_planning_msgs::msg::Path filterStopPathPoint(const autoware_planning_msgs::msg::Path & path)
 {
-  autoware_planning_msgs::Path filtered_path = path;
+  autoware_planning_msgs::msg::Path filtered_path = path;
   bool found_stop = false;
   for (size_t i = 0; i < filtered_path.points.size(); ++i) {
     if (std::fabs(filtered_path.points.at(i).twist.linear.x) < 0.01) found_stop = true;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/util.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/util.cpp
@@ -16,7 +16,7 @@
  * Author: Robin Karlsson
  */
 
-#include "utilization/util.h"
+#include <utilization/util.h>
 
 namespace planning_utils
 {
@@ -33,7 +33,7 @@ double normalizeEulerAngle(double euler)
   return res;
 }
 
-geometry_msgs::Quaternion getQuaternionFromYaw(double yaw)
+geometry_msgs::msg::Quaternion getQuaternionFromYaw(double yaw)
 {
   tf2::Quaternion q;
   q.setRPY(0, 0, yaw);
@@ -42,7 +42,7 @@ geometry_msgs::Quaternion getQuaternionFromYaw(double yaw)
 
 template <class T>
 bool calcClosestIndex(
-  const T & path, const geometry_msgs::Pose & pose, int & closest, double dist_thr,
+  const T & path, const geometry_msgs::msg::Pose & pose, int & closest, double dist_thr,
   double angle_thr)
 {
   double dist_squared_min = std::numeric_limits<double>::max();
@@ -70,19 +70,19 @@ bool calcClosestIndex(
   return closest == -1 ? false : true;
 }
 
-template bool calcClosestIndex<autoware_planning_msgs::Trajectory>(
-  const autoware_planning_msgs::Trajectory & path, const geometry_msgs::Pose & pose, int & closest,
+template bool calcClosestIndex<autoware_planning_msgs::msg::Trajectory>(
+  const autoware_planning_msgs::msg::Trajectory & path, const geometry_msgs::msg::Pose & pose, int & closest,
   double dist_thr, double angle_thr);
-template bool calcClosestIndex<autoware_planning_msgs::PathWithLaneId>(
-  const autoware_planning_msgs::PathWithLaneId & path, const geometry_msgs::Pose & pose,
+template bool calcClosestIndex<autoware_planning_msgs::msg::PathWithLaneId>(
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const geometry_msgs::msg::Pose & pose,
   int & closest, double dist_thr, double angle_thr);
-template bool calcClosestIndex<autoware_planning_msgs::Path>(
-  const autoware_planning_msgs::Path & path, const geometry_msgs::Pose & pose, int & closest,
+template bool calcClosestIndex<autoware_planning_msgs::msg::Path>(
+  const autoware_planning_msgs::msg::Path & path, const geometry_msgs::msg::Pose & pose, int & closest,
   double dist_thr, double angle_thr);
 
 template <class T>
 bool calcClosestIndex(
-  const T & path, const geometry_msgs::Point & point, int & closest, double dist_thr)
+  const T & path, const geometry_msgs::msg::Point & point, int & closest, double dist_thr)
 {
   double dist_squared_min = std::numeric_limits<double>::max();
   closest = -1;
@@ -101,28 +101,28 @@ bool calcClosestIndex(
 
   return closest == -1 ? false : true;
 }
-template bool calcClosestIndex<autoware_planning_msgs::Trajectory>(
-  const autoware_planning_msgs::Trajectory & path, const geometry_msgs::Point & point,
+template bool calcClosestIndex<autoware_planning_msgs::msg::Trajectory>(
+  const autoware_planning_msgs::msg::Trajectory & path, const geometry_msgs::msg::Point & point,
   int & closest, double dist_thr);
-template bool calcClosestIndex<autoware_planning_msgs::PathWithLaneId>(
-  const autoware_planning_msgs::PathWithLaneId & path, const geometry_msgs::Point & point,
+template bool calcClosestIndex<autoware_planning_msgs::msg::PathWithLaneId>(
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const geometry_msgs::msg::Point & point,
   int & closest, double dist_thr);
-template bool calcClosestIndex<autoware_planning_msgs::Path>(
-  const autoware_planning_msgs::Path & path, const geometry_msgs::Point & point, int & closest,
+template bool calcClosestIndex<autoware_planning_msgs::msg::Path>(
+  const autoware_planning_msgs::msg::Path & path, const geometry_msgs::msg::Point & point, int & closest,
   double dist_thr);
 
-geometry_msgs::Pose transformRelCoordinate2D(
-  const geometry_msgs::Pose & target, const geometry_msgs::Pose & origin)
+geometry_msgs::msg::Pose transformRelCoordinate2D(
+  const geometry_msgs::msg::Pose & target, const geometry_msgs::msg::Pose & origin)
 {
   // translation
-  geometry_msgs::Point trans_p;
+  geometry_msgs::msg::Point trans_p;
   trans_p.x = target.position.x - origin.position.x;
   trans_p.y = target.position.y - origin.position.y;
 
   // rotation (use inverse matrix of rotation)
   double yaw = tf2::getYaw(origin.orientation);
 
-  geometry_msgs::Pose res;
+  geometry_msgs::msg::Pose res;
   res.position.x = (std::cos(yaw) * trans_p.x) + (std::sin(yaw) * trans_p.y);
   res.position.y = ((-1.0) * std::sin(yaw) * trans_p.x) + (std::cos(yaw) * trans_p.y);
   res.position.z = target.position.z - origin.position.z;
@@ -131,17 +131,17 @@ geometry_msgs::Pose transformRelCoordinate2D(
   return res;
 }
 
-geometry_msgs::Pose transformAbsCoordinate2D(
-  const geometry_msgs::Pose & relative, const geometry_msgs::Pose & origin)
+geometry_msgs::msg::Pose transformAbsCoordinate2D(
+  const geometry_msgs::msg::Pose & relative, const geometry_msgs::msg::Pose & origin)
 {
   // rotation
-  geometry_msgs::Point rot_p;
+  geometry_msgs::msg::Point rot_p;
   double yaw = tf2::getYaw(origin.orientation);
   rot_p.x = (std::cos(yaw) * relative.position.x) + (-std::sin(yaw) * relative.position.y);
   rot_p.y = (std::sin(yaw) * relative.position.x) + (std::cos(yaw) * relative.position.y);
 
   // translation
-  geometry_msgs::Pose absolute;
+  geometry_msgs::msg::Pose absolute;
   absolute.position.x = rot_p.x + origin.position.x;
   absolute.position.y = rot_p.y + origin.position.y;
   absolute.position.z = relative.position.z + origin.position.z;
@@ -159,42 +159,42 @@ double calcJudgeLineDist(
   return judge_line_dist;
 }
 
-autoware_planning_msgs::StopReason initializeStopReason(const std::string & stop_reason)
+autoware_planning_msgs::msg::StopReason initializeStopReason(const std::string & stop_reason)
 {
-  autoware_planning_msgs::StopReason stop_reason_msg;
+  autoware_planning_msgs::msg::StopReason stop_reason_msg;
   stop_reason_msg.reason = stop_reason;
   return stop_reason_msg;
 }
 
 void appendStopReason(
-  const autoware_planning_msgs::StopFactor stop_factor,
-  autoware_planning_msgs::StopReason * stop_reason)
+  const autoware_planning_msgs::msg::StopFactor stop_factor,
+  autoware_planning_msgs::msg::StopReason * stop_reason)
 {
   stop_reason->stop_factors.emplace_back(stop_factor);
 }
 
-std::vector<geometry_msgs::Point> toRosPoints(
-  const autoware_perception_msgs::DynamicObjectArray & object)
+std::vector<geometry_msgs::msg::Point> toRosPoints(
+  const autoware_perception_msgs::msg::DynamicObjectArray & object)
 {
-  std::vector<geometry_msgs::Point> points;
+  std::vector<geometry_msgs::msg::Point> points;
   for (const auto obj : object.objects) {
     points.emplace_back(obj.state.pose_covariance.pose.position);
   }
   return points;
 }
 
-geometry_msgs::Point toRosPoint(const pcl::PointXYZ & pcl_point)
+geometry_msgs::msg::Point toRosPoint(const pcl::PointXYZ & pcl_point)
 {
-  geometry_msgs::Point point;
+  geometry_msgs::msg::Point point;
   point.x = pcl_point.x;
   point.y = pcl_point.y;
   point.z = pcl_point.z;
   return point;
 }
 
-geometry_msgs::Point toRosPoint(const Point2d & boost_point, const double z)
+geometry_msgs::msg::Point toRosPoint(const Point2d & boost_point, const double z)
 {
-  geometry_msgs::Point point;
+  geometry_msgs::msg::Point point;
   point.x = boost_point.x();
   point.y = boost_point.y();
   point.z = z;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/util.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/util.cpp
@@ -71,14 +71,14 @@ bool calcClosestIndex(
 }
 
 template bool calcClosestIndex<autoware_planning_msgs::msg::Trajectory>(
-  const autoware_planning_msgs::msg::Trajectory & path, const geometry_msgs::msg::Pose & pose, int & closest,
-  double dist_thr, double angle_thr);
+  const autoware_planning_msgs::msg::Trajectory & path, const geometry_msgs::msg::Pose & pose,
+  int & closest, double dist_thr, double angle_thr);
 template bool calcClosestIndex<autoware_planning_msgs::msg::PathWithLaneId>(
   const autoware_planning_msgs::msg::PathWithLaneId & path, const geometry_msgs::msg::Pose & pose,
   int & closest, double dist_thr, double angle_thr);
 template bool calcClosestIndex<autoware_planning_msgs::msg::Path>(
-  const autoware_planning_msgs::msg::Path & path, const geometry_msgs::msg::Pose & pose, int & closest,
-  double dist_thr, double angle_thr);
+  const autoware_planning_msgs::msg::Path & path, const geometry_msgs::msg::Pose & pose,
+  int & closest, double dist_thr, double angle_thr);
 
 template <class T>
 bool calcClosestIndex(
@@ -108,8 +108,8 @@ template bool calcClosestIndex<autoware_planning_msgs::msg::PathWithLaneId>(
   const autoware_planning_msgs::msg::PathWithLaneId & path, const geometry_msgs::msg::Point & point,
   int & closest, double dist_thr);
 template bool calcClosestIndex<autoware_planning_msgs::msg::Path>(
-  const autoware_planning_msgs::msg::Path & path, const geometry_msgs::msg::Point & point, int & closest,
-  double dist_thr);
+  const autoware_planning_msgs::msg::Path & path, const geometry_msgs::msg::Point & point,
+  int & closest, double dist_thr);
 
 geometry_msgs::msg::Pose transformRelCoordinate2D(
   const geometry_msgs::msg::Pose & target, const geometry_msgs::msg::Pose & origin)


### PR DESCRIPTION
## Changes
* For logging and time purposes, I gave the `SceneModuleInterface` and `SceneModuleManagerInterface` base classes a logger and a clock, which have to be passed into the child classes' constructors.
* In the debug.cpp files, I could have passed in a clock into each of the free functions, but preferred to set the stamp in `appendMarkerArray`.
* Used VehicleInfo (https://github.com/tier4/Pilot.Auto/pull/58), so that e.g. `planner_data_->base_link2front` was replaced with with `planner_data_->vehicle_info_.max_longitudinal_offset_m`
* One message was not built in `autoware_perception_msgs`, this fixes that
* Added missing dependencies, e.g. `diagnostic_msgs`
* Fixed a few `size_t` to `int` comparison warnings, sometimes by casting, sometimes by changing the loop variable to `size_t`
* Deleted a few unused functions
* "StopLineModule::modifyPathVelocity" and another function had no return statements.
* Tightened the includes in headers a bit – for instance, many `scene.h` files included Eigen, or `unordered_map` and didn't use it at all.

Interesting changes:
* The `waitForTransform` defined in here (not the same as `waitForTransform` in Foxy!) was only used in one place, in `onTrigger()`, to wait for the first `map->base_link` transform to arrive. `onTrigger()` already returns early when certain messages have not yet been received, and I simply did the same when the transform isn't available. 

## Reviewer notes
The first commit only has the boring parts that should not require a thorough review.