### PR TITLE
Create message package for dummy_perception_publisher

### DIFF
--- a/common/msgs/autoware_perception_msgs/CMakeLists.txt
+++ b/common/msgs/autoware_perception_msgs/CMakeLists.txt
@@ -114,7 +114,6 @@ elseif(${ROS_VERSION} EQUAL 2)
       geometry_msgs
       sensor_msgs
       unique_identifier_msgs
-    ADD_LINTER_TESTS
   )
 
   ament_export_dependencies(rosidl_default_runtime)

--- a/simulator/util/dummy_perception_publisher_msgs/CMakeLists.txt
+++ b/simulator/util/dummy_perception_publisher_msgs/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.5)
+project(dummy_perception_publisher_msgs)
+
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(autoware_perception_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(unique_identifier_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/InitialState.msg"
+  "msg/Object.msg"
+  DEPENDENCIES std_msgs geometry_msgs autoware_perception_msgs unique_identifier_msgs
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/simulator/util/dummy_perception_publisher_msgs/msg/InitialState.msg
+++ b/simulator/util/dummy_perception_publisher_msgs/msg/InitialState.msg
@@ -1,0 +1,2 @@
+geometry_msgs/PoseWithCovariance pose_covariance
+geometry_msgs/TwistWithCovariance twist_covariance

--- a/simulator/util/dummy_perception_publisher_msgs/msg/Object.msg
+++ b/simulator/util/dummy_perception_publisher_msgs/msg/Object.msg
@@ -1,0 +1,11 @@
+std_msgs/Header header
+unique_identifier_msgs/UUID id
+dummy_perception_publisher_msgs/InitialState initial_state
+autoware_perception_msgs/Semantic semantic
+autoware_perception_msgs/Shape shape
+
+uint8 ADD=0
+uint8 MODIFY=1
+uint8 DELETE=2
+uint8 DELETEALL=3
+int32 action

--- a/simulator/util/dummy_perception_publisher_msgs/package.xml
+++ b/simulator/util/dummy_perception_publisher_msgs/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <member_of_group>rosidl_interface_packages</member_of_group>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   
@@ -20,6 +19,7 @@
   <depend>std_msgs</depend>
   <depend>unique_identifier_msgs</depend>
 
+  <member_of_group>rosidl_interface_packages</member_of_group>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/simulator/util/dummy_perception_publisher_msgs/package.xml
+++ b/simulator/util/dummy_perception_publisher_msgs/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>dummy_perception_publisher_msgs</name>
+  <version>0.1.0</version>
+  <description>The dummy_perception_publisher_msgs package</description>
+
+  <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
+  <license>Apache2</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  
+  <depend>autoware_perception_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>unique_identifier_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
* I couldn't get message + library code to compile in one package, so this is a separate package for the messages
* Uses `unique_identifier_msgs` instead of `uuid_msgs`
* Using `ament_cmake_auto` doesn't appear to work for message packages, no generated headers or source files show up in the install directory.