### PR TITLE
Port lidar apollo instance segmentation

### DIFF
--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/CMakeLists.txt
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/CMakeLists.txt
@@ -145,6 +145,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
 
   ament_auto_package(INSTALL_TO_SHARE
     launch
+    config
     data
   )
 

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/CMakeLists.txt
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(lidar_apollo_instance_segmentation)
 
 option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
@@ -90,41 +90,28 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     execute_process(COMMAND gdown "https://drive.google.com/uc?id=1izpNotNxS6mrYIzJwHQ_EyX_IPDU-MBr" -O ${PATH}/vls-128.caffemodel)
   endif()
 
-  find_package(catkin REQUIRED COMPONENTS
-    roscpp
-    roslib
-    pcl_ros
-    tf2
-    tf2_geometry_msgs
-    tf2_eigen
-    tf2_ros
-    autoware_perception_msgs
-  )
-  set(CMAKE_CXX_STANDARD 14)
+  find_package(ament_cmake_auto REQUIRED)
+  ament_auto_find_build_dependencies()
+  find_package(PCL REQUIRED)
+  
+  if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 14)
+  endif()
+  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
+  endif()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -O3")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_MWAITXINTRIN_H_INCLUDED")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORCE_INLINES")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STRICT_ANSI__")
 
-  catkin_package(
-    INCLUDE_DIRS
-      include
-    CATKIN_DEPENDS
-      roscpp
-      roslib
-      pcl_ros
-      autoware_perception_msgs
-  )
-
   include_directories(
-    include
     lib/include
     ${CUDA_INCLUDE_DIRS}
-    ${catkin_INCLUDE_DIRS}
-    ${PCL_INCLUDE_DIR}
+    ${PCL_INCLUDE_DIRS}
   )
 
-  add_executable(lidar_apollo_instance_segmentation_node
+  ament_auto_add_executable(lidar_apollo_instance_segmentation_node
   src/main.cpp
   src/node.cpp
   src/detector.cpp
@@ -133,13 +120,10 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
   src/feature_map.cpp
   src/cluster2d.cpp
   src/debugger.cpp
-)
-
-  add_dependencies(lidar_apollo_instance_segmentation_node
-    ${catkin_EXPORTED_TARGETS}
   )
 
-  add_library(tensorrt_apollo_cnn_lib
+
+  ament_auto_add_library(tensorrt_apollo_cnn_lib SHARED
     lib/src/TrtNet.cpp
   )
 
@@ -151,42 +135,26 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     ${CUBLAS_LIBRARIES}
     ${CUDA_curand_LIBRARY}
     ${CUDNN_LIBRARY}
+    ${PCL_LIBRARIES}
   )
 
   target_link_libraries(lidar_apollo_instance_segmentation_node
-    ${catkin_LIBRARIES}
     tensorrt_apollo_cnn_lib
   )
 
 
-  install(
-    TARGETS
-      tensorrt_apollo_cnn_lib
-      lidar_apollo_instance_segmentation_node
-    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-  )
-
-  install(DIRECTORY launch/
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
-  )
-
-  install(DIRECTORY data/
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/data
-  )
-
-  install(DIRECTORY include/
-    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}/${PROJECT_NAME}/
+  ament_auto_package(INSTALL_TO_SHARE
+    launch
+    data
   )
 
 else()
-  find_package(catkin REQUIRED)
-  catkin_package()
+  find_package(ament_cmake_auto REQUIRED)
+  ament_auto_find_build_dependencies()
 
   # to avoid launch file missing without a gpu
-  install(DIRECTORY launch/
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+  ament_auto_package(INSTALL_TO_SHARE
+    launch
   )
 
 endif()

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/config/hdl-64.param.yaml
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/config/hdl-64.param.yaml
@@ -1,0 +1,8 @@
+/**:
+    ros__parameters:
+      score_threshold: 0.1
+      range: 70
+      width: 672
+      height: 672
+      use_intensity_feature: true
+      use_constant_feature: false

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/config/vlp-16.param.yaml
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/config/vlp-16.param.yaml
@@ -1,0 +1,8 @@
+/**:
+    ros__parameters:
+      score_threshold: 0.1
+      range: 70
+      width: 672
+      height: 672
+      use_intensity_feature: true
+      use_constant_feature: false

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/config/vls-128.param.yaml
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/config/vls-128.param.yaml
@@ -1,0 +1,8 @@
+/**:
+    ros__parameters:
+      score_threshold: 0.1
+      range: 90
+      width: 864
+      height: 864
+      use_intensity_feature: false
+      use_constant_feature: false

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/cluster2d.h
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/cluster2d.h
@@ -49,17 +49,18 @@
 #define CLUSTER2D_H
 
 #include <pcl/point_types.h>
-#include <pcl_ros/point_cloud.h>
+#include <pcl/point_cloud.h>
+#include <pcl/PointIndices.h>
 #include <memory>
 #include <vector>
 
 #include "disjoint_set.h"
 #include "util.h"
 
-#include <autoware_perception_msgs/DynamicObjectWithFeature.h>
-#include <autoware_perception_msgs/DynamicObjectWithFeatureArray.h>
+#include <autoware_perception_msgs/msg/dynamic_object_with_feature.hpp>
+#include <autoware_perception_msgs/msg/dynamic_object_with_feature_array.hpp>
 
-#include <std_msgs/Header.h>
+#include <std_msgs/msg/header.hpp>
 
 enum MetaType {
   META_UNKNOWN,
@@ -104,11 +105,11 @@ public:
 
   void getObjects(
     const float confidence_thresh, const float height_thresh, const int min_pts_num,
-    autoware_perception_msgs::DynamicObjectWithFeatureArray & objects,
-    const std_msgs::Header & in_header);
+    autoware_perception_msgs::msg::DynamicObjectWithFeatureArray & objects,
+    const std_msgs::msg::Header & in_header);
 
-  autoware_perception_msgs::DynamicObjectWithFeature obstacleToObject(
-    const Obstacle & in_obstacle, const std_msgs::Header & in_header);
+  autoware_perception_msgs::msg::DynamicObjectWithFeature obstacleToObject(
+    const Obstacle & in_obstacle, const std_msgs::msg::Header & in_header);
 
 private:
   int rows_;

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/debugger.h
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/debugger.h
@@ -15,19 +15,17 @@
  */
 
 #pragma once
-#include <ros/ros.h>
-#include "autoware_perception_msgs/DynamicObjectWithFeatureArray.h"
+#include <rclcpp/rclcpp.hpp>
+#include "autoware_perception_msgs/msg/dynamic_object_with_feature_array.hpp"
 
 class Debugger
 {
 public:
-  Debugger();
+  Debugger(const rclcpp::Node::SharedPtr & node);
   ~Debugger(){};
-  ros::Publisher instance_pointcloud_pub_;
   void publishColoredPointCloud(
-    const autoware_perception_msgs::DynamicObjectWithFeatureArray & input);
+    const autoware_perception_msgs::msg::DynamicObjectWithFeatureArray & input);
 
 private:
-  ros::NodeHandle nh_;
-  ros::NodeHandle pnh_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr instance_pointcloud_pub_;
 };

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/debugger.h
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/debugger.h
@@ -21,7 +21,7 @@
 class Debugger
 {
 public:
-  Debugger(const rclcpp::Node::SharedPtr & node);
+  Debugger(rclcpp::Node * node);
   ~Debugger(){};
   void publishColoredPointCloud(
     const autoware_perception_msgs::msg::DynamicObjectWithFeatureArray & input);

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/detector.h
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/detector.h
@@ -20,29 +20,28 @@
 #include "feature_generator.h"
 #include "lidar_apollo_instance_segmentation/node.h"
 
+#include <tf2_ros/buffer_interface.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_eigen/tf2_eigen.h>
-#include <pcl_ros/transforms.h>
+#include <pcl/common/transforms.h>
 #include <memory>
 
 class LidarApolloInstanceSegmentation : public LidarInstanceSegmentationInterface
 {
 public:
-  LidarApolloInstanceSegmentation();
+  LidarApolloInstanceSegmentation(const rclcpp::Node::SharedPtr & node);
   ~LidarApolloInstanceSegmentation(){};
   bool detectDynamicObjects(
-    const sensor_msgs::PointCloud2 & input,
-    autoware_perception_msgs::DynamicObjectWithFeatureArray & output) override;
+    const sensor_msgs::msg::PointCloud2 & input,
+    autoware_perception_msgs::msg::DynamicObjectWithFeatureArray & output) override;
 
 private:
   bool transformCloud(
-    const sensor_msgs::PointCloud2 & input,
-    sensor_msgs::PointCloud2& transformed_cloud,
+    const sensor_msgs::msg::PointCloud2 & input,
+    sensor_msgs::msg::PointCloud2& transformed_cloud,
     float z_offset);
 
-  ros::NodeHandle nh_;
-  ros::NodeHandle pnh_;
-
+  const rclcpp::Node::SharedPtr node_;
   std::unique_ptr<Tn::trtNet> net_ptr_;
   std::shared_ptr<Cluster2D> cluster2d_;
   std::shared_ptr<FeatureGenerator> feature_generator_;

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/detector.h
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/detector.h
@@ -29,7 +29,7 @@
 class LidarApolloInstanceSegmentation : public LidarInstanceSegmentationInterface
 {
 public:
-  LidarApolloInstanceSegmentation(const rclcpp::Node::SharedPtr & node);
+  LidarApolloInstanceSegmentation(rclcpp::Node * node);
   ~LidarApolloInstanceSegmentation(){};
   bool detectDynamicObjects(
     const sensor_msgs::msg::PointCloud2 & input,
@@ -41,7 +41,7 @@ private:
     sensor_msgs::msg::PointCloud2& transformed_cloud,
     float z_offset);
 
-  const rclcpp::Node::SharedPtr node_;
+  rclcpp::Node * node_;
   std::unique_ptr<Tn::trtNet> net_ptr_;
   std::shared_ptr<Cluster2D> cluster2d_;
   std::shared_ptr<FeatureGenerator> feature_generator_;

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/feature_generator.h
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/feature_generator.h
@@ -24,10 +24,10 @@
 class FeatureGenerator
 {
 private:
-  bool use_intensity_feature_;
-  bool use_constant_feature_;
   float min_height_;
   float max_height_;
+  bool use_intensity_feature_;
+  bool use_constant_feature_;
   std::shared_ptr<FeatureMapInterface> map_ptr_;
 
 public:

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/feature_generator.h
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/feature_generator.h
@@ -16,7 +16,7 @@
 
 #pragma once
 #include <pcl/point_types.h>
-#include <pcl_ros/point_cloud.h>
+#include <pcl/point_cloud.h>
 #include <memory>
 #include "lidar_apollo_instance_segmentation/feature_map.h"
 #include "util.h"

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/node.h
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/node.h
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 #pragma once
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include <autoware_perception_msgs/DynamicObjectWithFeatureArray.h>
-#include <sensor_msgs/PointCloud2.h>
+#include <autoware_perception_msgs/msg/dynamic_object_with_feature_array.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 #include <memory>
 
 #include "lidar_apollo_instance_segmentation/debugger.h"
@@ -28,20 +28,18 @@ public:
   LidarInstanceSegmentationInterface() {}
   virtual ~LidarInstanceSegmentationInterface() {}
   virtual bool detectDynamicObjects(
-    const sensor_msgs::PointCloud2 & input,
-    autoware_perception_msgs::DynamicObjectWithFeatureArray & output) = 0;
+    const sensor_msgs::msg::PointCloud2 & input,
+    autoware_perception_msgs::msg::DynamicObjectWithFeatureArray & output) = 0;
 };
 
-class LidarInstanceSegmentationNode
+class LidarInstanceSegmentationNode : public rclcpp::Node
 {
 private:
-  ros::NodeHandle nh_;
-  ros::NodeHandle pnh_;
-  ros::Subscriber pointcloud_sub_;
-  ros::Publisher dynamic_objects_pub_;
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_sub_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::DynamicObjectWithFeatureArray>::SharedPtr dynamic_objects_pub_;
   std::shared_ptr<LidarInstanceSegmentationInterface> detector_ptr_;
-  Debugger debugger_;
-  void pointCloudCallback(const sensor_msgs::PointCloud2 & msg);
+  std::shared_ptr<Debugger> debugger_ptr_;
+  void pointCloudCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
 
 public:
   LidarInstanceSegmentationNode();

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/node.h
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/node.h
@@ -44,4 +44,5 @@ private:
 public:
   LidarInstanceSegmentationNode();
   ~LidarInstanceSegmentationNode() {}
+  void init();
 };

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/node.h
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/node.h
@@ -44,5 +44,4 @@ private:
 public:
   LidarInstanceSegmentationNode();
   ~LidarInstanceSegmentationNode() {}
-  void init();
 };

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/launch/lidar_apollo_instance_segmentation.launch.xml
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/launch/lidar_apollo_instance_segmentation.launch.xml
@@ -2,64 +2,27 @@
   <arg name="model" default="model_128" />
   <arg name="output/objects" default="labeled_clusters" />
 
-  <arg if="$(eval model=='model_16')" name="trained_engine_file" default="$(find lidar_apollo_instance_segmentation)/data/vlp-16.engine" />
-  <arg if="$(eval model=='model_16')" name="trained_prototxt_file" default="$(find lidar_apollo_instance_segmentation)/data/vlp-16.prototxt" />
-  <arg if="$(eval model=='model_16')" name="trained_caffemodel_file" default="$(find lidar_apollo_instance_segmentation)/data/vlp-16.caffemodel" />
+  <arg if="$(eval &quot;'$(var model)'=='model_16'&quot;)" name="base_name" default="vlp-16" />
+  <arg if="$(eval &quot;'$(var model)'=='model_64'&quot;)" name="base_name" default="hdl-64" />
+  <arg if="$(eval &quot;'$(var model)'=='model_128'&quot;)" name="base_name" default="vls-128" />
 
-  <arg if="$(eval model=='model_64')" name="trained_engine_file" default="$(find lidar_apollo_instance_segmentation)/data/hdl-64.engine" />
-  <arg if="$(eval model=='model_64')" name="trained_prototxt_file" default="$(find lidar_apollo_instance_segmentation)/data/hdl-64.prototxt" />
-  <arg if="$(eval model=='model_64')" name="trained_caffemodel_file" default="$(find lidar_apollo_instance_segmentation)/data/hdl-64.caffemodel" />
+  <arg name="trained_engine_file" default="$(find-pkg-share lidar_apollo_instance_segmentation)/data/$(var base_name).engine" />
+  <arg name="trained_prototxt_file" default="$(find-pkg-share lidar_apollo_instance_segmentation)/data/$(var base_name).prototxt" />
+  <arg name="trained_caffemodel_file" default="$(find-pkg-share lidar_apollo_instance_segmentation)/data/$(var base_name).caffemodel" />
+  <arg name="param_file" default="$(find-pkg-share lidar_apollo_instance_segmentation)/config/$(var base_name).param.yaml"/>
 
-  <arg if="$(eval model=='model_128')" name="trained_engine_file" default="$(find lidar_apollo_instance_segmentation)/data/vls-128.engine" />
-  <arg if="$(eval model=='model_128')" name="trained_prototxt_file" default="$(find lidar_apollo_instance_segmentation)/data/vls-128.prototxt" />
-  <arg if="$(eval model=='model_128')" name="trained_caffemodel_file" default="$(find lidar_apollo_instance_segmentation)/data/vls-128.caffemodel" />
   <arg name="target_frame" default="base_link" />
   <arg name="z_offset" default="-2" />
 
-  <node pkg="lidar_apollo_instance_segmentation" type="lidar_apollo_instance_segmentation_node"
+  <node pkg="lidar_apollo_instance_segmentation" exec="lidar_apollo_instance_segmentation_node"
         name="lidar_apollo_instance_segmentation" output="screen" >
-    <remap from="~input/pointcloud" to="/sensing/lidar/top/rectified/pointcloud"/>
-    <remap from="~output/labeled_clusters" to="$(arg output/objects)"/>
-    <rosparam if="$(eval model=='model_16')" subst_value="true">
-      engine_file: $(arg trained_engine_file)
-      prototxt_file: $(arg trained_prototxt_file)
-      caffemodel_file: $(arg trained_caffemodel_file)
-      score_threshold: 0.1
-      range: 70
-      width: 672
-      height: 672
-      use_intensity_feature: true
-      use_constant_feature: false
-      z_offset: $(arg z_offset)
-      target_frame: $(arg target_frame)
-    </rosparam>
-
-    <rosparam if="$(eval model=='model_64')" subst_value="true">
-      engine_file: $(arg trained_engine_file)
-      prototxt_file: $(arg trained_prototxt_file)
-      caffemodel_file: $(arg trained_caffemodel_file)
-      score_threshold: 0.1
-      range: 70
-      width: 672
-      height: 672
-      use_intensity_feature: true
-      use_constant_feature: false
-      z_offset: $(arg z_offset)
-      target_frame: $(arg target_frame)
-    </rosparam>
-
-    <rosparam if="$(eval model=='model_128')" subst_value="true">
-      engine_file: $(arg trained_engine_file)
-      prototxt_file: $(arg trained_prototxt_file)
-      caffemodel_file: $(arg trained_caffemodel_file)
-      score_threshold: 0.1
-      range: 90
-      width: 864
-      height: 864
-      use_intensity_feature: false
-      use_constant_feature: false
-      z_offset: $(arg z_offset)
-      target_frame: $(arg target_frame)
-    </rosparam>
+    <remap from="input/pointcloud" to="/sensing/lidar/top/rectified/pointcloud"/>
+    <remap from="output/labeled_clusters" to="$(var output/objects)"/>
+    <param name="engine_file" value="$(var trained_engine_file)"/>
+    <param name="prototxt_file" value="$(var trained_prototxt_file)"/>
+    <param name="caffemodel_file" value="$(var trained_caffemodel_file)"/>
+    <param name="z_offset" value="$(var z_offset)"/>
+    <param name="target_frame" value="$(var target_frame)"/>
+    <param from="$(var param_file)"/>
   </node>
 </launch>

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/lib/src/TrtNet.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/lib/src/TrtNet.cpp
@@ -65,9 +65,10 @@ inline unsigned int getElementSize(nvinfer1::DataType t)
       return 2;
     case nvinfer1::DataType::kINT8:
       return 1;
+    default:
+      throw std::runtime_error("Invalid DataType.");
+      return 0;
   }
-  throw std::runtime_error("Invalid DataType.");
-  return 0;
 }
 
 namespace Tn

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/package.xml
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="3">
     <name>lidar_apollo_instance_segmentation</name>
     <version>0.1.0</version>
     <description>lidar_apollo_instance_segmentation</description>
@@ -10,17 +10,17 @@
 
     <license>Apache 2.0</license>
 
-    <buildtool_depend>catkin</buildtool_depend>
+    <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-    <build_depend>roscpp</build_depend>
-    <build_depend>roslib</build_depend>
-    <build_depend>pcl_ros</build_depend>
-    <build_depend>autoware_perception_msgs</build_depend>
-
-    <run_depend>roscpp</run_depend>
-    <run_depend>roslib</run_depend>
-    <run_depend>pcl_ros</run_depend>
-    <run_depend>autoware_perception_msgs</run_depend>
-
-    <export></export>
+    <depend>rclcpp</depend>
+    <depend>libpcl-all-dev</depend>
+    <depend>pcl_conversions</depend>
+    <depend>autoware_perception_msgs</depend>
+    <depend>tf2</depend>
+    <depend>tf2_geometry_msgs</depend>
+    <depend>tf2_eigen</depend>
+    <depend>tf2_ros</depend>
+    <export>
+        <build_type>ament_cmake</build_type>
+    </export>
 </package>

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/cluster2d.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/cluster2d.cpp
@@ -48,8 +48,9 @@
 
 #include "lidar_apollo_instance_segmentation/cluster2d.h"
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <pcl_conversions/pcl_conversions.h>
 
-geometry_msgs::Quaternion getQuaternionFromRPY(const double r, const double p, const double y){
+geometry_msgs::msg::Quaternion getQuaternionFromRPY(const double r, const double p, const double y){
   tf2::Quaternion q;
   q.setRPY(r, p, y);
   return tf2::toMsg(q);
@@ -240,24 +241,24 @@ void Cluster2D::classify(const std::shared_ptr<float> & inferred_data)
   }
 }
 
-autoware_perception_msgs::DynamicObjectWithFeature Cluster2D::obstacleToObject(
-  const Obstacle & in_obstacle, const std_msgs::Header & in_header)
+autoware_perception_msgs::msg::DynamicObjectWithFeature Cluster2D::obstacleToObject(
+  const Obstacle & in_obstacle, const std_msgs::msg::Header & in_header)
 {
-  autoware_perception_msgs::DynamicObjectWithFeature resulting_object;
+  autoware_perception_msgs::msg::DynamicObjectWithFeature resulting_object;
   // pcl::PointCloud<pcl::PointXYZI> in_cluster = *(in_obstacle.cloud_ptr);
 
   resulting_object.object.semantic.confidence = in_obstacle.score;
   if (in_obstacle.meta_type == MetaType::META_PEDESTRIAN) {
-    resulting_object.object.semantic.type = autoware_perception_msgs::Semantic::PEDESTRIAN;
+    resulting_object.object.semantic.type = autoware_perception_msgs::msg::Semantic::PEDESTRIAN;
   } else if (in_obstacle.meta_type == MetaType::META_NONMOT) {
-    resulting_object.object.semantic.type = autoware_perception_msgs::Semantic::MOTORBIKE;
+    resulting_object.object.semantic.type = autoware_perception_msgs::msg::Semantic::MOTORBIKE;
   } else if (in_obstacle.meta_type == MetaType::META_SMALLMOT) {
-    resulting_object.object.semantic.type = autoware_perception_msgs::Semantic::CAR;
+    resulting_object.object.semantic.type = autoware_perception_msgs::msg::Semantic::CAR;
   } else if (in_obstacle.meta_type == MetaType::META_BIGMOT) {
-    resulting_object.object.semantic.type = autoware_perception_msgs::Semantic::BUS;
+    resulting_object.object.semantic.type = autoware_perception_msgs::msg::Semantic::BUS;
   } else {
-    // resulting_object.object.semantic.type = autoware_perception_msgs::Semantic::PEDESTRIAN;
-    resulting_object.object.semantic.type = autoware_perception_msgs::Semantic::UNKNOWN;
+    // resulting_object.object.semantic.type = autoware_perception_msgs::msg::Semantic::PEDESTRIAN;
+    resulting_object.object.semantic.type = autoware_perception_msgs::msg::Semantic::UNKNOWN;
   }
 
   pcl::PointXYZ min_point;
@@ -285,7 +286,7 @@ autoware_perception_msgs::DynamicObjectWithFeature Cluster2D::obstacleToObject(
     if (pit->z < min_point.z) min_point.z = pit->z;
     if (pit->z > max_point.z) max_point.z = pit->z;
   }
-  sensor_msgs::PointCloud2 ros_pc;
+  sensor_msgs::msg::PointCloud2 ros_pc;
   pcl::toROSMsg(cluster, ros_pc);
   resulting_object.feature.cluster = ros_pc;
   resulting_object.feature.cluster.header = in_header;
@@ -306,8 +307,8 @@ autoware_perception_msgs::DynamicObjectWithFeature Cluster2D::obstacleToObject(
 
 void Cluster2D::getObjects(
   const float confidence_thresh, const float height_thresh, const int min_pts_num,
-  autoware_perception_msgs::DynamicObjectWithFeatureArray & objects,
-  const std_msgs::Header & in_header)
+  autoware_perception_msgs::msg::DynamicObjectWithFeatureArray & objects,
+  const std_msgs::msg::Header & in_header)
 {
   for (size_t i = 0; i < point2grid_.size(); ++i) {
     int grid = point2grid_[i];
@@ -333,7 +334,7 @@ void Cluster2D::getObjects(
     if (static_cast<int>(obs->cloud_ptr->size()) < min_pts_num) {
       continue;
     }
-    autoware_perception_msgs::DynamicObjectWithFeature out_obj = obstacleToObject(*obs, in_header);
+    autoware_perception_msgs::msg::DynamicObjectWithFeature out_obj = obstacleToObject(*obs, in_header);
     objects.feature_objects.push_back(out_obj);
   }
   objects.header = in_header;

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/cluster2d.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/cluster2d.cpp
@@ -107,7 +107,6 @@ void Cluster2D::cluster(
 
   std::vector<std::vector<Node>> nodes(rows_, std::vector<Node>(cols_, Node()));
 
-  size_t tot_point_num = pc_ptr_->size();
   valid_indices_in_pc_ = &(valid_indices.indices);
   point2grid_.assign(valid_indices_in_pc_->size(), -1);
 

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/debugger.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/debugger.cpp
@@ -20,7 +20,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
-Debugger::Debugger(const rclcpp::Node::SharedPtr & node)
+Debugger::Debugger(rclcpp::Node * node)
 {
   instance_pointcloud_pub_ =
     node->create_publisher<sensor_msgs::msg::PointCloud2>("debug/instance_pointcloud", 1);

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/debugger.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/debugger.cpp
@@ -16,17 +16,18 @@
 
 #include "lidar_apollo_instance_segmentation/debugger.h"
 #include <pcl/point_types.h>
-#include <pcl_ros/point_cloud.h>
-#include <sensor_msgs/PointCloud2.h>
+#include <pcl/point_cloud.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
-Debugger::Debugger() : nh_(""), pnh_("~")
+Debugger::Debugger(const rclcpp::Node::SharedPtr & node)
 {
   instance_pointcloud_pub_ =
-    pnh_.advertise<sensor_msgs::PointCloud2>("debug/instance_pointcloud", 1);
+    node->create_publisher<sensor_msgs::msg::PointCloud2>("debug/instance_pointcloud", 1);
 }
 
 void Debugger::publishColoredPointCloud(
-  const autoware_perception_msgs::DynamicObjectWithFeatureArray & input)
+  const autoware_perception_msgs::msg::DynamicObjectWithFeatureArray & input)
 {
   pcl::PointCloud<pcl::PointXYZRGB> colored_pointcloud;
   for (size_t i = 0; i < input.feature_objects.size(); i++) {
@@ -35,43 +36,43 @@ void Debugger::publishColoredPointCloud(
 
     int red, green, blue;
     switch (input.feature_objects.at(i).object.semantic.type) {
-      case autoware_perception_msgs::Semantic::CAR: {
+      case autoware_perception_msgs::msg::Semantic::CAR: {
         red = 255;
         green = 0;
         blue = 0;
         break;
       }
-      case autoware_perception_msgs::Semantic::TRUCK: {
+      case autoware_perception_msgs::msg::Semantic::TRUCK: {
         red = 255;
         green = 127;
         blue = 0;
         break;
       }
-      case autoware_perception_msgs::Semantic::BUS: {
+      case autoware_perception_msgs::msg::Semantic::BUS: {
         red = 255;
         green = 0;
         blue = 127;
         break;
       }
-      case autoware_perception_msgs::Semantic::PEDESTRIAN: {
+      case autoware_perception_msgs::msg::Semantic::PEDESTRIAN: {
         red = 0;
         green = 255;
         blue = 0;
         break;
       }
-      case autoware_perception_msgs::Semantic::BICYCLE: {
+      case autoware_perception_msgs::msg::Semantic::BICYCLE: {
         red = 0;
         green = 0;
         blue = 255;
         break;
       }
-      case autoware_perception_msgs::Semantic::MOTORBIKE: {
+      case autoware_perception_msgs::msg::Semantic::MOTORBIKE: {
         red = 0;
         green = 127;
         blue = 255;
         break;
       }
-      case autoware_perception_msgs::Semantic::UNKNOWN: {
+      case autoware_perception_msgs::msg::Semantic::UNKNOWN: {
         red = 255;
         green = 255;
         blue = 255;
@@ -90,8 +91,8 @@ void Debugger::publishColoredPointCloud(
       colored_pointcloud.push_back(colored_point);
     }
   }
-  sensor_msgs::PointCloud2 output_msg;
+  sensor_msgs::msg::PointCloud2 output_msg;
   pcl::toROSMsg(colored_pointcloud, output_msg);
   output_msg.header = input.header;
-  instance_pointcloud_pub_.publish(output_msg);
+  instance_pointcloud_pub_->publish(output_msg);
 }

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/debugger.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/debugger.cpp
@@ -34,7 +34,7 @@ void Debugger::publishColoredPointCloud(
     pcl::PointCloud<pcl::PointXYZI> object_pointcloud;
     pcl::fromROSMsg(input.feature_objects.at(i).feature.cluster, object_pointcloud);
 
-    int red, green, blue;
+    int red = 0, green = 0, blue = 0;
     switch (input.feature_objects.at(i).object.semantic.type) {
       case autoware_perception_msgs::msg::Semantic::CAR: {
         red = 255;

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/detector.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/detector.cpp
@@ -20,7 +20,7 @@
 #include "lidar_apollo_instance_segmentation/feature_map.h"
 #include <pcl_conversions/pcl_conversions.h>
 
-LidarApolloInstanceSegmentation::LidarApolloInstanceSegmentation(const rclcpp::Node::SharedPtr & node) 
+LidarApolloInstanceSegmentation::LidarApolloInstanceSegmentation(rclcpp::Node * node) 
 : node_(node),
   tf_buffer_(node_->get_clock()),
   tf_listener_(tf_buffer_)

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/detector.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/detector.cpp
@@ -17,32 +17,35 @@
 #include "lidar_apollo_instance_segmentation/detector.h"
 #include <NvCaffeParser.h>
 #include <NvInfer.h>
-#include <boost/filesystem.hpp>
 #include "lidar_apollo_instance_segmentation/feature_map.h"
+#include <pcl_conversions/pcl_conversions.h>
 
-LidarApolloInstanceSegmentation::LidarApolloInstanceSegmentation() : nh_(""), pnh_("~"), tf_listener_(tf_buffer_)
+LidarApolloInstanceSegmentation::LidarApolloInstanceSegmentation(const rclcpp::Node::SharedPtr & node) 
+: node_(node),
+  tf_buffer_(node_->get_clock()),
+  tf_listener_(tf_buffer_)
 {
   int range, width, height;
   bool use_intensity_feature, use_constant_feature;
   std::string engine_file;
   std::string prototxt_file;
   std::string caffemodel_file;
-  pnh_.param<float>("score_threshold", score_threshold_, 0.8);
-  pnh_.param<int>("range", range, 60);
-  pnh_.param<int>("width", width, 640);
-  pnh_.param<int>("height", height, 640);
-  pnh_.param<std::string>("engine_file", engine_file, "vls-128.engine");
-  pnh_.param<std::string>("prototxt_file", prototxt_file, "vls-128.prototxt");
-  pnh_.param<std::string>("caffemodel_file", caffemodel_file, "vls-128.caffemodel");
-  pnh_.param<bool>("use_intensity_feature", use_intensity_feature, true);
-  pnh_.param<bool>("use_constant_feature", use_constant_feature, true);
-  pnh_.param<std::string>("target_frame", target_frame_, "base_link");
-  pnh_.param<float>("z_offset", z_offset_, 2);
+  score_threshold_ = node_->declare_parameter("score_threshold", 0.8);
+  range = node_->declare_parameter("range", 60);
+  width = node_->declare_parameter("width", 640);
+  height = node_->declare_parameter("height", 640);
+  engine_file = node_->declare_parameter("engine_file", "vls-128.engine");
+  prototxt_file = node_->declare_parameter("prototxt_file", "vls-128.prototxt");
+  caffemodel_file = node_->declare_parameter("caffemodel_file", "vls-128.caffemodel");
+  use_intensity_feature = node_->declare_parameter("use_intensity_feature", true);
+  use_constant_feature = node_->declare_parameter("use_constant_feature", true);
+  target_frame_ = node_->declare_parameter("target_frame", "base_link");
+  z_offset_ = node_->declare_parameter("z_offset", 2);
 
   // load weight file
   std::ifstream fs(engine_file);
   if (!fs.is_open()) {
-    ROS_INFO(
+    RCLCPP_INFO( node_->get_logger(),
       "Could not find %s. try making TensorRT engine from caffemodel and prototxt",
       engine_file.c_str());
     Tn::Logger logger;
@@ -54,7 +57,7 @@ LidarApolloInstanceSegmentation::LidarApolloInstanceSegmentation() : nh_(""), pn
       prototxt_file.c_str(), caffemodel_file.c_str(), *network, nvinfer1::DataType::kFLOAT);
     std::string output_node = "deconv0";
     auto output = blob_name2tensor->find(output_node.c_str());
-    if (output == nullptr) ROS_ERROR("can not find output named %s", output_node.c_str());
+    if (output == nullptr) RCLCPP_ERROR(node_->get_logger(), "can not find output named %s", output_node.c_str());
     network->markOutput(*output);
     const int batch_size = 1;
     builder->setMaxBatchSize(batch_size);
@@ -82,43 +85,49 @@ LidarApolloInstanceSegmentation::LidarApolloInstanceSegmentation() : nh_(""), pn
 }
 
 bool LidarApolloInstanceSegmentation::transformCloud(
-  const sensor_msgs::PointCloud2 & input,
-  sensor_msgs::PointCloud2& transformed_cloud,
+  const sensor_msgs::msg::PointCloud2 & input,
+  sensor_msgs::msg::PointCloud2& transformed_cloud,
   float z_offset)
 {
+  // TODO(mitsudome-r): remove conversion once pcl_ros transform are available.
+  pcl::PointCloud<pcl::PointXYZI> pcl_input, pcl_transformed_cloud;
+  pcl::fromROSMsg(input, pcl_input);
+
   // transform pointcloud to tagret_frame
   if (target_frame_ != input.header.frame_id) {
     try {
-      geometry_msgs::TransformStamped transform_stamped;
+      geometry_msgs::msg::TransformStamped transform_stamped;
       transform_stamped = tf_buffer_.lookupTransform(target_frame_, input.header.frame_id,
-                                                     input.header.stamp, ros::Duration(0.5));
+                                                     input.header.stamp, std::chrono::milliseconds(500));
       Eigen::Matrix4f affine_matrix =
         tf2::transformToEigen(transform_stamped.transform).matrix().cast<float>();
-      pcl_ros::transformPointCloud(affine_matrix, input, transformed_cloud);
+      pcl::transformPointCloud(pcl_input, pcl_transformed_cloud, affine_matrix);
       transformed_cloud.header.frame_id = target_frame_;
     } catch (tf2::TransformException &ex) {
-      ROS_WARN("%s",ex.what());
+      RCLCPP_WARN(node_->get_logger(), "%s",ex.what());
       return false;
     }
   } else {
-    transformed_cloud = input;
+    pcl_transformed_cloud = pcl_input;
   }
 
   // move pointcloud z_offset in z axis
-  sensor_msgs::PointCloud2 pointcloud_with_z_offset;
+  pcl::PointCloud<pcl::PointXYZI> pointcloud_with_z_offset;
   Eigen::Affine3f z_up_translation(Eigen::Translation3f(0, 0, z_offset));
   Eigen::Matrix4f z_up_transform = z_up_translation.matrix();
-  pcl_ros::transformPointCloud(z_up_transform, transformed_cloud, transformed_cloud);
+  pcl::transformPointCloud(pcl_transformed_cloud, pcl_transformed_cloud, z_up_transform);
+
+  pcl::toROSMsg(pcl_transformed_cloud, transformed_cloud);
 
   return true;
 }
 
 bool LidarApolloInstanceSegmentation::detectDynamicObjects(
-  const sensor_msgs::PointCloud2 & input,
-  autoware_perception_msgs::DynamicObjectWithFeatureArray & output)
+  const sensor_msgs::msg::PointCloud2 & input,
+  autoware_perception_msgs::msg::DynamicObjectWithFeatureArray & output)
 {
   // move up pointcloud z_offset in z axis
-  sensor_msgs::PointCloud2 transformed_cloud;
+  sensor_msgs::msg::PointCloud2 transformed_cloud;
   transformCloud(input, transformed_cloud, z_offset_);
 
   // convert from ros to pcl
@@ -146,8 +155,8 @@ bool LidarApolloInstanceSegmentation::detectDynamicObjects(
   cluster2d_->getObjects(score_threshold_, height_thresh, min_pts_num, output, transformed_cloud.header);
 
   // move down pointcloud z_offset in z axis
-  for (int i=0; i<output.feature_objects.size(); i++) {
-    sensor_msgs::PointCloud2 transformed_cloud;
+  for (std::size_t i=0; i<output.feature_objects.size(); i++) {
+    sensor_msgs::msg::PointCloud2 transformed_cloud;
     transformCloud(output.feature_objects.at(i).feature.cluster, transformed_cloud, -z_offset_);
     output.feature_objects.at(i).feature.cluster = transformed_cloud;
   }

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/feature_map.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/feature_map.cpp
@@ -92,7 +92,6 @@ FeatureMapWithConstant::FeatureMapWithConstant(const int width, const int height
 }
 void FeatureMapWithConstant::initializeMap(std::vector<float> & map)
 {
-  const int size = width * height;
   for (int row = 0; row < height; ++row) {
     for (int col = 0; col < width; ++col) {
       int idx = row * width + col;
@@ -135,7 +134,6 @@ FeatureMapWithConstantAndIntensity::FeatureMapWithConstantAndIntensity(
 }
 void FeatureMapWithConstantAndIntensity::initializeMap(std::vector<float> & map)
 {
-  const int size = width * height;
   for (int row = 0; row < height; ++row) {
     for (int col = 0; col < width; ++col) {
       int idx = row * width + col;

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/main.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/main.cpp
@@ -18,9 +18,11 @@
 
 int main(int argc, char ** argv)
 {
-  ros::init(argc, argv, "lidar_apollo_instance_segmentation_node");
-  LidarInstanceSegmentationNode node;
-  ros::spin();
+  rclcpp::init(argc, argv);
+
+  rclcpp::spin(std::make_shared<LidarInstanceSegmentationNode>());
+
+  rclcpp::shutdown();
 
   return 0;
 }

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/main.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/main.cpp
@@ -20,9 +20,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  const auto node = std::make_shared<LidarInstanceSegmentationNode>();
-  node->init();
-  rclcpp::spin(node);
+  rclcpp::spin(std::make_shared<LidarInstanceSegmentationNode>());
 
   rclcpp::shutdown();
 

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/main.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/main.cpp
@@ -20,7 +20,9 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  rclcpp::spin(std::make_shared<LidarInstanceSegmentationNode>());
+  const auto node = std::make_shared<LidarInstanceSegmentationNode>();
+  node->init();
+  rclcpp::spin(node);
 
   rclcpp::shutdown();
 

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/node.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/node.cpp
@@ -19,6 +19,10 @@
 
 LidarInstanceSegmentationNode::LidarInstanceSegmentationNode() : Node("lidar_apollo_instance_segmentation_node")
 {
+}
+
+void LidarInstanceSegmentationNode::init()
+{
   using std::placeholders::_1;
   detector_ptr_ = std::make_shared<LidarApolloInstanceSegmentation>(this->shared_from_this());
   debugger_ptr_ = std::make_shared<Debugger>(this->shared_from_this());
@@ -33,5 +37,5 @@ void LidarInstanceSegmentationNode::pointCloudCallback(const sensor_msgs::msg::P
   autoware_perception_msgs::msg::DynamicObjectWithFeatureArray output_msg;
   detector_ptr_->detectDynamicObjects(*msg, output_msg);
   dynamic_objects_pub_->publish(output_msg);
-  debugger_ptr_->publishColoredPointCloud(output_msg);
+  // debugger_ptr_->publishColoredPointCloud(output_msg);
 }

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/node.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/node.cpp
@@ -17,19 +17,21 @@
 #include "lidar_apollo_instance_segmentation/node.h"
 #include "lidar_apollo_instance_segmentation/detector.h"
 
-LidarInstanceSegmentationNode::LidarInstanceSegmentationNode() : nh_(""), pnh_("~")
+LidarInstanceSegmentationNode::LidarInstanceSegmentationNode() : Node("lidar_apollo_instance_segmentation_node")
 {
-  detector_ptr_ = std::make_shared<LidarApolloInstanceSegmentation>();
+  using std::placeholders::_1;
+  detector_ptr_ = std::make_shared<LidarApolloInstanceSegmentation>(this->shared_from_this());
+  debugger_ptr_ = std::make_shared<Debugger>(this->shared_from_this());
   pointcloud_sub_ =
-    pnh_.subscribe("input/pointcloud", 1, &LidarInstanceSegmentationNode::pointCloudCallback, this);
-  dynamic_objects_pub_ = pnh_.advertise<autoware_perception_msgs::DynamicObjectWithFeatureArray>(
+    this->create_subscription<sensor_msgs::msg::PointCloud2>("input/pointcloud", 1, std::bind(&LidarInstanceSegmentationNode::pointCloudCallback, this, _1));
+  dynamic_objects_pub_ = this->create_publisher<autoware_perception_msgs::msg::DynamicObjectWithFeatureArray>(
     "output/labeled_clusters", 1);
 }
 
-void LidarInstanceSegmentationNode::pointCloudCallback(const sensor_msgs::PointCloud2 & msg)
+void LidarInstanceSegmentationNode::pointCloudCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
-  autoware_perception_msgs::DynamicObjectWithFeatureArray output_msg;
-  detector_ptr_->detectDynamicObjects(msg, output_msg);
-  dynamic_objects_pub_.publish(output_msg);
-  debugger_.publishColoredPointCloud(output_msg);
+  autoware_perception_msgs::msg::DynamicObjectWithFeatureArray output_msg;
+  detector_ptr_->detectDynamicObjects(*msg, output_msg);
+  dynamic_objects_pub_->publish(output_msg);
+  debugger_ptr_->publishColoredPointCloud(output_msg);
 }

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/node.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/node.cpp
@@ -33,5 +33,5 @@ void LidarInstanceSegmentationNode::pointCloudCallback(const sensor_msgs::msg::P
   autoware_perception_msgs::msg::DynamicObjectWithFeatureArray output_msg;
   detector_ptr_->detectDynamicObjects(*msg, output_msg);
   dynamic_objects_pub_->publish(output_msg);
-  // debugger_ptr_->publishColoredPointCloud(output_msg);
+  debugger_ptr_->publishColoredPointCloud(output_msg);
 }

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/node.cpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/src/node.cpp
@@ -19,13 +19,9 @@
 
 LidarInstanceSegmentationNode::LidarInstanceSegmentationNode() : Node("lidar_apollo_instance_segmentation_node")
 {
-}
-
-void LidarInstanceSegmentationNode::init()
-{
   using std::placeholders::_1;
-  detector_ptr_ = std::make_shared<LidarApolloInstanceSegmentation>(this->shared_from_this());
-  debugger_ptr_ = std::make_shared<Debugger>(this->shared_from_this());
+  detector_ptr_ = std::make_shared<LidarApolloInstanceSegmentation>(this);
+  debugger_ptr_ = std::make_shared<Debugger>(this);
   pointcloud_sub_ =
     this->create_subscription<sensor_msgs::msg::PointCloud2>("input/pointcloud", 1, std::bind(&LidarInstanceSegmentationNode::pointCloudCallback, this, _1));
   dynamic_objects_pub_ = this->create_publisher<autoware_perception_msgs::msg::DynamicObjectWithFeatureArray>(


### PR DESCRIPTION
This ports lidar_apollo_instance_segmentation package into ROS2.

Notes:
* Added init() function for LidarInstanceSegmentationNode class in order to use shared_from_this() function.
* Created param files for different models for better management of parameters