### PR TITLE
Revert "Add geometry2 to repos (#76)"

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,6 +28,10 @@ jobs:
         rosdep update
         DEBIAN_FRONTEND=noninteractive rosdep install --from-paths . --ignore-src --rosdistro foxy -y
 
+    - name: Show ros-foxy-tf2 version
+      run: |
+        apt show ros-foxy-tf2
+
     - name: Build
       run: |
         . /opt/ros/foxy/setup.sh

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,10 +28,6 @@ jobs:
         rosdep update
         DEBIAN_FRONTEND=noninteractive rosdep install --from-paths . --ignore-src --rosdistro foxy -y
 
-    - name: Show ros-foxy-tf2 version
-      run: |
-        apt show ros-foxy-tf2
-
     - name: Build
       run: |
         . /opt/ros/foxy/setup.sh

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,9 +24,14 @@ jobs:
 
     - name: Install missing dependencies
       run: |
-        sudo apt update
+        sudo apt-get update
         rosdep update
         DEBIAN_FRONTEND=noninteractive rosdep install --from-paths . --ignore-src --rosdistro foxy -y
+        sudo apt-get install -y \
+          ros-foxy-tf2>=0.13.6-1focal.20201028.172335 \
+          ros-foxy-tf2-geometry-msgs>=0.13.6-1focal.20201028.172335 \
+          ros-foxy-tf2-ros>=0.13.6-1focal.20201028.172335 \
+          ros-foxy-tf2-sensor-msgs>=0.13.6-1focal.20201028.172335
 
     - name: Build
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,20 +43,4 @@ jobs:
         . /opt/ros/foxy/setup.sh
         colcon test \
           --event-handlers console_cohesion+ \
-          --return-code-on-test-failure \
-          --packages-skip \
-            tf2_msgs \
-            tf2_kdl \
-            tf2_py \
-            geometry2 \
-            test_tf2 \
-            tf2_eigen \
-            tf2_ros \
-            tf2_tools \
-            tf2_sensor_msgs \
-            tf2_geometry_msgs \
-            geometry_experimental \
-            tf2_bullet \
-            examples_tf2_py \
-            tf2
-          # Skip geometry2 packages until they are released
+          --return-code-on-test-failure

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -7,12 +7,6 @@ repositories:
     type: git
     url: https://github.com/tier4/ublox.git
     version: foxy-devel
-  # temporary adding geometry2 package to add support for transforming covariance
-  # TODO(mitsudome-r): remove after geometry2 package is released in Foxy anytime after 2020/10/30
-  vendor/geometry2:
-    type: git
-    url: https://github.com/ros2/geometry2.git
-    version: foxy
   vendor/grid_map:
     type: git
     url: https://github.com/mitsudome-r/grid_map.git
@@ -29,4 +23,3 @@ repositories:
     type: git
     url: https://github.com/ApexAI/topic_tools.git
     version: autoware
-    

--- a/localization/twist_estimator/pose2twist/package.xml
+++ b/localization/twist_estimator/pose2twist/package.xml
@@ -11,7 +11,6 @@
     <depend>geometry_msgs</depend>
     <depend>rclcpp</depend>
     <depend>std_msgs</depend>
-    <depend>tf2</depend>
     <depend>tf2_geometry_msgs</depend>
 
     <export>

--- a/localization/twist_estimator/pose2twist/package.xml
+++ b/localization/twist_estimator/pose2twist/package.xml
@@ -11,6 +11,7 @@
     <depend>geometry_msgs</depend>
     <depend>rclcpp</depend>
     <depend>std_msgs</depend>
+    <depend>tf2</depend>
     <depend>tf2_geometry_msgs</depend>
 
     <export>

--- a/map/lanelet2_extension/package.xml
+++ b/map/lanelet2_extension/package.xml
@@ -22,8 +22,6 @@
   <depend>lanelet2_validation</depend>
   <depend>autoware_lanelet2_msgs</depend>
   <depend>geometry_msgs</depend>
-  <depend>tf2</depend>
-  <depend>tf2_geometry_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>pugixml-dev</depend>
 

--- a/map/lanelet2_extension/package.xml
+++ b/map/lanelet2_extension/package.xml
@@ -22,6 +22,8 @@
   <depend>lanelet2_validation</depend>
   <depend>autoware_lanelet2_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>pugixml-dev</depend>
 

--- a/planning/mission_planning/mission_planner/package.xml
+++ b/planning/mission_planning/mission_planner/package.xml
@@ -14,7 +14,6 @@
   <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
   <depend>rclcpp</depend>
-  <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
 

--- a/planning/mission_planning/mission_planner/package.xml
+++ b/planning/mission_planning/mission_planner/package.xml
@@ -14,6 +14,7 @@
   <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
   <depend>rclcpp</depend>
+  <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
 


### PR DESCRIPTION
https://github.com/ros/rosdistro/pull/27177 is now available through the ROS package repositories: I upgraded my system in ADE today and got 

```
$ apt show ros-foxy-tf2
Package: ros-foxy-tf2
Version: 0.13.6-1focal.20201028.172335
```

which is the version that has the PR required for `ndt_scan_matcher`.