### PR TITLE
Port obstacle stop planner

### DIFF
--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/CMakeLists.txt
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/CMakeLists.txt
@@ -1,73 +1,41 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(obstacle_stop_planner)
 
-add_compile_options(-std=c++14 -O3)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -O3)
+  add_compile_options(-Wno-unused-parameter)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  autoware_perception_msgs
-  autoware_planning_msgs
-  roscpp
-  sensor_msgs
-  std_msgs
-  tf2
-  tf2_geometry_msgs
-  tf2_eigen
-  tf2_ros
-  visualization_msgs
-  pcl_ros
-)
-
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED)
-
-catkin_package(
-  INCLUDE_DIRS include
-  CATKIN_DEPENDS
-  autoware_perception_msgs
-    autoware_planning_msgs
-    roscpp
-    sensor_msgs
-    std_msgs
-    tf2
-    tf2_geometry_msgs
-    tf2_eigen
-    tf2_ros
-    visualization_msgs
-    pcl_ros
-)
-
-include_directories(
-  include
-  ${EIGEN3_INCLUDE_DIRS}
-  ${OpenCV_INCLUDE_DIRS}
-  ${catkin_INCLUDE_DIRS}
-)
-
-add_executable(obstacle_stop_planner_node
+find_package(PCL REQUIRED)
+  
+ament_auto_add_executable(obstacle_stop_planner_node
   src/debug_marker.cpp
   src/node.cpp
   src/main.cpp
   src/adaptive_cruise_control.cpp
 )
-add_dependencies(obstacle_stop_planner_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+target_include_directories(obstacle_stop_planner_node
+  PUBLIC
+    ${OpenCV_INCLUDE_DIRS}
+    ${PCL_INCLUDE_DIRS}
+)
 
 target_link_libraries(obstacle_stop_planner_node
-  ${catkin_LIBRARIES}
-  ${OpenCV_LIBS}
+    ${OpenCV_LIBRARIES}
+    ${PCL_LIBRARIES}
 )
 
-install(
-  TARGETS
-    obstacle_stop_planner_node
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-install(
-  DIRECTORY
-    launch
-    config
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+ament_auto_package(
+  INSTALL_TO_SHARE
+  config
+  launch
 )

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/config/adaptive_cruise_control.yaml
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/config/adaptive_cruise_control.yaml
@@ -1,32 +1,34 @@
-# Adaptive Cruise Control (ACC) config
-use_object_to_estimate_vel: true # use tracking objects for estimating object velocity or not
-use_pcl_to_estimate_vel: true # use pcl for estimating object velocity or not
-consider_obj_velocity: true # consider forward vehicle velocity to ACC or not
+/**:
+  ros__parameters:
+    # Adaptive Cruise Control (ACC) config
+    use_object_to_estimate_vel: true # use tracking objects for estimating object velocity or not
+    use_pcl_to_estimate_vel: true # use pcl for estimating object velocity or not
+    consider_obj_velocity: true # consider forward vehicle velocity to ACC or not
 
-# general parameter for ACC
-obstacle_stop_velocity_thresh: 1.0 # threshold of forward obstacle velocity to insert stop line (to stop acc) [m/s]
-emergency_stop_acceleration: -5.0 # supposed minimum acceleration (deceleration) in emergency stop [m/ss]
-emergency_stop_idling_time: 0.5 # supposed idling time to start emergency stop [s]
-min_dist_stop: 4.0 # minimum distance of emergency stop [m]
-max_standard_acceleration: 0.5 # supposed maximum acceleration in active cruise control [m/ss]
-min_standard_acceleration: -1.0 # supposed minimum acceleration (deceleration) in active cruise control
-standard_idling_time: 0.5 # supposed idling time to react object in active cruise control [s]
-min_dist_standard: 4.0 # minimum distance in active cruise control [m]
-obstacle_min_standard_acceleration: -1.5 # supposed minimum acceleration of forward obstacle [m/ss]
-margin_rate_to_change_vel: 0.3 # margin to insert upper velocity [-]
+    # general parameter for ACC
+    obstacle_stop_velocity_thresh: 1.0 # threshold of forward obstacle velocity to insert stop line (to stop acc) [m/s]
+    emergency_stop_acceleration: -5.0 # supposed minimum acceleration (deceleration) in emergency stop [m/ss]
+    emergency_stop_idling_time: 0.5 # supposed idling time to start emergency stop [s]
+    min_dist_stop: 4.0 # minimum distance of emergency stop [m]
+    max_standard_acceleration: 0.5 # supposed maximum acceleration in active cruise control [m/ss]
+    min_standard_acceleration: -1.0 # supposed minimum acceleration (deceleration) in active cruise control
+    standard_idling_time: 0.5 # supposed idling time to react object in active cruise control [s]
+    min_dist_standard: 4.0 # minimum distance in active cruise control [m]
+    obstacle_min_standard_acceleration: -1.5 # supposed minimum acceleration of forward obstacle [m/ss]
+    margin_rate_to_change_vel: 0.3 # margin to insert upper velocity [-]
 
-# pid parameter for ACC
-p_coefficient_positive: 0.1 # coefficient P in PID control (used when target dist -current_dist >=0) [-]
-p_coefficient_negative: 0.3 # coefficient P in PID control (used when target dist -current_dist <0) [-]
-d_coefficient_positive: 0.0 # coefficient D in PID control (used when delta_dist >=0) [-]
-d_coefficient_negative: 0.2 # coefficient D in PID control (used when delta_dist <0) [-]
+    # pid parameter for ACC
+    p_coefficient_positive: 0.1 # coefficient P in PID control (used when target dist -current_dist >=0) [-]
+    p_coefficient_negative: 0.3 # coefficient P in PID control (used when target dist -current_dist <0) [-]
+    d_coefficient_positive: 0.0 # coefficient D in PID control (used when delta_dist >=0) [-]
+    d_coefficient_negative: 0.2 # coefficient D in PID control (used when delta_dist <0) [-]
 
-# parameter for object velocity estimation
-obect_polygon_length_margin: 2.0 # The distance to extend the polygon length the object in pointcloud-object matching [m]
-obect_polygon_width_margin: 0.5 # The distance to extend the polygon width the object in pointcloud-object matching [m]
-valid_estimated_vel_diff_time: 1.0 # Maximum time difference treated as continuous points in speed estimation using a point cloud [s]
-valid_vel_que_time: 0.5 # Time width of information used for speed estimation in speed estimation using a point cloud [s]
-valid_estimated_vel_max: 20.0 # Maximum value of valid speed estimation results in speed estimation using a point cloud [m/s]
-valid_estimated_vel_min: -20.0 # Minimum value of valid speed estimation results in speed estimation using a point cloud [m/s]
-thresh_vel_to_stop: 1.5 # Embed a stop line if the maximum speed calculated by ACC is lowar than this speed [m/s]
-lowpass_gain_of_upper_velocity: 0.75 #Lowpass-gain of upper velocity
+    # parameter for object velocity estimation
+    obect_polygon_length_margin: 2.0 # The distance to extend the polygon length the object in pointcloud-object matching [m]
+    obect_polygon_width_margin: 0.5 # The distance to extend the polygon width the object in pointcloud-object matching [m]
+    valid_estimated_vel_diff_time: 1.0 # Maximum time difference treated as continuous points in speed estimation using a point cloud [s]
+    valid_vel_que_time: 0.5 # Time width of information used for speed estimation in speed estimation using a point cloud [s]
+    valid_estimated_vel_max: 20.0 # Maximum value of valid speed estimation results in speed estimation using a point cloud [m/s]
+    valid_estimated_vel_min: -20.0 # Minimum value of valid speed estimation results in speed estimation using a point cloud [m/s]
+    thresh_vel_to_stop: 1.5 # Embed a stop line if the maximum speed calculated by ACC is lowar than this speed [m/s]
+    lowpass_gain_of_upper_velocity: 0.75 #Lowpass-gain of upper velocity

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/config/obstacle_stop_planner.yaml
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/config/obstacle_stop_planner.yaml
@@ -1,11 +1,13 @@
-# stop planner
-stop_margin: 5.0 # stop margin distance from obstacle on the path [m]
-min_behavior_stop_margin: 2.0 # stop margin distance when any other stop point is inserted in stop margin [m]
-step_length: 1.0 # step length for pointcloud search range [m]
+/**:
+  ros__parameters:
+    # stop planner
+    stop_margin: 5.0 # stop margin distance from obstacle on the path [m]
+    min_behavior_stop_margin: 2.0 # stop margin distance when any other stop point is inserted in stop margin [m]
+    step_length: 1.0 # step length for pointcloud search range [m]
 
-# slow down planner
-slow_down_margin: 5.0 # margin distance from slow down point [m]
-expand_slow_down_range: 1.0 # offset from vehicle side edge for expanding the search area of the surrounding point cloud [m]
-max_slow_down_vel: 4.0 # max slow down velocity [m/s]
-min_slow_down_vel: 0.84 # min slow down velocity [m/s]
-max_deceleration: 2.0 # max slow down deceleration [m/s2]
+    # slow down planner
+    slow_down_margin: 5.0 # margin distance from slow down point [m]
+    expand_slow_down_range: 1.0 # offset from vehicle side edge for expanding the search area of the surrounding point cloud [m]
+    max_slow_down_vel: 4.0 # max slow down velocity [m/s]
+    min_slow_down_vel: 0.84 # min slow down velocity [m/s]
+    max_deceleration: 2.0 # max slow down deceleration [m/s2]

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/include/obstacle_stop_planner/adaptive_cruise_control.hpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/include/obstacle_stop_planner/adaptive_cruise_control.hpp
@@ -22,7 +22,7 @@
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <rclcpp/rclcpp.hpp>
-#include <std_msgs/msg/float32_multi_array.hpp>
+#include <autoware_debug_msgs/msg/float32_multi_array_stamped.hpp>
 #include <tf2/utils.h>
 
 #include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
@@ -46,7 +46,7 @@ public:
     autoware_planning_msgs::msg::Trajectory * output_trajectory);
 
 private:
-  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr pub_debug_;
+  rclcpp::Publisher<autoware_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr pub_debug_;
 
   /*
    * Parameter
@@ -181,7 +181,7 @@ private:
   void registerQueToVelocity(const double vel, const rclcpp::Time & vel_time);
 
   /* Debug */
-  mutable std_msgs::msg::Float32MultiArray debug_values_;
+  mutable autoware_debug_msgs::msg::Float32MultiArrayStamped debug_values_;
   enum DBGVAL {
     ESTIMATED_VEL_PCL = 0,
     ESTIMATED_VEL_OBJ = 1,

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/include/obstacle_stop_planner/adaptive_cruise_control.hpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/include/obstacle_stop_planner/adaptive_cruise_control.hpp
@@ -18,21 +18,19 @@
 
 #include <vector>
 
-#include <geometry_msgs/TwistStamped.h>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <pcl_ros/point_cloud.h>
-#include <pcl_ros/transforms.h>
-#include <ros/ros.h>
-#include <std_msgs/Float32MultiArray.h>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/float32_multi_array.hpp>
 #include <tf2/utils.h>
 
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <autoware_planning_msgs/Trajectory.h>
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
 
 namespace motion_planning
 {
-class AdaptiveCruiseController
+class AdaptiveCruiseController : public rclcpp::Node
 {
 public:
   AdaptiveCruiseController(
@@ -40,17 +38,15 @@ public:
     const double front_overhang);
 
   void insertAdaptiveCruiseVelocity(
-    const autoware_planning_msgs::Trajectory & trajectory, const int nearest_collision_point_idx,
-    const geometry_msgs::Pose self_pose, const pcl::PointXYZ & nearest_collision_point,
-    const ros::Time nearest_collision_point_time,
-    const autoware_perception_msgs::DynamicObjectArray::ConstPtr object_ptr,
-    const geometry_msgs::TwistStamped::ConstPtr current_velocity_ptr, bool * need_to_stop,
-    autoware_planning_msgs::Trajectory * output_trajectory);
+    const autoware_planning_msgs::msg::Trajectory & trajectory, const int nearest_collision_point_idx,
+    const geometry_msgs::msg::Pose self_pose, const pcl::PointXYZ & nearest_collision_point,
+    const rclcpp::Time nearest_collision_point_time,
+    const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr object_ptr,
+    const geometry_msgs::msg::TwistStamped::ConstPtr current_velocity_ptr, bool * need_to_stop,
+    autoware_planning_msgs::msg::Trajectory * output_trajectory);
 
 private:
-  ros::NodeHandle nh_;
-  ros::NodeHandle pnh_;
-  ros::Publisher pub_debug_;
+  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr pub_debug_;
 
   /*
    * Parameter
@@ -60,12 +56,12 @@ private:
   double wheel_base_;
   double front_overhang_;
 
-  ros::Time prev_collsion_point_time_;
+  rclcpp::Time prev_collsion_point_time_;
   pcl::PointXYZ prev_collsion_point_;
   double prev_target_vehicle_time_ = 0.0;
   double prev_target_vehicle_dist_ = 0.0;
   bool prev_collsion_point_valid_ = false;
-  std::vector<geometry_msgs::TwistStamped> est_vel_que_;
+  std::vector<geometry_msgs::msg::TwistStamped> est_vel_que_;
   double prev_upper_velocity_ = 0.0;
 
   struct Param
@@ -156,20 +152,20 @@ private:
   };
   Param param_;
 
-  double getMedianVel(const std::vector<geometry_msgs::TwistStamped> vel_que);
+  double getMedianVel(const std::vector<geometry_msgs::msg::TwistStamped> vel_que);
   double lowpass_filter(const double current_value, const double prev_value, const double gain);
   void calcDistanceToNearestPointOnPath(
-    const autoware_planning_msgs::Trajectory & trajectory, const int nearest_point_idx,
-    const geometry_msgs::Pose & self_pose, const pcl::PointXYZ & nearest_collision_point,
+    const autoware_planning_msgs::msg::Trajectory & trajectory, const int nearest_point_idx,
+    const geometry_msgs::msg::Pose & self_pose, const pcl::PointXYZ & nearest_collision_point,
     double * distance);
   double calcTrajYaw(
-    const autoware_planning_msgs::Trajectory & trajectory, const int collsion_point_idx);
+    const autoware_planning_msgs::msg::Trajectory & trajectory, const int collsion_point_idx);
   bool estimatePointVelocityFromObject(
-    const autoware_perception_msgs::DynamicObjectArray::ConstPtr object_ptr, const double traj_yaw,
+    const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr object_ptr, const double traj_yaw,
     const pcl::PointXYZ & nearest_collision_point, double * velocity);
   bool estimatePointVelocityFromPcl(
     const double traj_yaw, const pcl::PointXYZ & nearest_collision_point,
-    const ros::Time & nearest_collision_point_time, double * velocity);
+    const rclcpp::Time & nearest_collision_point_time, double * velocity);
   double calcUpperVelocity(const double dist_to_col, const double obj_vel, const double self_vel);
   double calcThreshDistToForwardObstacle(const double current_vel, const double obj_vel);
   double calcBaseDistToForwardObstacle(const double current_vel, const double obj_vel);
@@ -181,11 +177,11 @@ private:
 
   void insertMaxVelocityToPath(
     const double current_vel, const double target_vel, const double dist_to_collsion_point,
-    autoware_planning_msgs::Trajectory * output_trajectory);
-  void registerQueToVelocity(const double vel, const ros::Time & vel_time);
+    autoware_planning_msgs::msg::Trajectory * output_trajectory);
+  void registerQueToVelocity(const double vel, const rclcpp::Time & vel_time);
 
   /* Debug */
-  mutable std_msgs::Float32MultiArray debug_values_;
+  mutable std_msgs::msg::Float32MultiArray debug_values_;
   enum DBGVAL {
     ESTIMATED_VEL_PCL = 0,
     ESTIMATED_VEL_OBJ = 1,

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/include/obstacle_stop_planner/debug_marker.hpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/include/obstacle_stop_planner/debug_marker.hpp
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 #pragma once
-#include <autoware_planning_msgs/StopReasonArray.h>
-#include <geometry_msgs/Point.h>
-#include <geometry_msgs/Pose.h>
+#include <autoware_planning_msgs/msg/stop_reason_array.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
 #include <pcl/point_types.h>
-#include <ros/ros.h>
-#include <visualization_msgs/Marker.h>
-#include <visualization_msgs/MarkerArray.h>
+#include <rclcpp/rclcpp.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 #include <memory>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <string>
 #define EIGEN_MPL2_ONLY
-#include <Eigen/Core>
-#include <Eigen/Geometry>
+#include <eigen3/Eigen/Core>
+#include <eigen3/Eigen/Geometry>
 namespace motion_planning
 {
 enum class PolygonType : int8_t { Vehicle = 0, Collision, SlowDownRange, SlowDown };
@@ -37,7 +37,7 @@ enum class PointType : int8_t { Stop = 0, SlowDown };
 
 enum class PoseType : int8_t { Stop = 0, SlowDownStart, SlowDownEnd };
 
-class ObstacleStopPlannerDebugNode
+class ObstacleStopPlannerDebugNode : public rclcpp::Node
 {
 public:
   ObstacleStopPlannerDebugNode(const double base_link2front);
@@ -45,26 +45,24 @@ public:
   bool pushPolygon(
     const std::vector<cv::Point2d> & polygon, const double z, const PolygonType & type);
   bool pushPolygon(const std::vector<Eigen::Vector3d> & polygon, const PolygonType & type);
-  bool pushPose(const geometry_msgs::Pose & pose, const PoseType & type);
-  bool pushObstaclePoint(const geometry_msgs::Point & obstacle_point, const PointType & type);
+  bool pushPose(const geometry_msgs::msg::Pose & pose, const PoseType & type);
+  bool pushObstaclePoint(const geometry_msgs::msg::Point & obstacle_point, const PointType & type);
   bool pushObstaclePoint(const pcl::PointXYZ & obstacle_point, const PointType & type);
-  visualization_msgs::MarkerArray makeVisualizationMarker();
-  autoware_planning_msgs::StopReasonArray makeStopReasonArray();
+  visualization_msgs::msg::MarkerArray makeVisualizationMarker();
+  autoware_planning_msgs::msg::StopReasonArray makeStopReasonArray();
 
   void publish();
 
 private:
-  ros::NodeHandle nh_;
-  ros::NodeHandle pnh_;
-  ros::Publisher debug_viz_pub_;
-  ros::Publisher stop_reason_pub_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
+  rclcpp::Publisher<autoware_planning_msgs::msg::StopReasonArray>::SharedPtr stop_reason_pub_;
   double base_link2front_;
 
-  std::shared_ptr<geometry_msgs::Pose> stop_pose_ptr_;
-  std::shared_ptr<geometry_msgs::Pose> slow_down_start_pose_ptr_;
-  std::shared_ptr<geometry_msgs::Pose> slow_down_end_pose_ptr_;
-  std::shared_ptr<geometry_msgs::Point> stop_obstacle_point_ptr_;
-  std::shared_ptr<geometry_msgs::Point> slow_down_obstacle_point_ptr_;
+  std::shared_ptr<geometry_msgs::msg::Pose> stop_pose_ptr_;
+  std::shared_ptr<geometry_msgs::msg::Pose> slow_down_start_pose_ptr_;
+  std::shared_ptr<geometry_msgs::msg::Pose> slow_down_end_pose_ptr_;
+  std::shared_ptr<geometry_msgs::msg::Point> stop_obstacle_point_ptr_;
+  std::shared_ptr<geometry_msgs::msg::Point> slow_down_obstacle_point_ptr_;
   std::vector<std::vector<Eigen::Vector3d>> vehicle_polygons_;
   std::vector<std::vector<Eigen::Vector3d>> slow_down_range_polygons_;
   std::vector<std::vector<Eigen::Vector3d>> collision_polygons_;

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -15,17 +15,22 @@
  */
 #pragma once
 
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <autoware_planning_msgs/Trajectory.h>
-#include <geometry_msgs/TwistStamped.h>
+#include<memory>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <pcl_ros/point_cloud.h>
-#include <pcl_ros/transforms.h>
-#include <ros/ros.h>
-#include <sensor_msgs/PointCloud2.h>
+#include <pcl/point_cloud.h>
+#include <pcl/common/transforms.h>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <tf2/utils.h>
 #include <tf2_ros/transform_listener.h>
-#include <visualization_msgs/MarkerArray.h>
+#include <visualization_msgs/msg/marker_array.hpp>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
@@ -34,7 +39,7 @@
 
 namespace motion_planning
 {
-class ObstacleStopPlannerNode
+class ObstacleStopPlannerNode : public rclcpp::Node
 {
 public:
   ObstacleStopPlannerNode();
@@ -44,14 +49,14 @@ private:
    * ROS
    */
   // publisher and subscriber
-  ros::NodeHandle nh_;
-  ros::NodeHandle pnh_;
-  ros::Subscriber path_sub_;
-  ros::Subscriber obstacle_pointcloud_sub_;
-  ros::Subscriber current_velocity_sub_;
-  ros::Subscriber dynamic_object_sub_;
-  ros::Publisher path_pub_;
-  ros::Publisher stop_reason_diag_pub_;
+  rclcpp::Subscription<autoware_planning_msgs::msg::Trajectory>::SharedPtr path_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr obstacle_pointcloud_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr current_velocity_sub_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::DynamicObjectArray>::SharedPtr dynamic_object_sub_;
+
+  rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr path_pub_;
+  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticStatus>::SharedPtr stop_reason_diag_pub_;
+
   std::shared_ptr<ObstacleStopPlannerDebugNode> debug_ptr_;
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
@@ -60,15 +65,15 @@ private:
    * Parameter
    */
   std::unique_ptr<motion_planning::AdaptiveCruiseController> acc_controller_;
-  sensor_msgs::PointCloud2::Ptr obstacle_ros_pointcloud_ptr_;
-  geometry_msgs::TwistStamped::ConstPtr current_velocity_ptr_;
-  autoware_perception_msgs::DynamicObjectArray::ConstPtr object_ptr_;
+  sensor_msgs::msg::PointCloud2::Ptr obstacle_ros_pointcloud_ptr_;
+  geometry_msgs::msg::TwistStamped::ConstPtr current_velocity_ptr_;
+  autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr object_ptr_;
   double wheel_base_, front_overhang_, rear_overhang_, left_overhang_, right_overhang_,
     vehicle_width_, vehicle_length_;
   double stop_margin_;
   double slow_down_margin_;
   double min_behavior_stop_margin_;
-  ros::Time prev_col_point_time_;
+  rclcpp::Time prev_col_point_time_;
   pcl::PointXYZ prev_col_point_;
   double expand_slow_down_range_;
   double max_slow_down_vel_;
@@ -78,49 +83,49 @@ private:
   double step_length_;
   double stop_search_radius_;
   double slow_down_search_radius_;
-  void obstaclePointcloudCallback(const sensor_msgs::PointCloud2::ConstPtr & input_msg);
-  void pathCallback(const autoware_planning_msgs::Trajectory::ConstPtr & input_msg);
+  void obstaclePointcloudCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr input_msg);
+  void pathCallback(const autoware_planning_msgs::msg::Trajectory::ConstSharedPtr input_msg);
   void dynamicObjectCallback(
-    const autoware_perception_msgs::DynamicObjectArray::ConstPtr & input_msg);
-  void currentVelocityCallback(const geometry_msgs::TwistStamped::ConstPtr & input_msg);
+    const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr input_msg);
+  void currentVelocityCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr input_msg);
 
 private:
   bool convexHull(
     const std::vector<cv::Point2d> pointcloud, std::vector<cv::Point2d> & polygon_points);
   bool decimateTrajectory(
-    const autoware_planning_msgs::Trajectory & input_trajectory, const double step_length,
-    autoware_planning_msgs::Trajectory & output_trajectory);
+    const autoware_planning_msgs::msg::Trajectory & input_trajectory, const double step_length,
+    autoware_planning_msgs::msg::Trajectory & output_trajectory);
   bool decimateTrajectory(
-    const autoware_planning_msgs::Trajectory & input_trajectory, const double step_length,
-    autoware_planning_msgs::Trajectory & output_trajectory,
+    const autoware_planning_msgs::msg::Trajectory & input_trajectory, const double step_length,
+    autoware_planning_msgs::msg::Trajectory & output_trajectory,
     std::map<size_t /* decimate */, size_t /* origin */> & index_map);
   bool trimTrajectoryFromSelfPose(
-    const autoware_planning_msgs::Trajectory & input_trajectory,
-    const geometry_msgs::Pose self_pose, autoware_planning_msgs::Trajectory & output_trajectory);
+    const autoware_planning_msgs::msg::Trajectory & input_trajectory,
+    const geometry_msgs::msg::Pose self_pose, autoware_planning_msgs::msg::Trajectory & output_trajectory);
   bool trimTrajectoryWithIndexFromSelfPose(
-    const autoware_planning_msgs::Trajectory & input_trajectory,
-    const geometry_msgs::Pose self_pose, autoware_planning_msgs::Trajectory & output_trajectory,
+    const autoware_planning_msgs::msg::Trajectory & input_trajectory,
+    const geometry_msgs::msg::Pose self_pose, autoware_planning_msgs::msg::Trajectory & output_trajectory,
     size_t & index);
   bool searchPointcloudNearTrajectory(
-    const autoware_planning_msgs::Trajectory & trajectory, const double radius,
+    const autoware_planning_msgs::msg::Trajectory & trajectory, const double radius,
     const pcl::PointCloud<pcl::PointXYZ>::Ptr input_pointcloud_ptr,
     pcl::PointCloud<pcl::PointXYZ>::Ptr output_pointcloud_ptr);
   void createOneStepPolygon(
-    const geometry_msgs::Pose base_stap_pose, const geometry_msgs::Pose next_step_pose,
+    const geometry_msgs::msg::Pose base_stap_pose, const geometry_msgs::msg::Pose next_step_pose,
     std::vector<cv::Point2d> & polygon, const double expand_width = 0.0);
   bool getSelfPose(
-    const std_msgs::Header & header, const tf2_ros::Buffer & tf_buffer,
-    geometry_msgs::Pose & self_pose);
+    const std_msgs::msg::Header & header, const tf2_ros::Buffer & tf_buffer,
+    geometry_msgs::msg::Pose & self_pose);
   bool getBackwordPointFromBasePoint(
     const Eigen::Vector2d & line_point1, const Eigen::Vector2d & line_point2,
     const Eigen::Vector2d & base_point, const double backward_length,
     Eigen::Vector2d & output_point);
   void getNearestPoint(
-    const pcl::PointCloud<pcl::PointXYZ> & pointcloud, const geometry_msgs::Pose & base_pose,
-    pcl::PointXYZ * nearest_collision_point, ros::Time * nearest_collision_point_time);
+    const pcl::PointCloud<pcl::PointXYZ> & pointcloud, const geometry_msgs::msg::Pose & base_pose,
+    pcl::PointXYZ * nearest_collision_point, rclcpp::Time * nearest_collision_point_time);
   void getLateralNearestPoint(
-    const pcl::PointCloud<pcl::PointXYZ> & pointcloud, const geometry_msgs::Pose & base_pose,
+    const pcl::PointCloud<pcl::PointXYZ> & pointcloud, const geometry_msgs::msg::Pose & base_pose,
     pcl::PointXYZ * lateral_nearest_point, double * deviation);
-  geometry_msgs::Pose getVehicleCenterFromBase(const geometry_msgs::Pose & base_pose);
+  geometry_msgs::msg::Pose getVehicleCenterFromBase(const geometry_msgs::msg::Pose & base_pose);
 };
 }  // namespace motion_planning

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/launch/obstacle_stop_planner.launch.xml
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/launch/obstacle_stop_planner.launch.xml
@@ -2,16 +2,16 @@
   <arg name="input_objects" default="/perception/object_recognition/objects" />
   <arg name="input_twist" default="/localization/twist" />
   <arg name="enable_slow_down" default="false" />
-  <arg name="param_file" default="$(find obstacle_stop_planner)/config/obstacle_stop_planner.yaml" />
+  <arg name="param_file" default="$(find-pkg-share obstacle_stop_planner)/config/obstacle_stop_planner.yaml" />
 
-  <node pkg="obstacle_stop_planner" type="obstacle_stop_planner_node" name="obstacle_stop_planner" output="screen">
-    <rosparam command="load" file="$(find obstacle_stop_planner)/config/adaptive_cruise_control.yaml" />
-    <rosparam command="load" file="$(arg param_file)" />
-    <remap from="~output/stop_reason" to="/planning/scenario_planning/status/stop_reason" />
-    <remap from="~output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons" />
-    <remap from="~input/objects" to="$(arg input_objects)" />
-    <remap from="~input/twist" to="$(arg input_twist)" />
-    <param name="enable_slow_down" value="$(arg enable_slow_down)" />
+  <node pkg="obstacle_stop_planner" exec="obstacle_stop_planner_node" name="obstacle_stop_planner" output="screen">
+    <param from="$(find-pkg-share obstacle_stop_planner)/config/adaptive_cruise_control.yaml" />
+    <param from="$(var param_file)" />
+    <remap from="output/stop_reason" to="/planning/scenario_planning/status/stop_reason" />
+    <remap from="output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons" />
+    <remap from="input/objects" to="$(var input_objects)" />
+    <remap from="input/twist" to="$(var input_twist)" />
+    <param name="enable_slow_down" value="$(var enable_slow_down)" />
   </node>
 
 </launch>

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/package.xml
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/package.xml
@@ -4,89 +4,27 @@
   <version>0.1.0</version>
   <description>The obstacle_stop_planner package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="tier4@todo.todo">tier4</maintainer>
 
+  <license>Apache 2.0</license>
 
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rclcpp</depend>
+  <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>pcl_conversions</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_eigen</depend>
+  <depend>tf2_ros</depend>
+  <depend>visualization_msgs</depend>
 
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/obstacle_stop_planner</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>autoware_perception_msgs</build_depend>
-  <build_depend>autoware_planning_msgs</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>tf2</build_depend>
-  <build_depend>tf2_geometry_msgs</build_depend>
-  <build_depend>tf2_eigen</build_depend>
-  <build_depend>tf2_ros</build_depend>
-  <build_depend>visualization_msgs</build_depend>
-  <build_depend>pcl_ros</build_depend>
-  <build_export_depend>autoware_perception_msgs</build_export_depend>
-  <build_export_depend>autoware_planning_msgs</build_export_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>sensor_msgs</build_export_depend>
-  <build_export_depend>std_msgs</build_export_depend>
-  <build_export_depend>tf2</build_export_depend>
-  <build_export_depend>tf2_geometry_msgs</build_export_depend>
-  <build_export_depend>tf2_eigen</build_export_depend>
-  <build_export_depend>tf2_ros</build_export_depend>
-  <build_export_depend>visualization_msgs</build_export_depend>
-  <build_export_depend>pcl_ros</build_export_depend>
-  <exec_depend>autoware_perception_msgs</exec_depend>
-  <exec_depend>autoware_planning_msgs</exec_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>tf2</exec_depend>
-  <exec_depend>tf2_geometry_msgs</exec_depend>
-  <exec_depend>tf2_eigen</exec_depend>
-  <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>visualization_msgs</exec_depend>
-  <exec_depend>pcl_ros</exec_depend>
-
-
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- Other tools can request additional information be placed here -->
-
+    <build_type>ament_cmake</build_type>
   </export>
+
 </package>

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/package.xml
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
+  <depend>autoware_debug_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>diagnostic_msgs</depend>

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
@@ -31,19 +31,19 @@ using Line = bg::model::linestring<Point>;
 
 namespace
 {
-Point convertPointRosToBoost(const geometry_msgs::Point & point)
+Point convertPointRosToBoost(const geometry_msgs::msg::Point & point)
 {
   const Point point2d(point.x, point.y);
   return point2d;
 }
 
-geometry_msgs::Vector3 rpyFromQuat(const geometry_msgs::Quaternion & q)
+geometry_msgs::msg::Vector3 rpyFromQuat(const geometry_msgs::msg::Quaternion & q)
 {
   tf2::Quaternion quat(q.x, q.y, q.z, q.w);
   tf2::Matrix3x3 mat(quat);
   double roll, pitch, yaw;
   mat.getRPY(roll, pitch, yaw);
-  geometry_msgs::Vector3 rpy;
+  geometry_msgs::msg::Vector3 rpy;
   rpy.x = roll;
   rpy.y = pitch;
   rpy.z = yaw;
@@ -51,11 +51,11 @@ geometry_msgs::Vector3 rpyFromQuat(const geometry_msgs::Quaternion & q)
 }
 
 Polygon getPolygon(
-  const geometry_msgs::Pose & pose, const geometry_msgs::Vector3 & size, const double center_offset,
+  const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Vector3 & size, const double center_offset,
   const double l_margin = 0.0, const double w_margin = 0.0)
 {
   Polygon obj_poly;
-  geometry_msgs::Vector3 obj_rpy = rpyFromQuat(pose.orientation);
+  geometry_msgs::msg::Vector3 obj_rpy = rpyFromQuat(pose.orientation);
 
   double l = size.x * std::cos(obj_rpy.y) + l_margin;
   double w = size.y * std::cos(obj_rpy.x) + w_margin;
@@ -77,7 +77,7 @@ Polygon getPolygon(
 }
 
 double getDistanceFromTwoPoint(
-  const geometry_msgs::Point & point1, const geometry_msgs::Point & point2)
+  const geometry_msgs::msg::Point & point1, const geometry_msgs::msg::Point & point2)
 {
   const double dx = point1.x - point2.x;
   const double dy = point1.y - point2.y;
@@ -106,38 +106,14 @@ constexpr double sign(const double value)
     return 0.0;
   }
 }
-
-template <class T>
-T getParam(const ros::NodeHandle & nh, const std::string & key, const T & default_value)
-{
-  T value;
-  nh.param<T>(key, value, default_value);
-  return value;
-}
-template <class T>
-T waitForParam(const ros::NodeHandle & nh, const std::string & key)
-{
-  T value;
-  ros::Rate rate(1.0);
-  while (ros::ok()) {
-    const auto result = nh.getParam(key, value);
-    if (result) {
-      return value;
-    }
-    ROS_WARN("waiting for parameter `%s` ...", key.c_str());
-    rate.sleep();
-  }
-}
-
-}  // namespace
+} //namespace
 
 namespace motion_planning
 {
 AdaptiveCruiseController::AdaptiveCruiseController(
   const double vehicle_width, const double vehicle_length, const double wheel_base,
   const double front_overhang)
-: nh_(),
-  pnh_("~"),
+: Node("adaptive_cruise_controller"),
   vehicle_width_(vehicle_width),
   vehicle_length_(vehicle_length),
   wheel_base_(wheel_base),
@@ -147,52 +123,52 @@ AdaptiveCruiseController::AdaptiveCruiseController(
 
   /* config */
   param_.min_behavior_stop_margin =
-    getParam<double>(pnh_, "min_behavior_stop_margin", 2.0) + wheel_base_ + front_overhang_;
-  param_.use_object_to_est_vel = getParam<bool>(pnh_, "use_object_to_estimate_vel", true);
-  param_.use_pcl_to_est_vel = getParam<bool>(pnh_, "use_pcl_to_estimate_vel", true);
-  param_.consider_obj_velocity = getParam<bool>(pnh_, "consider_obj_velocity", true);
+    declare_parameter("min_behavior_stop_margin", 2.0) + wheel_base_ + front_overhang_;
+  param_.use_object_to_est_vel = declare_parameter("use_object_to_estimate_vel", true);
+  param_.use_pcl_to_est_vel = declare_parameter("use_pcl_to_estimate_vel", true);
+  param_.consider_obj_velocity = declare_parameter("consider_obj_velocity", true);
 
   /* paramter for acc */
   param_.obstacle_stop_velocity_thresh =
-    getParam<double>(pnh_, "obstacle_stop_velocity_thresh", 1.0);
-  param_.emergency_stop_acceleration = getParam<double>(pnh_, "emergency_stop_acceleration", -5.0);
-  param_.emergency_stop_idling_time = getParam<double>(pnh_, "emergency_stop_idling_time", 0.5);
-  param_.min_dist_stop = getParam<double>(pnh_, "min_dist_stop", 4.0);
-  param_.max_standard_acceleration = getParam<double>(pnh_, "max_standard_acceleration", 0.5);
-  param_.min_standard_acceleration = getParam<double>(pnh_, "min_standard_acceleration", -1.0);
-  param_.standard_idling_time = getParam<double>(pnh_, "standard_idling_time", 0.5);
-  param_.min_dist_standard = getParam<double>(pnh_, "min_dist_standard", 4.0);
+    declare_parameter("obstacle_stop_velocity_thresh", 1.0);
+  param_.emergency_stop_acceleration = declare_parameter("emergency_stop_acceleration", -5.0);
+  param_.emergency_stop_idling_time = declare_parameter("emergency_stop_idling_time", 0.5);
+  param_.min_dist_stop = declare_parameter("min_dist_stop", 4.0);
+  param_.max_standard_acceleration = declare_parameter("max_standard_acceleration", 0.5);
+  param_.min_standard_acceleration = declare_parameter("min_standard_acceleration", -1.0);
+  param_.standard_idling_time = declare_parameter("standard_idling_time", 0.5);
+  param_.min_dist_standard = declare_parameter("min_dist_standard", 4.0);
   param_.obstacle_min_standard_acceleration =
-    getParam<double>(pnh_, "obstacle_min_standard_acceleration", -1.5);
-  param_.margin_rate_to_change_vel = getParam<double>(pnh_, "margin_rate_to_change_vel", 0.3);
-  param_.lowpass_gain_ = getParam<double>(pnh_, "lowpass_gain_of_upper_velocity", 0.6);
+    declare_parameter("obstacle_min_standard_acceleration", -1.5);
+  param_.margin_rate_to_change_vel = declare_parameter("margin_rate_to_change_vel", 0.3);
+  param_.lowpass_gain_ = declare_parameter("lowpass_gain_of_upper_velocity", 0.6);
 
   /* parameter for pid in acc */
-  param_.p_coeff_pos = getParam<double>(pnh_, "p_coefficient_positive", 0.1);
-  param_.p_coeff_neg = getParam<double>(pnh_, "p_coefficient_negative", 0.3);
-  param_.d_coeff_pos = getParam<double>(pnh_, "d_coefficient_positive", 0.0);
-  param_.d_coeff_neg = getParam<double>(pnh_, "d_coefficient_negative", 0.1);
+  param_.p_coeff_pos = declare_parameter("p_coefficient_positive", 0.1);
+  param_.p_coeff_neg = declare_parameter("p_coefficient_negative", 0.3);
+  param_.d_coeff_pos = declare_parameter("d_coefficient_positive", 0.0);
+  param_.d_coeff_neg = declare_parameter("d_coefficient_negative", 0.1);
 
   /* parameter for speed estimation of obstacle */
-  param_.object_polygon_length_margin = getParam<double>(pnh_, "obect_polygon_length_margin", 2.0);
-  param_.object_polygon_width_margin = getParam<double>(pnh_, "obect_polygon_width_margin", 0.5);
-  param_.valid_est_vel_diff_time = getParam<double>(pnh_, "valid_estimated_vel_diff_time", 1.0);
-  param_.valid_vel_que_time = getParam<double>(pnh_, "valid_vel_que_time", 0.5);
-  param_.valid_est_vel_max = getParam<double>(pnh_, "valid_estimated_vel_max", 20.0);
-  param_.valid_est_vel_min = getParam<double>(pnh_, "valid_estimated_vel_min", -20.0);
-  param_.thresh_vel_to_stop = getParam<double>(pnh_, "thresh_vel_to_stop", 0.5);
+  param_.object_polygon_length_margin = declare_parameter("obect_polygon_length_margin", 2.0);
+  param_.object_polygon_width_margin = declare_parameter("obect_polygon_width_margin", 0.5);
+  param_.valid_est_vel_diff_time = declare_parameter("valid_estimated_vel_diff_time", 1.0);
+  param_.valid_vel_que_time = declare_parameter("valid_vel_que_time", 0.5);
+  param_.valid_est_vel_max = declare_parameter("valid_estimated_vel_max", 20.0);
+  param_.valid_est_vel_min = declare_parameter("valid_estimated_vel_min", -20.0);
+  param_.thresh_vel_to_stop = declare_parameter("thresh_vel_to_stop", 0.5);
 
   /* publisher */
-  pub_debug_ = pnh_.advertise<std_msgs::Float32MultiArray>("debug_values", 1);
+  pub_debug_ = create_publisher<std_msgs::msg::Float32MultiArray>("debug_values", 1);
 }
 
 void AdaptiveCruiseController::insertAdaptiveCruiseVelocity(
-  const autoware_planning_msgs::Trajectory & trajectory, const int nearest_collision_point_idx,
-  const geometry_msgs::Pose self_pose, const pcl::PointXYZ & nearest_collision_point,
-  const ros::Time nearest_collision_point_time,
-  const autoware_perception_msgs::DynamicObjectArray::ConstPtr object_ptr,
-  const geometry_msgs::TwistStamped::ConstPtr current_velocity_ptr, bool * need_to_stop,
-  autoware_planning_msgs::Trajectory * output_trajectory)
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const int nearest_collision_point_idx,
+  const geometry_msgs::msg::Pose self_pose, const pcl::PointXYZ & nearest_collision_point,
+  const rclcpp::Time nearest_collision_point_time,
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr object_ptr,
+  const geometry_msgs::msg::TwistStamped::ConstPtr current_velocity_ptr, bool * need_to_stop,
+  autoware_planning_msgs::msg::Trajectory * output_trajectory)
 {
   debug_values_.data.clear();
   debug_values_.data.resize(num_debug_values_, 0.0);
@@ -232,21 +208,23 @@ void AdaptiveCruiseController::insertAdaptiveCruiseVelocity(
 
   if (!success_estm_vel) {
     //if failed to estimate velocity, need to stop
-    ROS_DEBUG_THROTTLE(1.0, "Failed to estimate velocity of forward vehicle. Insert stop line.");
+    RCLCPP_DEBUG_THROTTLE(get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
+      "Failed to estimate velocity of forward vehicle. Insert stop line.");
     *need_to_stop = true;
     prev_upper_velocity_ = current_velocity;  //reset prev_upper_velocity
-    pub_debug_.publish(debug_values_);
+    pub_debug_->publish(debug_values_);
     return;
   }
 
   //calculate max(target) velocity of self
   const double upper_velocity =
     calcUpperVelocity(col_point_distance, point_velocity, current_velocity);
-  pub_debug_.publish(debug_values_);
+  pub_debug_->publish(debug_values_);
 
   if (upper_velocity <= param_.thresh_vel_to_stop) {
     //if upper velocity is too low, need to stop
-    ROS_DEBUG_THROTTLE(1.0, "Upper velocity is too low. Insert stop line.");
+    RCLCPP_DEBUG_THROTTLE(get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
+      "Upper velocity is too low. Insert stop line.");
     *need_to_stop = true;
     prev_upper_velocity_ = current_velocity;  //reset prev_upper_velocity
     return;
@@ -260,18 +238,19 @@ void AdaptiveCruiseController::insertAdaptiveCruiseVelocity(
 }
 
 void AdaptiveCruiseController::calcDistanceToNearestPointOnPath(
-  const autoware_planning_msgs::Trajectory & trajectory, const int nearest_point_idx,
-  const geometry_msgs::Pose & self_pose, const pcl::PointXYZ & nearest_collision_point,
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const int nearest_point_idx,
+  const geometry_msgs::msg::Pose & self_pose, const pcl::PointXYZ & nearest_collision_point,
   double * distance)
 {
   if (trajectory.points.size() == 0) {
-    ROS_DEBUG_THROTTLE(1.0, "input path is too short(size=0)");
+    RCLCPP_DEBUG_THROTTLE(get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(), 
+      "input path is too short(size=0)");
     *distance = 0;
     return;
   }
 
   // get self polygon
-  geometry_msgs::Vector3 self_size;
+  geometry_msgs::msg::Vector3 self_size;
   self_size.x = vehicle_length_;
   self_size.y = vehicle_width_;
   double self_offset = (wheel_base_ + front_overhang_) - vehicle_length_ / 2.0;
@@ -313,16 +292,16 @@ void AdaptiveCruiseController::calcDistanceToNearestPointOnPath(
 }
 
 double AdaptiveCruiseController::calcTrajYaw(
-  const autoware_planning_msgs::Trajectory & trajectory, const int collsion_point_idx)
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const int collsion_point_idx)
 {
   return tf2::getYaw(trajectory.points.at(collsion_point_idx).pose.orientation);
 }
 
 bool AdaptiveCruiseController::estimatePointVelocityFromObject(
-  const autoware_perception_msgs::DynamicObjectArray::ConstPtr object_ptr, const double traj_yaw,
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstPtr object_ptr, const double traj_yaw,
   const pcl::PointXYZ & nearest_collision_point, double * velocity)
 {
-  geometry_msgs::Point nearest_collsion_p_ros;
+  geometry_msgs::msg::Point nearest_collsion_p_ros;
   nearest_collsion_p_ros.x = nearest_collision_point.x;
   nearest_collsion_p_ros.y = nearest_collision_point.y;
   nearest_collsion_p_ros.z = nearest_collision_point.z;
@@ -355,15 +334,15 @@ bool AdaptiveCruiseController::estimatePointVelocityFromObject(
 
 bool AdaptiveCruiseController::estimatePointVelocityFromPcl(
   const double traj_yaw, const pcl::PointXYZ & nearest_collision_point,
-  const ros::Time & nearest_collision_point_time, double * velocity)
+  const rclcpp::Time & nearest_collision_point_time, double * velocity)
 {
-  geometry_msgs::Point nearest_collsion_p_ros;
+  geometry_msgs::msg::Point nearest_collsion_p_ros;
   nearest_collsion_p_ros.x = nearest_collision_point.x;
   nearest_collsion_p_ros.y = nearest_collision_point.y;
   nearest_collsion_p_ros.z = nearest_collision_point.z;
 
   /* estimate velocity */
-  const double p_dt = nearest_collision_point_time.toSec() - prev_collsion_point_time_.toSec();
+  const double p_dt = nearest_collision_point_time.seconds() - prev_collsion_point_time_.seconds();
 
   // if get same pointcloud with previous step,
   // skip estimate process
@@ -410,14 +389,16 @@ double AdaptiveCruiseController::calcUpperVelocity(
   debug_values_.data.at(DBGVAL::ESTIMATED_VEL_FINAL) = obj_vel;
   if (obj_vel < param_.obstacle_stop_velocity_thresh) {
     // stop by static obstacle
-    ROS_DEBUG_THROTTLE(1.0, "The velocity of forward vehicle is too low. Insert stop line.");
+    RCLCPP_DEBUG_THROTTLE(get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
+      "The velocity of forward vehicle is too low. Insert stop line.");
     return 0.0;
   }
 
   const double thresh_dist = calcThreshDistToForwardObstacle(self_vel, obj_vel);
   if (thresh_dist >= dist_to_col) {
     // emergency stop
-    ROS_DEBUG_THROTTLE(1.0, "Forward vehicle is too close. Insert stop line.");
+    RCLCPP_DEBUG_THROTTLE(get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
+      "Forward vehicle is too close. Insert stop line.");
     return 0.0;
   }
 
@@ -484,13 +465,13 @@ double AdaptiveCruiseController::calcTargetVelocity_I(
 double AdaptiveCruiseController::calcTargetVelocity_D(
   const double target_dist, const double current_dist)
 {
-  if (ros::Time::now().toSec() - prev_target_vehicle_time_ >= param_.d_coeff_valid_time) {
+  if (rclcpp::Clock().now().seconds() - prev_target_vehicle_time_ >= param_.d_coeff_valid_time) {
     // invalid time(prev is too old)
     return 0.0;
   }
 
   double diff_vel = (target_dist - prev_target_vehicle_dist_) /
-                    (ros::Time::now().toSec() - prev_target_vehicle_time_);
+                    (rclcpp::Clock().now().seconds() - prev_target_vehicle_time_);
 
   if (std::fabs(diff_vel) >= param_.d_coeff_valid_diff_vel) {
     // invalid(discontinuous) diff_vel
@@ -506,7 +487,7 @@ double AdaptiveCruiseController::calcTargetVelocity_D(
 
   // add buffer
   prev_target_vehicle_dist_ = current_dist;
-  prev_target_vehicle_time_ = ros::Time::now().toSec();
+  prev_target_vehicle_time_ = rclcpp::Clock().now().seconds();
 
   return add_vel_d;
 }
@@ -515,7 +496,7 @@ double AdaptiveCruiseController::calcTargetVelocityByPID(
   const double current_vel, const double current_dist, const double obj_vel)
 {
   const double target_dist = calcBaseDistToForwardObstacle(current_vel, obj_vel);
-  ROS_DEBUG_STREAM("[adaptive cruise control] target_dist" << target_dist);
+  RCLCPP_DEBUG_STREAM(get_logger(), "[adaptive cruise control] target_dist" << target_dist);
 
   const double add_vel_p = calcTargetVelocity_P(target_dist, current_dist);
   //** I is not implemented **
@@ -533,7 +514,7 @@ double AdaptiveCruiseController::calcTargetVelocityByPID(
 
 void AdaptiveCruiseController::insertMaxVelocityToPath(
   const double current_vel, const double target_vel, const double dist_to_collsion_point,
-  autoware_planning_msgs::Trajectory * output_trajectory)
+  autoware_planning_msgs::msg::Trajectory * output_trajectory)
 {
   double target_acc = sign(target_vel - current_vel) *
                       ((target_vel - current_vel) * (target_vel - current_vel)) /
@@ -574,13 +555,13 @@ void AdaptiveCruiseController::insertMaxVelocityToPath(
   }
 }
 
-void AdaptiveCruiseController::registerQueToVelocity(const double vel, const ros::Time & vel_time)
+void AdaptiveCruiseController::registerQueToVelocity(const double vel, const rclcpp::Time & vel_time)
 {
   // remove old msg from que
   std::vector<int> delete_idxs;
   for (int i = 0; i < est_vel_que_.size(); i++) {
     if (
-      ros::Time::now().toSec() - est_vel_que_.at(i).header.stamp.toSec() >
+      rclcpp::Clock().now().seconds() - est_vel_que_.at(i).header.stamp.sec >
       param_.valid_vel_que_time) {
       delete_idxs.push_back(i);
     }
@@ -590,17 +571,17 @@ void AdaptiveCruiseController::registerQueToVelocity(const double vel, const ros
   }
 
   // append new que
-  geometry_msgs::TwistStamped new_vel;
+  geometry_msgs::msg::TwistStamped new_vel;
   new_vel.header.stamp = vel_time;
   new_vel.twist.linear.x = vel;
   est_vel_que_.emplace_back(new_vel);
 }
 
 double AdaptiveCruiseController::getMedianVel(
-  const std::vector<geometry_msgs::TwistStamped> vel_que)
+  const std::vector<geometry_msgs::msg::TwistStamped> vel_que)
 {
   if (vel_que.size() == 0) {
-    ROS_WARN_STREAM("size of vel que is 0. Something has wrong.");
+    RCLCPP_WARN_STREAM(get_logger(), "size of vel que is 0. Something has wrong.");
     return 0.0;
   }
 

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
@@ -159,7 +159,7 @@ AdaptiveCruiseController::AdaptiveCruiseController(
   param_.thresh_vel_to_stop = declare_parameter("thresh_vel_to_stop", 0.5);
 
   /* publisher */
-  pub_debug_ = create_publisher<std_msgs::msg::Float32MultiArray>("debug_values", 1);
+  pub_debug_ = create_publisher<autoware_debug_msgs::msg::Float32MultiArrayStamped>("debug_values", 1);
 }
 
 void AdaptiveCruiseController::insertAdaptiveCruiseVelocity(

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/main.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/main.cpp
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <obstacle_stop_planner/node.hpp>
 
 int main(int argc, char ** argv)
 {
-  ros::init(argc, argv, "obstacle_stop_planner_node");
-
-  motion_planning::ObstacleStopPlannerNode node;
-
-  ros::spin();
-
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<motion_planning::ObstacleStopPlannerNode>());
+  rclcpp::shutdown();
   return 0;
 }

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/node.cpp
@@ -209,12 +209,12 @@ void ObstacleStopPlannerNode::pathCallback(
 
     Eigen::Matrix4f affine_matrix =
       tf2::transformToEigen(transform_stamped.transform).matrix().cast<float>();
-    pcl::PointCloud<pcl::PointXYZ>::Ptr obstacle_ros_pointcloud_pcl_ptr_(
+    pcl::PointCloud<pcl::PointXYZ>::Ptr obstacle_pointcloud_pcl_ptr_(
       new pcl::PointCloud<pcl::PointXYZ>);
-    pcl::fromROSMsg(*obstacle_ros_pointcloud_ptr_, *obstacle_ros_pointcloud_pcl_ptr_);
+    pcl::fromROSMsg(*obstacle_ros_pointcloud_ptr_, *obstacle_pointcloud_pcl_ptr_);
     pcl::PointCloud<pcl::PointXYZ>::Ptr transformed_obstacle_pointcloud_ptr(
       new pcl::PointCloud<pcl::PointXYZ>);
-    pcl::transformPointCloud(*obstacle_ros_pointcloud_pcl_ptr_, *transformed_obstacle_pointcloud_ptr, affine_matrix);
+    pcl::transformPointCloud(*obstacle_pointcloud_pcl_ptr_, *transformed_obstacle_pointcloud_ptr, affine_matrix);
 
     // search obstacle candidate pointcloud to reduce calculation cost
     const double search_radius = enable_slow_down_ ? slow_down_search_radius_ : stop_search_radius_;

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/node.cpp
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <diagnostic_msgs/DiagnosticStatus.h>
-#include <diagnostic_msgs/KeyValue.h>
+#include <diagnostic_msgs/msg/key_value.hpp>
 #include <pcl/filters/voxel_grid.h>
 #include <tf2/utils.h>
 #include <tf2_eigen/tf2_eigen.h>
@@ -27,37 +26,11 @@
 #include <obstacle_stop_planner/node.hpp>
 #include <vector>
 #define EIGEN_MPL2_ONLY
-#include <Eigen/Core>
-#include <Eigen/Geometry>
+#include <eigen3/Eigen/Core>
+#include <eigen3/Eigen/Geometry>
 namespace
 {
-template <class T>
-T getParam(const ros::NodeHandle & nh, const std::string & key, const T & default_value)
-{
-  T value;
-  nh.param<T>(key, value, default_value);
-  return value;
-}
-
-template <class T>
-T waitForParam(const ros::NodeHandle & nh, const std::string & key)
-{
-  T value;
-  ros::Rate rate(1.0);
-
-  while (ros::ok()) {
-    const auto result = nh.getParam(key, value);
-    if (result) {
-      return value;
-    }
-
-    ROS_WARN("waiting for parameter `%s` ...", key.c_str());
-    rate.sleep();
-  }
-
-  return {};
-}
-double getYawFromGeometryMsgsQuaternion(const geometry_msgs::Quaternion & quat)
+double getYawFromGeometryMsgsQuaternion(const geometry_msgs::msg::Quaternion & quat)
 {
   tf2::Quaternion tf2_quat(quat.x, quat.y, quat.z, quat.w);
   double roll, pitch, yaw;
@@ -65,7 +38,7 @@ double getYawFromGeometryMsgsQuaternion(const geometry_msgs::Quaternion & quat)
 
   return yaw;
 }
-std::string jsonDumpsPose(const geometry_msgs::Pose & pose)
+std::string jsonDumpsPose(const geometry_msgs::msg::Pose & pose)
 {
   const std::string json_dumps_pose =
     (boost::format(
@@ -75,12 +48,12 @@ std::string jsonDumpsPose(const geometry_msgs::Pose & pose)
       .str();
   return json_dumps_pose;
 }
-diagnostic_msgs::DiagnosticStatus makeStopReasonDiag(
-  const std::string stop_reason, const geometry_msgs::Pose & stop_pose)
+diagnostic_msgs::msg::DiagnosticStatus makeStopReasonDiag(
+  const std::string stop_reason, const geometry_msgs::msg::Pose & stop_pose)
 {
-  diagnostic_msgs::DiagnosticStatus stop_reason_diag;
-  diagnostic_msgs::KeyValue stop_reason_diag_kv;
-  stop_reason_diag.level = diagnostic_msgs::DiagnosticStatus::OK;
+  diagnostic_msgs::msg::DiagnosticStatus stop_reason_diag;
+  diagnostic_msgs::msg::KeyValue stop_reason_diag_kv;
+  stop_reason_diag.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
   stop_reason_diag.name = "stop_reason";
   stop_reason_diag.message = stop_reason;
   stop_reason_diag_kv.key = "stop_pose";
@@ -97,27 +70,28 @@ using Point = bg::model::d2::point_xy<double>;
 using Polygon = bg::model::polygon<Point, false>;
 using Line = bg::model::linestring<Point>;
 
-ObstacleStopPlannerNode::ObstacleStopPlannerNode() : nh_(), pnh_("~"), tf_listener_(tf_buffer_)
+ObstacleStopPlannerNode::ObstacleStopPlannerNode() 
+: Node("obstacle_stop_planner"),  tf_buffer_(this->get_clock()), tf_listener_(tf_buffer_)
 {
   // Vehicle Parameters
-  wheel_base_ = waitForParam<double>(pnh_, "/vehicle_info/wheel_base");
-  front_overhang_ = waitForParam<double>(pnh_, "/vehicle_info/front_overhang");
-  rear_overhang_ = waitForParam<double>(pnh_, "/vehicle_info/rear_overhang");
-  left_overhang_ = waitForParam<double>(pnh_, "/vehicle_info/left_overhang");
-  right_overhang_ = waitForParam<double>(pnh_, "/vehicle_info/right_overhang");
-  vehicle_width_ = waitForParam<double>(pnh_, "/vehicle_info/vehicle_width");
-  vehicle_length_ = waitForParam<double>(pnh_, "/vehicle_info/vehicle_length");
+  wheel_base_ = declare_parameter("/vehicle_info/wheel_base", 1.0);
+  front_overhang_ = declare_parameter("/vehicle_info/front_overhang", 0.5);
+  rear_overhang_ = declare_parameter("/vehicle_info/rear_overhang", 0.5);
+  left_overhang_ = declare_parameter("/vehicle_info/left_overhang", 0.5);
+  right_overhang_ = declare_parameter("/vehicle_info/right_overhang", 0.5);
+  vehicle_width_ = declare_parameter("/vehicle_info/vehicle_width", 1.5);
+  vehicle_length_ = declare_parameter("/vehicle_info/vehicle_length", 2.0);
 
   // Parameters
-  stop_margin_ = getParam<double>(pnh_, "stop_margin", 5.0);
-  slow_down_margin_ = getParam<double>(pnh_, "slow_down_margin", 5.0);
-  min_behavior_stop_margin_ = getParam<double>(pnh_, "min_behavior_stop_margin", 2.0);
-  expand_slow_down_range_ = getParam<double>(pnh_, "expand_slow_down_range", 1.0);
-  max_slow_down_vel_ = getParam<double>(pnh_, "max_slow_down_vel", 4.0);
-  min_slow_down_vel_ = getParam<double>(pnh_, "min_slow_down_vel", 2.0);
-  max_deceleration_ = getParam<double>(pnh_, "max_deceleration", 2.0);
-  enable_slow_down_ = getParam<bool>(pnh_, "enable_slow_down", false);
-  step_length_ = getParam<double>(pnh_, "step_length", 1.0);
+  stop_margin_ = declare_parameter("stop_margin", 5.0);
+  slow_down_margin_ = declare_parameter("slow_down_margin", 5.0);
+  min_behavior_stop_margin_ = declare_parameter("min_behavior_stop_margin", 2.0);
+  expand_slow_down_range_ = declare_parameter("expand_slow_down_range", 1.0);
+  max_slow_down_vel_ = declare_parameter("max_slow_down_vel", 4.0);
+  min_slow_down_vel_ = declare_parameter("min_slow_down_vel", 2.0);
+  max_deceleration_ = declare_parameter("max_deceleration", 2.0);
+  enable_slow_down_ = declare_parameter("enable_slow_down", false);
+  step_length_ = declare_parameter("step_length", 1.0);
   stop_margin_ += wheel_base_ + front_overhang_;
   min_behavior_stop_margin_ += wheel_base_ + front_overhang_;
   slow_down_margin_ += wheel_base_ + front_overhang_;
@@ -132,24 +106,32 @@ ObstacleStopPlannerNode::ObstacleStopPlannerNode() : nh_(), pnh_("~"), tf_listen
     vehicle_width_, vehicle_length_, wheel_base_, front_overhang_);
 
   // Publishers
-  path_pub_ = pnh_.advertise<autoware_planning_msgs::Trajectory>("output/trajectory", 1);
+  path_pub_ = 
+    this->create_publisher<autoware_planning_msgs::msg::Trajectory>("output/trajectory", 1);
   stop_reason_diag_pub_ =
-    pnh_.advertise<diagnostic_msgs::DiagnosticStatus>("output/stop_reason", 1);
+    this->create_publisher<diagnostic_msgs::msg::DiagnosticStatus>("output/stop_reason", 1);
 
   // Subscribers
-  obstacle_pointcloud_sub_ = pnh_.subscribe(
-    "input/pointcloud", 1, &ObstacleStopPlannerNode::obstaclePointcloudCallback, this);
-  path_sub_ = pnh_.subscribe("input/trajectory", 1, &ObstacleStopPlannerNode::pathCallback, this);
-  current_velocity_sub_ =
-    pnh_.subscribe("input/twist", 1, &ObstacleStopPlannerNode::currentVelocityCallback, this);
-  dynamic_object_sub_ =
-    pnh_.subscribe("input/objects", 1, &ObstacleStopPlannerNode::dynamicObjectCallback, this);
+  obstacle_pointcloud_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
+    "input/pointcloud", 1,
+    std::bind(&ObstacleStopPlannerNode::obstaclePointcloudCallback, this, std::placeholders::_1));
+  path_sub_ = this->create_subscription<autoware_planning_msgs::msg::Trajectory>(
+    "input/trajectory", 1, 
+    std::bind(&ObstacleStopPlannerNode::pathCallback, this, std::placeholders::_1));
+  current_velocity_sub_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+    "input/twist", 1,
+    std::bind(&ObstacleStopPlannerNode::currentVelocityCallback, this, std::placeholders::_1)
+  );
+  dynamic_object_sub_ = this->create_subscription<autoware_perception_msgs::msg::DynamicObjectArray>(
+    "input/objects", 1,
+    std::bind(&ObstacleStopPlannerNode::dynamicObjectCallback, this, std::placeholders::_1)
+  );
 }
 
 void ObstacleStopPlannerNode::obstaclePointcloudCallback(
-  const sensor_msgs::PointCloud2::ConstPtr & input_msg)
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr input_msg)
 {
-  obstacle_ros_pointcloud_ptr_ = boost::make_shared<sensor_msgs::PointCloud2>();
+  obstacle_ros_pointcloud_ptr_ = std::make_shared<sensor_msgs::msg::PointCloud2>();
   pcl::VoxelGrid<pcl::PointXYZ> filter;
   pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud_ptr(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr no_height_pointcloud_ptr(new pcl::PointCloud<pcl::PointXYZ>);
@@ -167,28 +149,30 @@ void ObstacleStopPlannerNode::obstaclePointcloudCallback(
   obstacle_ros_pointcloud_ptr_->header = input_msg->header;
 }
 void ObstacleStopPlannerNode::pathCallback(
-  const autoware_planning_msgs::Trajectory::ConstPtr & input_msg)
+  const autoware_planning_msgs::msg::Trajectory::ConstSharedPtr input_msg)
 {
   if (!obstacle_ros_pointcloud_ptr_) {
-    ROS_WARN_THROTTLE(1.0, "waiting for obstacle pointcloud...");
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
+      "waiting for obstacle pointcloud...");
     return;
   }
 
   if (!current_velocity_ptr_ && enable_slow_down_) {
-    ROS_WARN_THROTTLE(1.0, "waiting for current velocity...");
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
+      "waiting for current velocity...");
     return;
   }
 
-  const autoware_planning_msgs::Trajectory base_path = *input_msg;
-  autoware_planning_msgs::Trajectory output_msg = *input_msg;
-  diagnostic_msgs::DiagnosticStatus stop_reason_diag;
+  const autoware_planning_msgs::msg::Trajectory base_path = *input_msg;
+  autoware_planning_msgs::msg::Trajectory output_msg = *input_msg;
+  diagnostic_msgs::msg::DiagnosticStatus stop_reason_diag;
   const double epsilon = 0.00001;
   /*
    * trim trajectory from self pose
    */
-  geometry_msgs::Pose self_pose;
+  geometry_msgs::msg::Pose self_pose;
   getSelfPose(input_msg->header, tf_buffer_, self_pose);
-  autoware_planning_msgs::Trajectory trim_trajectory;
+  autoware_planning_msgs::msg::Trajectory trim_trajectory;
   size_t trajectory_trim_index;
   trimTrajectoryWithIndexFromSelfPose(
     *input_msg, self_pose, trim_trajectory, trajectory_trim_index);
@@ -196,12 +180,12 @@ void ObstacleStopPlannerNode::pathCallback(
   /*
    * decimate trajectory for calculation cost
    */
-  autoware_planning_msgs::Trajectory decimate_trajectory;
+  autoware_planning_msgs::msg::Trajectory decimate_trajectory;
   std::map<size_t /* decimate */, size_t /* origin */> decimate_trajectory_index_map;
   decimateTrajectory(
     trim_trajectory, step_length_, decimate_trajectory, decimate_trajectory_index_map);
 
-  autoware_planning_msgs::Trajectory & trajectory = decimate_trajectory;
+  autoware_planning_msgs::msg::Trajectory & trajectory = decimate_trajectory;
 
   /*
    * search candidate obstacle pointcloud
@@ -210,13 +194,13 @@ void ObstacleStopPlannerNode::pathCallback(
     new pcl::PointCloud<pcl::PointXYZ>);
   {
     // transform pointcloud
-    geometry_msgs::TransformStamped transform_stamped;
+    geometry_msgs::msg::TransformStamped transform_stamped;
     try {
       transform_stamped = tf_buffer_.lookupTransform(
         trajectory.header.frame_id, obstacle_ros_pointcloud_ptr_->header.frame_id,
-        obstacle_ros_pointcloud_ptr_->header.stamp, ros::Duration(0.5));
+        obstacle_ros_pointcloud_ptr_->header.stamp, rclcpp::Duration(0.5));
     } catch (tf2::TransformException & ex) {
-      ROS_ERROR_STREAM(
+      RCLCPP_ERROR_STREAM(get_logger(),
         "[obstacle_stop_plannnr] Failed to look up transform from "
         << trajectory.header.frame_id << " to " << obstacle_ros_pointcloud_ptr_->header.frame_id);
       // do not publish path
@@ -225,12 +209,13 @@ void ObstacleStopPlannerNode::pathCallback(
 
     Eigen::Matrix4f affine_matrix =
       tf2::transformToEigen(transform_stamped.transform).matrix().cast<float>();
-    sensor_msgs::PointCloud2 transformed_obstacle_ros_pointcloud;
-    pcl_ros::transformPointCloud(
-      affine_matrix, *obstacle_ros_pointcloud_ptr_, transformed_obstacle_ros_pointcloud);
+    pcl::PointCloud<pcl::PointXYZ>::Ptr obstacle_ros_pointcloud_pcl_ptr_(
+      new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::fromROSMsg(*obstacle_ros_pointcloud_ptr_, *obstacle_ros_pointcloud_pcl_ptr_);
     pcl::PointCloud<pcl::PointXYZ>::Ptr transformed_obstacle_pointcloud_ptr(
       new pcl::PointCloud<pcl::PointXYZ>);
-    pcl::fromROSMsg(transformed_obstacle_ros_pointcloud, *transformed_obstacle_pointcloud_ptr);
+    pcl::transformPointCloud(*obstacle_ros_pointcloud_pcl_ptr_, *transformed_obstacle_pointcloud_ptr, affine_matrix);
+
     // search obstacle candidate pointcloud to reduce calculation cost
     const double search_radius = enable_slow_down_ ? slow_down_search_radius_ : stop_search_radius_;
     searchPointcloudNearTrajectory(
@@ -246,7 +231,7 @@ void ObstacleStopPlannerNode::pathCallback(
   bool is_collision = false;
   size_t decimate_trajectory_collision_index;
   pcl::PointXYZ nearest_collision_point;
-  ros::Time nearest_collision_point_time;
+  rclcpp::Time nearest_collision_point_time;
   // for slow down
   bool canditate_slow_down = false;
   bool is_slow_down = false;
@@ -465,7 +450,7 @@ void ObstacleStopPlannerNode::pathCallback(
           !is_inserted_already_stop_point ? max_dist_stop_point_idx : min_dist_stop_point_idx;
         const Eigen::Vector2d stop_point =
           !is_inserted_already_stop_point ? max_dist_stop_point : min_dist_stop_point;
-        autoware_planning_msgs::TrajectoryPoint stop_trajectory_point =
+        autoware_planning_msgs::msg::TrajectoryPoint stop_trajectory_point =
           base_path.points.at(std::max((int)(insert_stop_point_index)-1, 0));
         stop_trajectory_point.pose.position.x = stop_point.x();
         stop_trajectory_point.pose.position.y = stop_point.y();
@@ -542,9 +527,9 @@ void ObstacleStopPlannerNode::pathCallback(
             current_velocity_ptr_->twist.linear.x);
         }
 
-        autoware_planning_msgs::TrajectoryPoint slow_down_start_trajectory_point =
+        autoware_planning_msgs::msg::TrajectoryPoint slow_down_start_trajectory_point =
           base_path.points.at(std::max((int)(slow_down_start_point_idx)-1, 0));
-        autoware_planning_msgs::TrajectoryPoint slow_down_end_trajectory_point;
+        autoware_planning_msgs::msg::TrajectoryPoint slow_down_end_trajectory_point;
         slow_down_start_trajectory_point.pose.position.x = slow_down_start_point.x();
         slow_down_start_trajectory_point.pose.position.y = slow_down_start_point.y();
         slow_down_start_trajectory_point.twist.linear.x = slow_down_vel;
@@ -574,34 +559,34 @@ void ObstacleStopPlannerNode::pathCallback(
       }
     }
   }
-  path_pub_.publish(output_msg);
-  stop_reason_diag_pub_.publish(stop_reason_diag);
+  path_pub_->publish(output_msg);
+  stop_reason_diag_pub_->publish(stop_reason_diag);
   debug_ptr_->publish();
 }
 
 void ObstacleStopPlannerNode::dynamicObjectCallback(
-  const autoware_perception_msgs::DynamicObjectArrayConstPtr & input_msg)
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr input_msg)
 {
   object_ptr_ = input_msg;
 }
 
 void ObstacleStopPlannerNode::currentVelocityCallback(
-  const geometry_msgs::TwistStamped::ConstPtr & input_msg)
+  const geometry_msgs::msg::TwistStamped::ConstSharedPtr input_msg)
 {
   current_velocity_ptr_ = input_msg;
 }
 
 bool ObstacleStopPlannerNode::decimateTrajectory(
-  const autoware_planning_msgs::Trajectory & input_trajectory, const double step_length,
-  autoware_planning_msgs::Trajectory & output_trajectory)
+  const autoware_planning_msgs::msg::Trajectory & input_trajectory, const double step_length,
+  autoware_planning_msgs::msg::Trajectory & output_trajectory)
 {
   std::map<size_t /* decimate */, size_t /* origin */> index_map;
   decimateTrajectory(input_trajectory, step_length, output_trajectory, index_map);
 }
 
 bool ObstacleStopPlannerNode::decimateTrajectory(
-  const autoware_planning_msgs::Trajectory & input_trajectory, const double step_length,
-  autoware_planning_msgs::Trajectory & output_trajectory,
+  const autoware_planning_msgs::msg::Trajectory & input_trajectory, const double step_length,
+  autoware_planning_msgs::msg::Trajectory & output_trajectory,
   std::map<size_t /* decimate */, size_t /* origin */> & index_map)
 {
   output_trajectory.header = input_trajectory.header;
@@ -620,7 +605,7 @@ bool ObstacleStopPlannerNode::decimateTrajectory(
       getBackwordPointFromBasePoint(
         line_start_point, line_end_point, line_end_point,
         -1.0 * (trajectory_length_sum - next_length), interporated_point);
-      autoware_planning_msgs::TrajectoryPoint trajectory_point;
+      autoware_planning_msgs::msg::TrajectoryPoint trajectory_point;
       trajectory_point = input_trajectory.points.at(i);
       trajectory_point.pose.position.x = interporated_point.x();
       trajectory_point.pose.position.y = interporated_point.y();
@@ -646,8 +631,8 @@ bool ObstacleStopPlannerNode::decimateTrajectory(
 }
 
 bool ObstacleStopPlannerNode::trimTrajectoryWithIndexFromSelfPose(
-  const autoware_planning_msgs::Trajectory & input_trajectory, const geometry_msgs::Pose self_pose,
-  autoware_planning_msgs::Trajectory & output_trajectory, size_t & index)
+  const autoware_planning_msgs::msg::Trajectory & input_trajectory, const geometry_msgs::msg::Pose self_pose,
+  autoware_planning_msgs::msg::Trajectory & output_trajectory, size_t & index)
 {
   double min_distance = 0.0;
   size_t min_dintance_index = 0;
@@ -671,8 +656,8 @@ bool ObstacleStopPlannerNode::trimTrajectoryWithIndexFromSelfPose(
 }
 
 bool ObstacleStopPlannerNode::trimTrajectoryFromSelfPose(
-  const autoware_planning_msgs::Trajectory & input_trajectory, const geometry_msgs::Pose self_pose,
-  autoware_planning_msgs::Trajectory & output_trajectory)
+  const autoware_planning_msgs::msg::Trajectory & input_trajectory, const geometry_msgs::msg::Pose self_pose,
+  autoware_planning_msgs::msg::Trajectory & output_trajectory)
 {
   size_t index;
   return trimTrajectoryWithIndexFromSelfPose(
@@ -680,7 +665,7 @@ bool ObstacleStopPlannerNode::trimTrajectoryFromSelfPose(
 }
 
 bool ObstacleStopPlannerNode::searchPointcloudNearTrajectory(
-  const autoware_planning_msgs::Trajectory & trajectory, const double radius,
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const double radius,
   const pcl::PointCloud<pcl::PointXYZ>::Ptr input_pointcloud_ptr,
   pcl::PointCloud<pcl::PointXYZ>::Ptr output_pointcloud_ptr)
 {
@@ -698,7 +683,7 @@ bool ObstacleStopPlannerNode::searchPointcloudNearTrajectory(
 }
 
 void ObstacleStopPlannerNode::createOneStepPolygon(
-  const geometry_msgs::Pose base_stap_pose, const geometry_msgs::Pose next_step_pose,
+  const geometry_msgs::msg::Pose base_stap_pose, const geometry_msgs::msg::Pose next_step_pose,
   std::vector<cv::Point2d> & polygon, const double expand_width)
 {
   std::vector<cv::Point2d> one_step_move_vehicle_corner_points;
@@ -786,13 +771,13 @@ bool ObstacleStopPlannerNode::convexHull(
 }
 
 bool ObstacleStopPlannerNode::getSelfPose(
-  const std_msgs::Header & header, const tf2_ros::Buffer & tf_buffer,
-  geometry_msgs::Pose & self_pose)
+  const std_msgs::msg::Header & header, const tf2_ros::Buffer & tf_buffer,
+  geometry_msgs::msg::Pose & self_pose)
 {
   try {
-    geometry_msgs::TransformStamped transform;
+    geometry_msgs::msg::TransformStamped transform;
     transform =
-      tf_buffer.lookupTransform(header.frame_id, "base_link", header.stamp, ros::Duration(0.1));
+      tf_buffer.lookupTransform(header.frame_id, "base_link", header.stamp, rclcpp::Duration(0.1));
     self_pose.position.x = transform.transform.translation.x;
     self_pose.position.y = transform.transform.translation.y;
     self_pose.position.z = transform.transform.translation.z;
@@ -816,8 +801,8 @@ bool ObstacleStopPlannerNode::getBackwordPointFromBasePoint(
 }
 
 void ObstacleStopPlannerNode::getNearestPoint(
-  const pcl::PointCloud<pcl::PointXYZ> & pointcloud, const geometry_msgs::Pose & base_pose,
-  pcl::PointXYZ * nearest_collision_point, ros::Time * nearest_collision_point_time)
+  const pcl::PointCloud<pcl::PointXYZ> & pointcloud, const geometry_msgs::msg::Pose & base_pose,
+  pcl::PointXYZ * nearest_collision_point, rclcpp::Time * nearest_collision_point_time)
 {
   double min_norm = 0.0;
   bool is_init = false;
@@ -840,7 +825,7 @@ void ObstacleStopPlannerNode::getNearestPoint(
 }
 
 void ObstacleStopPlannerNode::getLateralNearestPoint(
-  const pcl::PointCloud<pcl::PointXYZ> & pointcloud, const geometry_msgs::Pose & base_pose,
+  const pcl::PointCloud<pcl::PointXYZ> & pointcloud, const geometry_msgs::msg::Pose & base_pose,
   pcl::PointXYZ * lateral_nearest_point, double * deviation)
 {
   double min_norm = std::numeric_limits<double>::max();
@@ -861,10 +846,10 @@ void ObstacleStopPlannerNode::getLateralNearestPoint(
   *deviation = min_norm;
 }
 
-geometry_msgs::Pose ObstacleStopPlannerNode::getVehicleCenterFromBase(
-  const geometry_msgs::Pose & base_pose)
+geometry_msgs::msg::Pose ObstacleStopPlannerNode::getVehicleCenterFromBase(
+  const geometry_msgs::msg::Pose & base_pose)
 {
-  geometry_msgs::Pose center_pose;
+  geometry_msgs::msg::Pose center_pose;
   const double yaw = getYawFromGeometryMsgsQuaternion(base_pose.orientation);
   center_pose.position.x =
     base_pose.position.x + (vehicle_length_ / 2.0 - rear_overhang_) * std::cos(yaw);


### PR DESCRIPTION
Port of `obstacle-stop-planner` to ROS2. A couple of notes:

- In the `CMakeLists.txt` compile option `-O3` needs to be added for the `static constexpr` in the `adaptive_cruise_control.hpp` parameters to be compiled properly.
- In `node.cpp` line [212](https://github.com/tier4/Pilot.Auto/pull/86/files#diff-9493ac6ff50c82cecb25fb47d2f6fb1a6a512d07e8aad7d2693d94cc419a1107R212) I've replaced the `pcl_ros::transformPointCloud` usage with the `pcl::transformPointCloud` equivalent as `pcl_ros` is not available in ROS2 yet
