### PR TITLE
Port map based prediction

### DIFF
--- a/perception/object_recognition/prediction/map_based_prediction/CMakeLists.txt
+++ b/perception/object_recognition/prediction/map_based_prediction/CMakeLists.txt
@@ -1,59 +1,26 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(map_based_prediction)
 
-add_compile_options(-std=c++14)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wno-unused-parameter)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  autoware_perception_msgs
-  roscpp
-  tf2_ros
-  tf2_geometry_msgs
-  lanelet2_extension
-)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 find_package(Eigen3 REQUIRED)
 
-catkin_package(
-  INCLUDE_DIRS
-    include
-  CATKIN_DEPENDS
-    autoware_perception_msgs
-    roscpp
-    tf2_ros
-    tf2_geometry_msgs
-)
-
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIR}
-)
-
-add_executable(map_based_prediction
+ament_auto_add_executable(map_based_prediction
   src/map_based_prediction_main.cpp
   src/map_based_prediction_ros.cpp
   src/map_based_prediction.cpp
 )
 
-add_dependencies(map_based_prediction
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
-)
-
-target_link_libraries(map_based_prediction
-  ${catkin_LIBRARIES}
-  ${OpenCV_LIBS}
-  ${PCL_LIBRARIES}
-)
-
-install(TARGETS map_based_prediction
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-install(
-  DIRECTORY
-    launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+ament_auto_package(
+  INSTALL_TO_SHARE
+  launch
+) 

--- a/perception/object_recognition/prediction/map_based_prediction/include/cubic_spline.hpp
+++ b/perception/object_recognition/prediction/map_based_prediction/include/cubic_spline.hpp
@@ -24,7 +24,7 @@
 #ifndef CUBIC_SPLINE_H
 #define CUBIC_SPLINE_H
 
-#include <Eigen/Eigen>
+#include <eigen3/Eigen/Eigen>
 #include <algorithm>
 #include <array>
 #include <iostream>

--- a/perception/object_recognition/prediction/map_based_prediction/include/map_based_prediction.h
+++ b/perception/object_recognition/prediction/map_based_prediction/include/map_based_prediction.h
@@ -17,28 +17,21 @@
 #ifndef MAP_BASED_PREDICTION_H
 #define MAP_BASED_PREDICTION_H
 
-namespace autoware_perception_msgs
-{
-ROS_DECLARE_MESSAGE(DynamicObjectArray);
-ROS_DECLARE_MESSAGE(DynamicObject);
-ROS_DECLARE_MESSAGE(PredictedPath);
-}  // namespace autoware_perception_msgs
-
-namespace geometry_msgs
-{
-ROS_DECLARE_MESSAGE(Point);
-ROS_DECLARE_MESSAGE(Pose);
-}  // namespace geometry_msgs
+#include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
+#include <autoware_perception_msgs/msg/dynamic_object.hpp>
+#include <autoware_perception_msgs/msg/predicted_path.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
 
 struct DynamicObjectWithLanes
 {
-  autoware_perception_msgs::DynamicObject object;
-  std::vector<std::vector<geometry_msgs::Pose>> lanes;
+  autoware_perception_msgs::msg::DynamicObject object;
+  std::vector<std::vector<geometry_msgs::msg::Pose>> lanes;
 };
 
 struct DynamicObjectWithLanesArray
 {
-  std_msgs::Header header;
+  std_msgs::msg::Header header;
   std::vector<DynamicObjectWithLanes> objects;
 };
 
@@ -54,18 +47,18 @@ private:
   bool getPredictedPath(
     const double height, const double current_d_position, const double current_d_velocity,
     const double current_s_position, const double current_s_velocity,
-    const double target_s_position, const std_msgs::Header & origin_header, Spline2D & spline2d,
-    autoware_perception_msgs::PredictedPath & path);
+    const double target_s_position, const std_msgs::msg::Header & origin_header, Spline2D & spline2d,
+    autoware_perception_msgs::msg::PredictedPath & path);
 
   bool getLinearPredictedPath(
-    const geometry_msgs::Pose & object_pose, const geometry_msgs::Twist & object_twist,
-    const std_msgs::Header & origin_header,
-    autoware_perception_msgs::PredictedPath & predicted_path);
+    const geometry_msgs::msg::Pose & object_pose, const geometry_msgs::msg::Twist & object_twist,
+    const std_msgs::msg::Header & origin_header,
+    autoware_perception_msgs::msg::PredictedPath & predicted_path);
 
   // double calculateLikelyhood(const double desired_yaw, const double current_d, const double current_yaw);
   double calculateLikelyhood(const double current_d);
 
-  bool normalizeLikelyhood(std::vector<autoware_perception_msgs::PredictedPath> & paths);
+  bool normalizeLikelyhood(std::vector<autoware_perception_msgs::msg::PredictedPath> & paths);
 
 public:
   MapBasedPrediction(
@@ -73,12 +66,12 @@ public:
 
   bool doPrediction(
     const DynamicObjectWithLanesArray & in_objects,
-    std::vector<autoware_perception_msgs::DynamicObject> & out_objects,
-    std::vector<geometry_msgs::Point> & debug_interpolated_points);
+    std::vector<autoware_perception_msgs::msg::DynamicObject> & out_objects,
+    std::vector<geometry_msgs::msg::Point> & debug_interpolated_points);
 
   bool doLinearPrediction(
-    const autoware_perception_msgs::DynamicObjectArray & in_objects,
-    std::vector<autoware_perception_msgs::DynamicObject> & out_objects);
+    const autoware_perception_msgs::msg::DynamicObjectArray & in_objects,
+    std::vector<autoware_perception_msgs::msg::DynamicObject> & out_objects);
 };
 
 #endif  // MAP_BASED_PREDICTION_H

--- a/perception/object_recognition/prediction/map_based_prediction/launch/map_based_prediction.launch.xml
+++ b/perception/object_recognition/prediction/map_based_prediction/launch/map_based_prediction.launch.xml
@@ -4,9 +4,9 @@
   <arg name="prediction_time_horizon" default="10" />
   <arg name="prediction_sampling_delta_time" default="0.5" />
   <arg name="vector_map_topic" default="/map/vector_map" />
-  <node pkg="map_based_prediction" type="map_based_prediction" name="map_based_prediction" output="screen">
-    <param name="prediction_time_horizon" value="$(arg prediction_time_horizon)" />
-    <param name="prediction_sampling_delta_time" value="$(arg prediction_sampling_delta_time)" />
-    <remap from="/vector_map" to="$(arg vector_map_topic)"/>
+  <node pkg="map_based_prediction" exec="map_based_prediction" name="map_based_prediction" output="screen">
+    <param from="$(var prediction_time_horizon)" />
+    <param from="$(var prediction_sampling_delta_time)" />
+    <remap from="/vector_map" to="$(var vector_map_topic)"/>
   </node>
 </launch>

--- a/perception/object_recognition/prediction/map_based_prediction/launch/map_based_prediction.launch.xml
+++ b/perception/object_recognition/prediction/map_based_prediction/launch/map_based_prediction.launch.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 
 <launch>
-  <arg name="prediction_time_horizon" default="10" />
+  <arg name="prediction_time_horizon" default="10.0" />
   <arg name="prediction_sampling_delta_time" default="0.5" />
   <arg name="vector_map_topic" default="/map/vector_map" />
   <node pkg="map_based_prediction" exec="map_based_prediction" name="map_based_prediction" output="screen">
-    <param from="$(var prediction_time_horizon)" />
-    <param from="$(var prediction_sampling_delta_time)" />
+    <param name="$(var prediction_time_horizon)" />
+    <param name="$(var prediction_sampling_delta_time)" />
     <remap from="/vector_map" to="$(var vector_map_topic)"/>
   </node>
 </launch>

--- a/perception/object_recognition/prediction/map_based_prediction/package.xml
+++ b/perception/object_recognition/prediction/map_based_prediction/package.xml
@@ -13,6 +13,7 @@
   <depend>rclcpp</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>lanelet2_extension</depend>
+  <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>unique_identifier_msgs</depend>

--- a/perception/object_recognition/prediction/map_based_prediction/package.xml
+++ b/perception/object_recognition/prediction/map_based_prediction/package.xml
@@ -8,14 +8,16 @@
 
   <license>Apache</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>roscpp</depend>
+  <depend>rclcpp</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>lanelet2_extension</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>unique_identifier_msgs</depend>
 
   <export>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/perception/object_recognition/prediction/map_based_prediction/src/map_based_prediction.cpp
+++ b/perception/object_recognition/prediction/map_based_prediction/src/map_based_prediction.cpp
@@ -15,9 +15,6 @@
  */
 #include <chrono>
 
-#include <unique_id/unique_id.h>
-
-#include <autoware_perception_msgs/DynamicObjectArray.h>
 #include <tf2/utils.h>
 
 #include "cubic_spline.hpp"
@@ -33,7 +30,7 @@ MapBasedPrediction::MapBasedPrediction(
 }
 
 double calculateEuclideanDistance(
-  const geometry_msgs::Point & point1, const geometry_msgs::Point & point2)
+  const geometry_msgs::msg::Point & point1, const geometry_msgs::msg::Point & point2)
 {
   double dx = point1.x - point2.x;
   double dy = point1.y - point2.y;
@@ -42,8 +39,8 @@ double calculateEuclideanDistance(
 }
 
 bool getNearestPoint(
-  const std::vector<geometry_msgs::Point> & points, const geometry_msgs::Point point,
-  geometry_msgs::Point & nearest_point)
+  const std::vector<geometry_msgs::msg::Point> & points, const geometry_msgs::msg::Point point,
+  geometry_msgs::msg::Point & nearest_point)
 {
   double min_dist = 1e+10;
   bool flag = false;
@@ -59,8 +56,8 @@ bool getNearestPoint(
 }
 
 bool getNearestPointIdx(
-  const std::vector<geometry_msgs::Point> & points, const geometry_msgs::Point point,
-  geometry_msgs::Point & nearest_point, size_t & nearest_index)
+  const std::vector<geometry_msgs::msg::Point> & points, const geometry_msgs::msg::Point point,
+  geometry_msgs::msg::Point & nearest_point, size_t & nearest_index)
 {
   double min_dist = 10000000;
   bool flag = false;
@@ -80,8 +77,8 @@ bool getNearestPointIdx(
 
 bool MapBasedPrediction::doPrediction(
   const DynamicObjectWithLanesArray & in_objects,
-  std::vector<autoware_perception_msgs::DynamicObject> & out_objects,
-  std::vector<geometry_msgs::Point> & debug_interpolated_points)
+  std::vector<autoware_perception_msgs::msg::DynamicObject> & out_objects,
+  std::vector<geometry_msgs::msg::Point> & debug_interpolated_points)
 {
   std::chrono::high_resolution_clock::time_point begin = std::chrono::high_resolution_clock::now();
   for (auto & object_with_lanes : in_objects.objects) {
@@ -89,22 +86,22 @@ bool MapBasedPrediction::doPrediction(
     if (
       std::fabs(object_with_lanes.object.state.twist_covariance.twist.linear.x) <
       min_lon_velocity_ms_for_map_based_prediction) {
-      autoware_perception_msgs::PredictedPath predicted_path;
+      autoware_perception_msgs::msg::PredictedPath predicted_path;
       getLinearPredictedPath(
         object_with_lanes.object.state.pose_covariance.pose,
         object_with_lanes.object.state.twist_covariance.twist, in_objects.header, predicted_path);
-      autoware_perception_msgs::DynamicObject tmp_object;
+      autoware_perception_msgs::msg::DynamicObject tmp_object;
       tmp_object = object_with_lanes.object;
       tmp_object.state.predicted_paths.push_back(predicted_path);
       out_objects.push_back(tmp_object);
       continue;
     }
-    autoware_perception_msgs::DynamicObject tmp_object;
+    autoware_perception_msgs::msg::DynamicObject tmp_object;
     tmp_object = object_with_lanes.object;
     for (const auto & path : object_with_lanes.lanes) {
       std::vector<double> tmp_x;
       std::vector<double> tmp_y;
-      std::vector<geometry_msgs::Pose> geometry_points = path;
+      std::vector<geometry_msgs::msg::Pose> geometry_points = path;
       for (size_t i = 0; i < path.size(); i++) {
         if (i > 0) {
           double dist = calculateEuclideanDistance(
@@ -118,11 +115,11 @@ bool MapBasedPrediction::doPrediction(
       }
 
       Spline2D spline2d(tmp_x, tmp_y);
-      std::vector<geometry_msgs::Point> interpolated_points;
+      std::vector<geometry_msgs::msg::Point> interpolated_points;
       std::vector<double> interpolated_yaws;
       for (float s = 0.0; s < spline2d.s.back(); s += interpolating_resolution_) {
         std::array<double, 2> point1 = spline2d.calc_position(s);
-        geometry_msgs::Point g_point;
+        geometry_msgs::msg::Point g_point;
         g_point.x = point1[0];
         g_point.y = point1[1];
         g_point.z = object_with_lanes.object.state.pose_covariance.pose.position.z;
@@ -131,9 +128,9 @@ bool MapBasedPrediction::doPrediction(
       }
       debug_interpolated_points = interpolated_points;
 
-      geometry_msgs::Point object_point =
+      geometry_msgs::msg::Point object_point =
         object_with_lanes.object.state.pose_covariance.pose.position;
-      geometry_msgs::Point nearest_point;
+      geometry_msgs::msg::Point nearest_point;
       size_t nearest_point_idx;
       if (getNearestPointIdx(interpolated_points, object_point, nearest_point, nearest_point_idx)) {
         // calculate initial position in Frenet coordinate
@@ -157,9 +154,9 @@ bool MapBasedPrediction::doPrediction(
         double current_s_velocity =
           std::fabs(object_with_lanes.object.state.twist_covariance.twist.linear.x);
         double target_s_position = std::min(spline2d.s.back(), current_s_position + 10);
-        autoware_perception_msgs::PredictedPath path;
+        autoware_perception_msgs::msg::PredictedPath path;
 
-        geometry_msgs::PoseWithCovarianceStamped point;
+        geometry_msgs::msg::PoseWithCovarianceStamped point;
         point.pose.pose.position = object_point;
         getPredictedPath(
           object_point.z, current_d_position, current_d_velocity, current_s_position,
@@ -179,17 +176,17 @@ bool MapBasedPrediction::doPrediction(
 }
 
 bool MapBasedPrediction::doLinearPrediction(
-  const autoware_perception_msgs::DynamicObjectArray & in_objects,
-  std::vector<autoware_perception_msgs::DynamicObject> & out_objects)
+  const autoware_perception_msgs::msg::DynamicObjectArray & in_objects,
+  std::vector<autoware_perception_msgs::msg::DynamicObject> & out_objects)
 {
   std::chrono::high_resolution_clock::time_point begin = std::chrono::high_resolution_clock::now();
 
   for (const auto object : in_objects.objects) {
-    autoware_perception_msgs::PredictedPath path;
+    autoware_perception_msgs::msg::PredictedPath path;
     getLinearPredictedPath(
       object.state.pose_covariance.pose, object.state.twist_covariance.twist, in_objects.header,
       path);
-    autoware_perception_msgs::DynamicObject tmp_object;
+    autoware_perception_msgs::msg::DynamicObject tmp_object;
     tmp_object = object;
     tmp_object.state.predicted_paths.push_back(path);
     out_objects.push_back(tmp_object);
@@ -202,7 +199,7 @@ bool MapBasedPrediction::doLinearPrediction(
 }
 
 bool MapBasedPrediction::normalizeLikelyhood(
-  std::vector<autoware_perception_msgs::PredictedPath> & paths)
+  std::vector<autoware_perception_msgs::msg::PredictedPath> & paths)
 {
   // TODO: is could not be the smartest way
   double sum_confidence = 0;
@@ -218,8 +215,8 @@ bool MapBasedPrediction::normalizeLikelyhood(
 bool MapBasedPrediction::getPredictedPath(
   const double height, const double current_d_position, const double current_d_velocity,
   const double current_s_position, const double current_s_velocity, const double target_s_position,
-  const std_msgs::Header & origin_header, Spline2D & spline2d,
-  autoware_perception_msgs::PredictedPath & path)
+  const std_msgs::msg::Header & origin_header, Spline2D & spline2d,
+  autoware_perception_msgs::msg::PredictedPath & path)
 {
   // Quintic polynominal for d
   // A = np.array([[T**3, T**4, T**5],
@@ -271,7 +268,7 @@ bool MapBasedPrediction::getPredictedPath(
     calculated_s = current_s_position + current_s_velocity * i + 2 * 0 * i * i +
                    x_2(0) * i * i * i + x_2(1) * i * i * i * i;
 
-    geometry_msgs::PoseWithCovarianceStamped tmp_point;
+    geometry_msgs::msg::PoseWithCovarianceStamped tmp_point;
     if (calculated_s > spline2d.s.back()) {
       break;
     }
@@ -285,7 +282,7 @@ bool MapBasedPrediction::getPredictedPath(
     tmp_point.pose.pose.orientation.z = 0;
     tmp_point.pose.pose.orientation.w = 1;
     tmp_point.header = origin_header;
-    tmp_point.header.stamp = origin_header.stamp + ros::Duration(i);
+    tmp_point.header.stamp = rclcpp::Time(origin_header.stamp) + rclcpp::Duration(i);
     path.path.push_back(tmp_point);
   }
   path.confidence = calculateLikelyhood(current_d_position);
@@ -294,8 +291,8 @@ bool MapBasedPrediction::getPredictedPath(
 }
 
 bool MapBasedPrediction::getLinearPredictedPath(
-  const geometry_msgs::Pose & object_pose, const geometry_msgs::Twist & object_twist,
-  const std_msgs::Header & origin_header, autoware_perception_msgs::PredictedPath & predicted_path)
+  const geometry_msgs::msg::Pose & object_pose, const geometry_msgs::msg::Twist & object_twist,
+  const std_msgs::msg::Header & origin_header, autoware_perception_msgs::msg::PredictedPath & predicted_path)
 {
   const double yaw = tf2::getYaw(object_pose.orientation);
   const double & sampling_delta_time = sampling_delta_time_;
@@ -303,11 +300,11 @@ bool MapBasedPrediction::getLinearPredictedPath(
   const double ep = 0.001;
 
   for (double dt = 0.0; dt < time_horizon + ep; dt += sampling_delta_time) {
-    geometry_msgs::PoseWithCovarianceStamped pose_cov_stamped;
+    geometry_msgs::msg::PoseWithCovarianceStamped pose_cov_stamped;
     pose_cov_stamped.header = origin_header;
-    pose_cov_stamped.header.stamp = origin_header.stamp + ros::Duration(dt);
-    geometry_msgs::Pose object_frame_pose;
-    geometry_msgs::Pose world_frame_pose;
+    pose_cov_stamped.header.stamp = rclcpp::Time(origin_header.stamp) + rclcpp::Duration(dt);
+    geometry_msgs::msg::Pose object_frame_pose;
+    geometry_msgs::msg::Pose world_frame_pose;
     object_frame_pose.position.x = object_twist.linear.x * dt;
     object_frame_pose.position.y = object_twist.linear.y * dt;
     tf2::Transform tf_object2future;

--- a/perception/object_recognition/prediction/map_based_prediction/src/map_based_prediction_main.cpp
+++ b/perception/object_recognition/prediction/map_based_prediction/src/map_based_prediction_main.cpp
@@ -16,14 +16,13 @@
  *
  */
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include "map_based_prediction_ros.h"
 
 int main(int argc, char ** argv)
 {
-  ros::init(argc, argv, "map_based_prediction");
-  MapBasedPredictionROS ros_node;
-  ros_node.createROSPubSub();
-  ros::spin();
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<MapBasedPredictionROS>());
+  rclcpp::shutdown();
   return 0;
 }

--- a/perception/object_recognition/prediction/map_based_prediction/src/map_based_prediction_ros.cpp
+++ b/perception/object_recognition/prediction/map_based_prediction/src/map_based_prediction_ros.cpp
@@ -42,13 +42,11 @@
 #include "map_based_prediction_ros.h"
 
 std::string toHexString(const unique_identifier_msgs::msg::UUID & id){
-  auto begin = id.uuid.begin();
-  auto end = id.uuid.end();
-  std::ostringstream hex;
-  hex << std::hex;
-  while (begin != end)
-      hex << static_cast<unsigned>(*begin++);
-  return hex.str();
+  std::stringstream ss;
+    for (auto i = 0; i < 16; ++i) {
+        ss << std::hex << std::setfill('0') << std::setw(2) << +id.uuid[i];
+    }
+    return ss.str();
 }
 
 bool MapBasedPredictionROS::getClosestLanelets(

--- a/perception/object_recognition/prediction/map_based_prediction/src/map_based_prediction_ros.cpp
+++ b/perception/object_recognition/prediction/map_based_prediction/src/map_based_prediction_ros.cpp
@@ -19,19 +19,13 @@
 #include <cmath>
 #include <unordered_map>
 
-#include <unique_id/unique_id.h>
-#include <uuid_msgs/UniqueID.h>
+#include <unique_identifier_msgs/msg/uuid.hpp>
 
 // headers in ROS
-#include <autoware_lanelet2_msgs/MapBin.h>
-#include <autoware_perception_msgs/DynamicObject.h>
-#include <autoware_perception_msgs/DynamicObjectArray.h>
-#include <geometry_msgs/Pose.h>
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <tf2/utils.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/transform_listener.h>
-#include <visualization_msgs/MarkerArray.h>
 
 // lanelet
 #include <lanelet2_core/LaneletMap.h>
@@ -47,8 +41,18 @@
 #include "map_based_prediction.h"
 #include "map_based_prediction_ros.h"
 
+std::string toHexString(const unique_identifier_msgs::msg::UUID & id){
+  auto begin = id.uuid.begin();
+  auto end = id.uuid.end();
+  std::ostringstream hex;
+  hex << std::hex;
+  while (begin != end)
+      hex << static_cast<unsigned>(*begin++);
+  return hex.str();
+}
+
 bool MapBasedPredictionROS::getClosestLanelets(
-  const autoware_perception_msgs::DynamicObject & object,
+  const autoware_perception_msgs::msg::DynamicObject & object,
   const lanelet::LaneletMapPtr & lanelet_map_ptr_, std::vector<lanelet::Lanelet> & closest_lanelets,
   std::string uuid_string)
 {
@@ -68,7 +72,6 @@ bool MapBasedPredictionROS::getClosestLanelets(
   if (uuid2laneids_.size() == 0 || uuid2laneids_.count(uuid_string) == 0) {
     bool is_found_target_closest_lanelet = false;
     const double max_delta_yaw_threshold = M_PI / 4.;
-    double min_delta_yaw = 999999999;
     const double max_dist_for_searching_lanelet = 3;
     lanelet::Lanelet target_closest_lanelet;
     for (const auto & lanelet : nearest_lanelets) {
@@ -76,8 +79,8 @@ bool MapBasedPredictionROS::getClosestLanelets(
       if (object.state.orientation_reliable) {
         object_yaw = tf2::getYaw(object.state.pose_covariance.pose.orientation);
       } else {
-        geometry_msgs::Pose object_frame_pose;
-        geometry_msgs::Pose map_frame_pose;
+        geometry_msgs::msg::Pose object_frame_pose;
+        geometry_msgs::msg::Pose map_frame_pose;
         object_frame_pose.position.x = object.state.twist_covariance.twist.linear.x * 0.1;
         object_frame_pose.position.y = object.state.twist_covariance.twist.linear.y * 0.1;
         tf2::Transform tf_object2future;
@@ -126,8 +129,8 @@ bool MapBasedPredictionROS::getClosestLanelets(
         if (object.state.orientation_reliable) {
           object_yaw = tf2::getYaw(object.state.pose_covariance.pose.orientation);
         } else {
-          geometry_msgs::Pose object_frame_pose;
-          geometry_msgs::Pose map_frame_pose;
+          geometry_msgs::msg::Pose object_frame_pose;
+          geometry_msgs::msg::Pose map_frame_pose;
           object_frame_pose.position.x = object.state.twist_covariance.twist.linear.x * 0.1;
           object_frame_pose.position.y = object.state.twist_covariance.twist.linear.y * 0.1;
           tf2::Transform tf_object2future;
@@ -168,7 +171,7 @@ bool MapBasedPredictionROS::getClosestLanelets(
   return false;
 }
 
-double calculateDistance(const geometry_msgs::Point & point1, const geometry_msgs::Point & point2)
+double calculateDistance(const geometry_msgs::msg::Point & point1, const geometry_msgs::msg::Point & point2)
 {
   double dx = point1.x - point2.x;
   double dy = point1.y - point2.y;
@@ -176,30 +179,31 @@ double calculateDistance(const geometry_msgs::Point & point1, const geometry_msg
   return distance;
 }
 
-MapBasedPredictionROS::MapBasedPredictionROS() : pnh_("~"), interpolating_resolution_(0.5)
+MapBasedPredictionROS::MapBasedPredictionROS() 
+: Node("map_based_prediction"), interpolating_resolution_(0.5)
 {
-  tf_buffer_ptr_ = std::make_shared<tf2_ros::Buffer>();
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  tf_buffer_ptr_ = std::make_shared<tf2_ros::Buffer>(clock);
   tf_listener_ptr_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_ptr_);
-  pnh_.param<bool>("map_based_prediction/has_subscribed_map", has_subscribed_map_, false);
-  pnh_.param<double>("prediction_time_horizon", prediction_time_horizon_, 10.0);
-  pnh_.param<double>("prediction_sampling_delta_time", prediction_sampling_delta_time_, 0.5);
+  has_subscribed_map_ = declare_parameter("map_based_prediction/has_subscribed_map", false);
+  prediction_time_horizon_ = declare_parameter("prediction_time_horizon", 10.0);
+  prediction_sampling_delta_time_ = declare_parameter("prediction_sampling_delta_time", 0.5);
   map_based_prediction_ = std::make_shared<MapBasedPrediction>(
     interpolating_resolution_, prediction_time_horizon_, prediction_sampling_delta_time_);
-}
 
-void MapBasedPredictionROS::createROSPubSub()
-{
-  sub_objects_ = nh_.subscribe<autoware_perception_msgs::DynamicObjectArray>(
-    "/perception/object_recognition/tracking/objects", 1, &MapBasedPredictionROS::objectsCallback,
-    this);
-  sub_map_ = nh_.subscribe("/vector_map", 10, &MapBasedPredictionROS::mapCallback, this);
+  sub_objects_ = this->create_subscription<autoware_perception_msgs::msg::DynamicObjectArray>(
+    "/perception/object_recognition/tracking/objects", 1, 
+    std::bind(&MapBasedPredictionROS::objectsCallback, this, std::placeholders::_1));
+  sub_map_ = this->create_subscription<autoware_lanelet2_msgs::msg::MapBin>(
+    "/vector_map", 10, 
+    std::bind(&MapBasedPredictionROS::mapCallback, this, std::placeholders::_1));
 
-  pub_objects_ = nh_.advertise<autoware_perception_msgs::DynamicObjectArray>("objects", 1);
-  pub_markers_ = nh_.advertise<visualization_msgs::MarkerArray>("objects_path_markers", 1);
+  pub_objects_ = this->create_publisher<autoware_perception_msgs::msg::DynamicObjectArray>("objects", 1);
+  pub_markers_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("objects_path_markers", 1);
 }
 
 void MapBasedPredictionROS::objectsCallback(
-  const autoware_perception_msgs::DynamicObjectArrayConstPtr & in_objects)
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr in_objects)
 {
   debug_accumulated_time_ = 0.0;
   std::chrono::high_resolution_clock::time_point begin = std::chrono::high_resolution_clock::now();
@@ -208,27 +212,27 @@ void MapBasedPredictionROS::objectsCallback(
     return;
   }
 
-  geometry_msgs::TransformStamped world2map_transform;
-  geometry_msgs::TransformStamped map2world_transform;
-  geometry_msgs::TransformStamped debug_map2lidar_transform;
+  geometry_msgs::msg::TransformStamped world2map_transform;
+  geometry_msgs::msg::TransformStamped map2world_transform;
+  geometry_msgs::msg::TransformStamped debug_map2lidar_transform;
   try {
     world2map_transform = tf_buffer_ptr_->lookupTransform(
       "map",                        // target
       in_objects->header.frame_id,  // src
-      in_objects->header.stamp, ros::Duration(0.1));
+      in_objects->header.stamp, rclcpp::Duration(0.1));
     map2world_transform = tf_buffer_ptr_->lookupTransform(
       in_objects->header.frame_id,  // target
       "map",                        // src
-      in_objects->header.stamp, ros::Duration(0.1));
+      in_objects->header.stamp, rclcpp::Duration(0.1));
     debug_map2lidar_transform = tf_buffer_ptr_->lookupTransform(
       "base_link",  // target
       "map",        // src
-      ros::Time(), ros::Duration(0.1));
+      rclcpp::Time(), rclcpp::Duration(0.1));
   } catch (tf2::TransformException & ex) {
     return;
   }
 
-  autoware_perception_msgs::DynamicObjectArray tmp_objects_whitout_map;
+  autoware_perception_msgs::msg::DynamicObjectArray tmp_objects_whitout_map;
   tmp_objects_whitout_map.header = in_objects->header;
   DynamicObjectWithLanesArray prediction_input;
   prediction_input.header = in_objects->header;
@@ -237,30 +241,34 @@ void MapBasedPredictionROS::objectsCallback(
     DynamicObjectWithLanes tmp_object;
     tmp_object.object = object;
     if (in_objects->header.frame_id != "map") {
-      geometry_msgs::Pose pose_in_map;
-      tf2::doTransform(object.state.pose_covariance.pose, pose_in_map, world2map_transform);
-      tmp_object.object.state.pose_covariance.pose = pose_in_map;
+      geometry_msgs::msg::PoseStamped pose_in_map;
+      geometry_msgs::msg::PoseStamped pose_orig;
+      pose_orig.pose = object.state.pose_covariance.pose;
+      tf2::doTransform(pose_orig, pose_in_map, world2map_transform);
+      tmp_object.object.state.pose_covariance.pose = pose_in_map.pose;
     }
 
     if (
-      object.semantic.type != autoware_perception_msgs::Semantic::CAR &&
-      object.semantic.type != autoware_perception_msgs::Semantic::BUS &&
-      object.semantic.type != autoware_perception_msgs::Semantic::TRUCK) {
+      object.semantic.type != autoware_perception_msgs::msg::Semantic::CAR &&
+      object.semantic.type != autoware_perception_msgs::msg::Semantic::BUS &&
+      object.semantic.type != autoware_perception_msgs::msg::Semantic::TRUCK) {
       tmp_objects_whitout_map.objects.push_back(tmp_object.object);
       continue;
     }
 
     // generate non redundant lanelet vector
     std::vector<lanelet::Lanelet> start_lanelets;
-    geometry_msgs::Point closest_point;
-    std::vector<geometry_msgs::Pose> path_points;
-    std::vector<geometry_msgs::Pose> second_path_points;
-    std::vector<geometry_msgs::Pose> right_path_points;
-    std::string uuid_string = unique_id::toHexString(object.id);
+    geometry_msgs::msg::Point closest_point;
+    std::vector<geometry_msgs::msg::Pose> path_points;
+    std::vector<geometry_msgs::msg::Pose> second_path_points;
+    std::vector<geometry_msgs::msg::Pose> right_path_points;
+    std::string uuid_string = toHexString(object.id);
     if (!getClosestLanelets(tmp_object.object, lanelet_map_ptr_, start_lanelets, uuid_string)) {
-      geometry_msgs::Point debug_point;
+      geometry_msgs::msg::PointStamped debug_point;
+      geometry_msgs::msg::PointStamped point_orig;
+      point_orig.point = tmp_object.object.state.pose_covariance.pose.position;
       tf2::doTransform(
-        tmp_object.object.state.pose_covariance.pose.position, debug_point,
+        point_orig, debug_point,
         debug_map2lidar_transform);
       tmp_objects_whitout_map.objects.push_back(object);
       continue;
@@ -328,9 +336,11 @@ void MapBasedPredictionROS::objectsCallback(
       paths.insert(paths.end(), left_paths.begin(), left_paths.end());
     }
     if (paths.size() == 0) {
-      geometry_msgs::Point debug_point;
+      geometry_msgs::msg::PointStamped debug_point;
+      geometry_msgs::msg::PointStamped point_orig;
+      point_orig.point = tmp_object.object.state.pose_covariance.pose.position;
       tf2::doTransform(
-        tmp_object.object.state.pose_covariance.pose.position, debug_point,
+        point_orig, debug_point,
         debug_map2lidar_transform);
       tmp_objects_whitout_map.objects.push_back(object);
       continue;
@@ -343,7 +353,7 @@ void MapBasedPredictionROS::objectsCallback(
       }
     }
 
-    std::string uid_string = unique_id::toHexString(object.id);
+    std::string uid_string = toHexString(object.id);
     if (uuid2laneids_.count(uid_string) == 0) {
       uuid2laneids_.emplace(uid_string, lanelet_ids);
     } else {
@@ -364,15 +374,15 @@ void MapBasedPredictionROS::objectsCallback(
       }
     }
 
-    std::vector<std::vector<geometry_msgs::Pose>> tmp_paths;
+    std::vector<std::vector<geometry_msgs::msg::Pose>> tmp_paths;
     for (const auto & path : paths) {
-      std::vector<geometry_msgs::Pose> tmp_path;
+      std::vector<geometry_msgs::msg::Pose> tmp_path;
       if (!path.empty()) {
         lanelet::ConstLanelets prev_lanelets = routing_graph_ptr_->previous(path.front());
         if (!prev_lanelets.empty()) {
           lanelet::ConstLanelet prev_lanelet = prev_lanelets.front();
           for (const auto & point : prev_lanelet.centerline()) {
-            geometry_msgs::Pose tmp_pose;
+            geometry_msgs::msg::Pose tmp_pose;
             tmp_pose.position.x = point.x();
             tmp_pose.position.y = point.y();
             tmp_pose.position.z = point.z();
@@ -382,7 +392,7 @@ void MapBasedPredictionROS::objectsCallback(
       }
       for (const auto & lanelet : path) {
         for (const auto & point : lanelet.centerline()) {
-          geometry_msgs::Pose tmp_pose;
+          geometry_msgs::msg::Pose tmp_pose;
           tmp_pose.position.x = point.x();
           tmp_pose.position.y = point.y();
           tmp_pose.position.z = point.z();
@@ -398,26 +408,26 @@ void MapBasedPredictionROS::objectsCallback(
   std::chrono::high_resolution_clock::time_point end = std::chrono::high_resolution_clock::now();
   std::chrono::nanoseconds time = std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin);
 
-  std::vector<autoware_perception_msgs::DynamicObject> out_objects_in_map;
-  std::vector<geometry_msgs::Point> interpolated_points;
+  std::vector<autoware_perception_msgs::msg::DynamicObject> out_objects_in_map;
+  std::vector<geometry_msgs::msg::Point> interpolated_points;
   map_based_prediction_->doPrediction(prediction_input, out_objects_in_map, interpolated_points);
-  autoware_perception_msgs::DynamicObjectArray output;
+  autoware_perception_msgs::msg::DynamicObjectArray output;
   output.header = in_objects->header;
   output.header.frame_id = "map";
   output.objects = out_objects_in_map;
 
-  std::vector<autoware_perception_msgs::DynamicObject> out_objects_without_map;
+  std::vector<autoware_perception_msgs::msg::DynamicObject> out_objects_without_map;
   map_based_prediction_->doLinearPrediction(tmp_objects_whitout_map, out_objects_without_map);
   output.objects.insert(
     output.objects.begin(), out_objects_without_map.begin(), out_objects_without_map.end());
-  pub_objects_.publish(output);
+  pub_objects_->publish(output);
 }
 
-void MapBasedPredictionROS::mapCallback(const autoware_lanelet2_msgs::MapBin & msg)
+void MapBasedPredictionROS::mapCallback(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr msg)
 {
-  ROS_INFO("Start loading lanelet");
+  RCLCPP_INFO(get_logger(), "Start loading lanelet");
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
   lanelet::utils::conversion::fromBinMsg(
-    msg, lanelet_map_ptr_, &traffic_rules_ptr_, &routing_graph_ptr_);
-  ROS_INFO("Map is loaded");
+    *msg, lanelet_map_ptr_, &traffic_rules_ptr_, &routing_graph_ptr_);
+  RCLCPP_INFO(get_logger(), "Map is loaded");
 }


### PR DESCRIPTION
Port of `map_based_prediction` to ROS2.

I've added a `toHexString` function [here](https://github.com/tier4/Pilot.Auto/pull/95/files#diff-6609d065fa15d5b881b14c3a7b45a522484085c047f05d28f884ca8e27dda4b3R44) as it seems `unique_id::toHexString` is not available.

Signed-off-by: Servando German Serrano <servando.german.serrano@linaro.org>