### PR TITLE
Ros2 port traffic light map

### DIFF
--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/CMakeLists.txt
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/CMakeLists.txt
@@ -19,8 +19,6 @@ find_package(Eigen3 REQUIRED)
 
 include_directories(
   ${EIGEN3_INCLUDE_DIR}
-  include
-  src/autoware/pilot.auto/map/lanelet2_extension/include
 )
 
 ament_auto_add_executable(traffic_light_map_based_detector_node

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/CMakeLists.txt
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 
 
 find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 find_package(Eigen3 REQUIRED)
 

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/CMakeLists.txt
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/CMakeLists.txt
@@ -1,40 +1,24 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(traffic_light_map_based_detector)
 
-add_compile_options(-std=c++14)
+if(NOT CMAKE_CXX_STANDARD)
+	set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  autoware_perception_msgs
-  autoware_planning_msgs
-  geometry_msgs
-  lanelet2_extension
-  roscpp
-  sensor_msgs
-  tf2
-  tf2_ros
-)
+
+find_package(ament_cmake_auto REQUIRED)
+
 find_package(Eigen3 REQUIRED)
 
-catkin_package(
-  INCLUDE_DIRS include
-  CATKIN_DEPENDS
-    autoware_perception_msgs
-    autoware_planning_msgs
-    geometry_msgs
-    lanelet2_extension
-    roscpp
-    sensor_msgs
-    tf2
-    tf2_ros
-)
 
 ###########
 ## Build ##
 ###########
 
 include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIR}
 )
 
@@ -43,27 +27,12 @@ add_executable(traffic_light_map_based_detector_node
   src/main.cpp
 )
 
-add_dependencies(traffic_light_map_based_detector_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-target_link_libraries(traffic_light_map_based_detector_node
-  ${catkin_LIBRARIES}
-)
 
 #############
 ## Install ##
 #############
 
-install(
-  TARGETS
-    traffic_light_map_based_detector_node
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-install(
-  DIRECTORY
-    launch
-    config
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+ament_auto_package(INSTALL_TO_SHARE
+  launch
+  config
 )

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/CMakeLists.txt
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 
 
 find_package(ament_cmake_auto REQUIRED)
+find_package(rclcpp REQUIRED)
 ament_auto_find_build_dependencies()
 
 find_package(Eigen3 REQUIRED)
@@ -21,9 +22,11 @@ find_package(Eigen3 REQUIRED)
 
 include_directories(
   ${EIGEN3_INCLUDE_DIR}
+  include
+  src/autoware/pilot.auto/map/lanelet2_extension/include
 )
 
-add_executable(traffic_light_map_based_detector_node
+ament_auto_add_executable(traffic_light_map_based_detector_node
   src/node.cpp
   src/main.cpp
 )

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/CMakeLists.txt
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/CMakeLists.txt
@@ -8,12 +8,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
 endif()
 
-
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 find_package(Eigen3 REQUIRED)
-
 
 ###########
 ## Build ##
@@ -29,7 +27,6 @@ ament_auto_add_executable(traffic_light_map_based_detector_node
   src/node.cpp
   src/main.cpp
 )
-
 
 #############
 ## Install ##

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/config/traffic_light_map_based_detector.yaml
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/config/traffic_light_map_based_detector.yaml
@@ -1,5 +1,7 @@
-max_vibration_pitch: 0.01745329251 # -0.5 ~ 0.5 deg
-max_vibration_yaw: 0.01745329251 # -0.5 ~ 0.5 deg
-max_vibration_height: 0.1 # -0.05 ~ 0.05 m
-max_vibration_width: 0.1 # -0.05 ~ 0.05 m
-max_vibration_depth: 0.1 # -0.05 ~ 0.05 m
+/**:
+  ros__parameters:
+    max_vibration_pitch: 0.01745329251   # -0.5 ~ 0.5 deg
+    max_vibration_yaw: 0.01745329251     # -0.5 ~ 0.5 deg
+    max_vibration_height: 0.1            # -0.05 ~ 0.05 m
+    max_vibration_width: 0.1             # -0.05 ~ 0.05 m
+    max_vibration_depth: 0.1             # -0.05 ~ 0.05 m

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/include/traffic_light_map_based_detector/node.hpp
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/include/traffic_light_map_based_detector/node.hpp
@@ -19,27 +19,28 @@
 
 #pragma once
 
-#include <ros/ros.h>
-
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_extension/regulatory_elements/autoware_traffic_light.h>
 #include <lanelet2_extension/utility/query.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
 
-#include <autoware_lanelet2_msgs/MapBin.h>
-#include <autoware_perception_msgs/TrafficLightRoiArray.h>
-#include <autoware_planning_msgs/Route.h>
-#include <geometry_msgs/PoseStamped.h>
-#include <sensor_msgs/CameraInfo.h>
+#include <autoware_lanelet2_msgs/msg/map_bin.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_roi_array.hpp>
+#include <autoware_planning_msgs/msg/route.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <tf2/transform_datatypes.h>
 #include <tf2_ros/transform_listener.h>
-#include <visualization_msgs/MarkerArray.h>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <rclcpp/rclcpp.hpp>
 
 #include <memory>
 
 namespace traffic_light
 {
-class MapBasedDetector
+class MapBasedDetector: public rclcpp::Node
 {
 public:
   MapBasedDetector();
@@ -62,20 +63,21 @@ private:
   };
 
 private:
-  ros::NodeHandle nh_;
-  ros::NodeHandle pnh_;
-  ros::Subscriber map_sub_;
-  ros::Subscriber camera_info_sub_;
-  ros::Subscriber route_sub_;
-  ros::Publisher roi_pub_;
-  ros::Publisher viz_pub_;
+  //  ros::NodeHandle nh_;
+  // ros::NodeHandle pnh_;
+  rclcpp::Subscription<autoware_lanelet2_msgs::msg::MapBin>::SharedPtr map_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_sub_;
+  rclcpp::Subscription<autoware_planning_msgs::msg::Route>::SharedPtr route_sub_;
 
-  tf2_ros::Buffer tf_buffer_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightRoiArray>::SharedPtr roi_pub_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr viz_pub_;
+
+  tf2::BufferCore tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 
   using TrafficLightSet = std::set<lanelet::ConstLineString3d, IdLessThan>;
 
-  sensor_msgs::CameraInfo::ConstPtr camera_info_ptr_;
+  sensor_msgs::msg::CameraInfo::ConstSharedPtr camera_info_ptr_;
   std::shared_ptr<TrafficLightSet> all_traffic_lights_ptr_;
   std::shared_ptr<TrafficLightSet> route_traffic_lights_ptr_;
 
@@ -84,28 +86,30 @@ private:
   lanelet::routing::RoutingGraphPtr routing_graph_ptr_;
   Config config_;
 
-  void mapCallback(const autoware_lanelet2_msgs::MapBin & input_msg);
-  void cameraInfoCallback(const sensor_msgs::CameraInfo::ConstPtr & input_msg);
-  void routeCallback(const autoware_planning_msgs::Route::ConstPtr & input_msg);
+  void mapCallback(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr input_msg);
+  void cameraInfoCallback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_msg);
+  void routeCallback(const autoware_planning_msgs::msg::Route::ConstSharedPtr input_msg);
   void isInVisibility(
     const TrafficLightSet & all_traffic_lights,
-    const geometry_msgs::Pose & camera_pose, const sensor_msgs::CameraInfo & camera_info,
+    const geometry_msgs::msg::Pose & camera_pose, const sensor_msgs::msg::CameraInfo & camera_info,
     std::vector<lanelet::ConstLineString3d> & visible_traffic_lights);
   bool isInDistanceRange(
-    const geometry_msgs::Point & tl_point, const geometry_msgs::Point & camera_point,
+			 const geometry_msgs::msg::Point & tl_point, const geometry_msgs::msg::Point & camera_point,
     const double max_distance_range);
   bool isInAngleRange(
     const double & tl_yaw, const double & camera_yaw, const double max_angele_range);
   bool isInImageFrame(
-    const sensor_msgs::CameraInfo & camera_info, const geometry_msgs::Point & point);
+		      const sensor_msgs::msg::CameraInfo & camera_info, const geometry_msgs::msg::Point & point);
   double normalizeAngle(const double & angle);
   bool getTrafficLightRoi(
-    const geometry_msgs::Pose & camera_pose, const sensor_msgs::CameraInfo & camera_info,
-    const lanelet::ConstLineString3d traffic_light, const Config & config,
-    autoware_perception_msgs::TrafficLightRoi & tl_roi);
+			  const geometry_msgs::msg::Pose & camera_pose, const sensor_msgs::msg::CameraInfo & camera_info,
+			  const lanelet::ConstLineString3d traffic_light, const Config & config,
+			  autoware_perception_msgs::msg::TrafficLightRoi & tl_roi);
   void publishVisibleTrafficLights(
-    const geometry_msgs::PoseStamped camera_pose_stamped,
-    const std::vector<lanelet::ConstLineString3d> & visible_traffic_lights,
-    const ros::Publisher & pub);
+				   const geometry_msgs::msg::PoseStamped camera_pose_stamped,
+				   const std::vector<lanelet::ConstLineString3d> & visible_traffic_lights,
+				   const rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub);
+				   // const ros::Publisher & pub
+				   
 };
 }  // namespace traffic_light

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/include/traffic_light_map_based_detector/node.hpp
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/include/traffic_light_map_based_detector/node.hpp
@@ -63,8 +63,6 @@ private:
   };
 
 private:
-  //  ros::NodeHandle nh_;
-  // ros::NodeHandle pnh_;
   rclcpp::Subscription<autoware_lanelet2_msgs::msg::MapBin>::SharedPtr map_sub_;
   rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_sub_;
   rclcpp::Subscription<autoware_planning_msgs::msg::Route>::SharedPtr route_sub_;
@@ -91,25 +89,28 @@ private:
   void routeCallback(const autoware_planning_msgs::msg::Route::ConstSharedPtr input_msg);
   void isInVisibility(
     const TrafficLightSet & all_traffic_lights,
-    const geometry_msgs::msg::Pose & camera_pose, const sensor_msgs::msg::CameraInfo & camera_info,
+    const geometry_msgs::msg::Pose & camera_pose,
+    const sensor_msgs::msg::CameraInfo & camera_info,
     std::vector<lanelet::ConstLineString3d> & visible_traffic_lights);
   bool isInDistanceRange(
-			 const geometry_msgs::msg::Point & tl_point, const geometry_msgs::msg::Point & camera_point,
+    const geometry_msgs::msg::Point & tl_point,
+    const geometry_msgs::msg::Point & camera_point,
     const double max_distance_range);
   bool isInAngleRange(
     const double & tl_yaw, const double & camera_yaw, const double max_angele_range);
   bool isInImageFrame(
-		      const sensor_msgs::msg::CameraInfo & camera_info, const geometry_msgs::msg::Point & point);
+    const sensor_msgs::msg::CameraInfo & camera_info,
+    const geometry_msgs::msg::Point & point);
   double normalizeAngle(const double & angle);
   bool getTrafficLightRoi(
-			  const geometry_msgs::msg::Pose & camera_pose, const sensor_msgs::msg::CameraInfo & camera_info,
-			  const lanelet::ConstLineString3d traffic_light, const Config & config,
-			  autoware_perception_msgs::msg::TrafficLightRoi & tl_roi);
+    const geometry_msgs::msg::Pose & camera_pose,
+    const sensor_msgs::msg::CameraInfo & camera_info,
+    const lanelet::ConstLineString3d traffic_light,
+    const Config & config,
+    autoware_perception_msgs::msg::TrafficLightRoi & tl_roi);
   void publishVisibleTrafficLights(
-				   const geometry_msgs::msg::PoseStamped camera_pose_stamped,
-				   const std::vector<lanelet::ConstLineString3d> & visible_traffic_lights,
-				   const rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub);
-				   // const ros::Publisher & pub
-				   
+    const geometry_msgs::msg::PoseStamped camera_pose_stamped,
+    const std::vector<lanelet::ConstLineString3d> & visible_traffic_lights,
+    const rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub);
 };
 }  // namespace traffic_light

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/include/traffic_light_map_based_detector/node.hpp
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/include/traffic_light_map_based_detector/node.hpp
@@ -30,7 +30,6 @@
 #include <autoware_planning_msgs/msg/route.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
-#include <tf2/transform_datatypes.h>
 #include <tf2_ros/transform_listener.h>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -70,7 +69,7 @@ private:
   rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightRoiArray>::SharedPtr roi_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr viz_pub_;
 
-  tf2::BufferCore tf_buffer_;
+  tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 
   using TrafficLightSet = std::set<lanelet::ConstLineString3d, IdLessThan>;

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/launch/traffic_light_map_based_detector.launch.xml
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/launch/traffic_light_map_based_detector.launch.xml
@@ -7,11 +7,10 @@
   <arg name="input/route" default="/planning/mission_planning/route" />
   <arg name="output/rois" default="output/rois" />
 
-  <node pkg="traffic_light_map_based_detector" type="traffic_light_map_based_detector_node" name="traffic_light_map_based_detector" output="screen">
-    <remap from="~input/vector_map" to="$(arg input/vector_map)" />
-    <remap from="~input/camera_info" to="$(arg input/camera_info)" />
-    <remap from="~input/route" to="$(arg input/route)" />
-    <remap from="~output/rois" to="$(arg output/rois)" />
-    <rosparam command="load" file="$(find traffic_light_map_based_detector)/config/traffic_light_map_based_detector.yaml" />
+  <node pkg="traffic_light_map_based_detector" exec="traffic_light_map_based_detector_node" name="traffic_light_map_based_detector" output="screen">
+    <remap from="/input/vector_map" to="$(val input/vector_map)" />
+    <remap from="/input/camera_info" to="$(val input/camera_info)" />
+    <remap from="/input/route" to="$(val input/route)" />
+    <remap from="/output/rois" to="$(val output/rois)" />
   </node>
 </launch>

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/launch/traffic_light_map_based_detector.launch.xml
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/launch/traffic_light_map_based_detector.launch.xml
@@ -8,9 +8,9 @@
   <arg name="output/rois" default="output/rois" />
 
   <node pkg="traffic_light_map_based_detector" exec="traffic_light_map_based_detector_node" name="traffic_light_map_based_detector" output="screen">
-    <remap from="/input/vector_map" to="$(val input/vector_map)" />
-    <remap from="/input/camera_info" to="$(val input/camera_info)" />
-    <remap from="/input/route" to="$(val input/route)" />
-    <remap from="/output/rois" to="$(val output/rois)" />
+    <remap from="/input/vector_map" to="$(var input/vector_map)" />
+    <remap from="/input/camera_info" to="$(var input/camera_info)" />
+    <remap from="/input/route" to="$(var input/route)" />
+    <remap from="/output/rois" to="$(var output/rois)" />
   </node>
 </launch>

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/package.xml
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/package.xml
@@ -18,7 +18,6 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 
-
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/package.xml
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/package.xml
@@ -12,7 +12,7 @@
   <build_depend>autoware_planning_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>lanelet2_extension</build_depend>
-  <build_depend>roscpp</build_depend>
+  <build_depend>rclcpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
@@ -20,7 +20,7 @@
   <build_export_depend>autoware_planning_msgs</build_export_depend>
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>lanelet2_extension</build_export_depend>
-  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>rclcpp</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
   <build_export_depend>tf2</build_export_depend>
   <build_export_depend>tf2_ros</build_export_depend>
@@ -28,7 +28,7 @@
   <exec_depend>autoware_planning_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>lanelet2_extension</exec_depend>
-  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_ros</exec_depend>

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/package.xml
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>autoware_perception_msgs</depend>
+  <depend>autoware_lanelet2_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/package.xml
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/package.xml
@@ -7,36 +7,21 @@
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <license>Apache2</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>autoware_perception_msgs</build_depend>
-  <build_depend>autoware_planning_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>lanelet2_extension</build_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>tf2</build_depend>
-  <build_depend>tf2_ros</build_depend>
-  <build_export_depend>autoware_perception_msgs</build_export_depend>
-  <build_export_depend>autoware_planning_msgs</build_export_depend>
-  <build_export_depend>geometry_msgs</build_export_depend>
-  <build_export_depend>lanelet2_extension</build_export_depend>
-  <build_export_depend>rclcpp</build_export_depend>
-  <build_export_depend>sensor_msgs</build_export_depend>
-  <build_export_depend>tf2</build_export_depend>
-  <build_export_depend>tf2_ros</build_export_depend>
-  <exec_depend>autoware_perception_msgs</exec_depend>
-  <exec_depend>autoware_planning_msgs</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>lanelet2_extension</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>tf2</exec_depend>
-  <exec_depend>tf2_ros</exec_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>lanelet2_extension</depend>
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->
-
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/src/main.cpp
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/src/main.cpp
@@ -26,8 +26,7 @@ int main(int argc, char ** argv)
   
   auto node = std::make_shared<traffic_light::MapBasedDetector>();
   
-  rclcpp::spin(node);
-  
+  rclcpp::spin(node);  
   rclcpp::shutdown();
 
   return 0;

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/src/main.cpp
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/src/main.cpp
@@ -17,15 +17,18 @@
  *
  */
 
-#include <ros/ros.h>
 #include <traffic_light_map_based_detector/node.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 int main(int argc, char ** argv)
-{
-  ros::init(argc, argv, "traffic_light_map_based_detector");
-  traffic_light::MapBasedDetector node;
-
-  ros::spin();
+{  
+  rclcpp::init(argc, argv);
+  
+  auto node = std::make_shared<traffic_light::MapBasedDetector>();
+  
+  rclcpp::spin(node);
+  
+  rclcpp::shutdown();
 
   return 0;
 }

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/src/node.cpp
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/src/node.cpp
@@ -78,7 +78,7 @@ namespace traffic_light
   try {
     geometry_msgs::msg::TransformStamped transform;
     transform = tf_buffer_.lookupTransform(
-       "map", input_msg->header.frame_id, tf2::TimePointZero);
+      "map", input_msg->header.frame_id, tf2::TimePointZero);
     camera_pose_stamped.header = input_msg->header;
     camera_pose_stamped.pose.position.x = transform.transform.translation.x;
     camera_pose_stamped.pose.position.y = transform.transform.translation.y;
@@ -88,7 +88,7 @@ namespace traffic_light
     camera_pose_stamped.pose.orientation.z = transform.transform.rotation.z;
     camera_pose_stamped.pose.orientation.w = transform.transform.rotation.w;
   } catch (tf2::TransformException & ex) {
-    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5,
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000,
       "cannot get transform frome map frame to camera frame");
     return;
   }
@@ -399,7 +399,7 @@ void MapBasedDetector::publishVisibleTrafficLights(
     point.z = tf_camera2tl.getOrigin().z();
     marker.points.push_back(point);
 
-    marker.lifetime = rclcpp::Duration(0.2);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
     marker.color.a = 1.0;  // Don't forget to set the alpha!
     marker.color.r = 0.0;
     marker.color.g = 1.0;

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/src/node.cpp
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/src/node.cpp
@@ -21,7 +21,6 @@
 #include <lanelet2_extension/utility/utilities.h>
 #include <lanelet2_extension/visualization/visualization.h>
 
-
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/Point.h>
 #include <lanelet2_projection/UTM.h>
@@ -47,20 +46,18 @@ namespace traffic_light
   using std::placeholders::_1;
 
   // subscribers
-  map_sub_ = create_subscription<autoware_lanelet2_msgs::msg::MapBin>("input/vector_map", 1, std::bind(&MapBasedDetector::mapCallback, this, _1));
-  camera_info_sub_ = create_subscription<sensor_msgs::msg::CameraInfo>("input/camera_info", 1, std::bind(&MapBasedDetector::cameraInfoCallback, this, _1));
-  route_sub_ = create_subscription<autoware_planning_msgs::msg::Route>("input/route", 1, std::bind(&MapBasedDetector::routeCallback, this, _1));
+  map_sub_ = create_subscription<autoware_lanelet2_msgs::msg::MapBin>(
+    "input/vector_map", 1, std::bind(&MapBasedDetector::mapCallback, this, _1));
+  camera_info_sub_ = create_subscription<sensor_msgs::msg::CameraInfo>(
+    "input/camera_info", 1, std::bind(&MapBasedDetector::cameraInfoCallback, this, _1));
+  route_sub_ = create_subscription<autoware_planning_msgs::msg::Route>(
+    "input/route", 1, std::bind(&MapBasedDetector::routeCallback, this, _1));
 
   // publishers
-  roi_pub_ = this->create_publisher<autoware_perception_msgs::msg::TrafficLightRoiArray>("output/rois", 1);
-  viz_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("debug/markers", 1);
-  
-  // parameters
-  //  pnh_.getParam("max_vibration_pitch", config_.max_vibration_pitch);
-  // pnh_.getParam("max_vibration_yaw", config_.max_vibration_yaw);
-  // pnh_.getParam("max_vibration_height", config_.max_vibration_height);
-  // pnh_.getParam("max_vibration_width", config_.max_vibration_width);
-  // pnh_.getParam("max_vibration_depth", config_.max_vibration_depth);
+  roi_pub_ = this->create_publisher<autoware_perception_msgs::msg::TrafficLightRoiArray>(
+    "output/rois", 1);
+  viz_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
+    "debug/markers", 1);
 
   // parameter declaration needs default values: are 0.0 goof defaults for this?
   config_.max_vibration_pitch = declare_parameter<double>("max_vibration_pitch", 0.0);
@@ -91,8 +88,8 @@ namespace traffic_light
     camera_pose_stamped.pose.orientation.z = transform.transform.rotation.z;
     camera_pose_stamped.pose.orientation.w = transform.transform.rotation.w;
   } catch (tf2::TransformException & ex) {
-    // static constexpr auto duration = (std::literals::5000ms).count();
-    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5, "cannot get transform frome map frame to camera frame");
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5,
+      "cannot get transform frome map frame to camera frame");
     return;
   }
 
@@ -119,8 +116,10 @@ namespace traffic_light
 }
 
 bool MapBasedDetector::getTrafficLightRoi(
-					  const geometry_msgs::msg::Pose & camera_pose, const sensor_msgs::msg::CameraInfo & camera_info,
-  const lanelet::ConstLineString3d traffic_light, const Config & config,
+  const geometry_msgs::msg::Pose & camera_pose,
+  const sensor_msgs::msg::CameraInfo & camera_info,
+  const lanelet::ConstLineString3d traffic_light,
+  const Config & config,
   autoware_perception_msgs::msg::TrafficLightRoi & tl_roi)
 {
   const double tl_height = traffic_light.attributeOr("height", 0.0);
@@ -193,7 +192,8 @@ bool MapBasedDetector::getTrafficLightRoi(
   return true;
 }
 
-void MapBasedDetector::mapCallback(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr input_msg)
+void MapBasedDetector::mapCallback(
+  const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr input_msg)
 {
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
 
@@ -216,7 +216,8 @@ void MapBasedDetector::mapCallback(const autoware_lanelet2_msgs::msg::MapBin::Co
   }
 }
 
-void MapBasedDetector::routeCallback(const autoware_planning_msgs::msg::Route::ConstSharedPtr input_msg)
+void MapBasedDetector::routeCallback(
+  const autoware_planning_msgs::msg::Route::ConstSharedPtr input_msg)
 {
   if (lanelet_map_ptr_ == nullptr) {
     RCLCPP_WARN(get_logger(), "cannot set traffic light in route because don't recieve map");
@@ -246,7 +247,8 @@ void MapBasedDetector::routeCallback(const autoware_planning_msgs::msg::Route::C
 
 void MapBasedDetector::isInVisibility(
   const MapBasedDetector::TrafficLightSet & all_traffic_lights,
-  const geometry_msgs::msg::Pose & camera_pose, const sensor_msgs::msg::CameraInfo & camera_info,
+  const geometry_msgs::msg::Pose & camera_pose,
+  const sensor_msgs::msg::CameraInfo & camera_info,
   std::vector<lanelet::ConstLineString3d> & visible_traffic_lights)
 {
   for (const auto & traffic_light : all_traffic_lights) {
@@ -302,7 +304,8 @@ void MapBasedDetector::isInVisibility(
 }
 
 bool MapBasedDetector::isInDistanceRange(
-					 const geometry_msgs::msg::Point & tl_point, const geometry_msgs::msg::Point & camera_point,
+  const geometry_msgs::msg::Point & tl_point,
+  const geometry_msgs::msg::Point & camera_point,
   const double max_distance_range)
 {
   const double sq_dist = (tl_point.x - camera_point.x) * (tl_point.x - camera_point.x) +
@@ -311,7 +314,9 @@ bool MapBasedDetector::isInDistanceRange(
 }
 
 bool MapBasedDetector::isInAngleRange(
-  const double & tl_yaw, const double & camera_yaw, const double max_angele_range)
+  const double & tl_yaw,
+  const double & camera_yaw,
+  const double max_angele_range)
 {
   Eigen::Vector2d vec1, vec2;
   vec1 << std::cos(tl_yaw), std::sin(tl_yaw);
@@ -321,7 +326,8 @@ bool MapBasedDetector::isInAngleRange(
 }
 
 bool MapBasedDetector::isInImageFrame(
-				      const sensor_msgs::msg::CameraInfo & camera_info, const geometry_msgs::msg::Point & point)
+  const sensor_msgs::msg::CameraInfo & camera_info,
+  const geometry_msgs::msg::Point & point)
 {
   const double & camera_x = point.x;
   const double & camera_y = point.y;
@@ -339,7 +345,7 @@ bool MapBasedDetector::isInImageFrame(
 }
 
 void MapBasedDetector::publishVisibleTrafficLights(
-						   const geometry_msgs::msg::PoseStamped camera_pose_stamped,
+  const geometry_msgs::msg::PoseStamped camera_pose_stamped,
   const std::vector<lanelet::ConstLineString3d> & visible_traffic_lights,
   const rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub)
 {

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/src/node.cpp
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/src/node.cpp
@@ -17,54 +17,71 @@
  *
  */
 
-#include <ros/ros.h>
-
-#include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_core/geometry/Point.h>
 #include <lanelet2_extension/utility/message_conversion.h>
 #include <lanelet2_extension/utility/utilities.h>
 #include <lanelet2_extension/visualization/visualization.h>
+
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/geometry/Point.h>
 #include <lanelet2_projection/UTM.h>
 #include <lanelet2_routing/RoutingGraphContainer.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
 
-#include <autoware_perception_msgs/TrafficLightRoi.h>
+#include <autoware_perception_msgs/msg/traffic_light_roi.h>
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Transform.h>
 #include <traffic_light_map_based_detector/node.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
 namespace traffic_light
 {
-MapBasedDetector::MapBasedDetector() : nh_(""), pnh_("~"), tf_listener_(tf_buffer_)
+  MapBasedDetector::MapBasedDetector() : Node("traffic_light_map_based_detector"), tf_listener_(tf_buffer_)
 {
-  map_sub_ = pnh_.subscribe("input/vector_map", 1, &MapBasedDetector::mapCallback, this);
-  camera_info_sub_ =
-    pnh_.subscribe("input/camera_info", 1, &MapBasedDetector::cameraInfoCallback, this);
-  route_sub_ = pnh_.subscribe("input/route", 1, &MapBasedDetector::routeCallback, this);
-  roi_pub_ = pnh_.advertise<autoware_perception_msgs::TrafficLightRoiArray>("output/rois", 1);
-  viz_pub_ = pnh_.advertise<visualization_msgs::MarkerArray>("debug/markers", 1);
-  pnh_.getParam("max_vibration_pitch", config_.max_vibration_pitch);
-  pnh_.getParam("max_vibration_yaw", config_.max_vibration_yaw);
-  pnh_.getParam("max_vibration_height", config_.max_vibration_height);
-  pnh_.getParam("max_vibration_width", config_.max_vibration_width);
-  pnh_.getParam("max_vibration_depth", config_.max_vibration_depth);
+
+  using std::placeholders::_1;
+
+  // subscribers
+  map_sub_ = create_subscription<autoware_lanelet2_msgs::msg::MapBin>("input/vector_map", 1, std::bind(&MapBasedDetector::mapCallback, this, _1));
+  camera_info_sub_ = create_subscription<sensor_msgs::msg::CameraInfo>("input/camera_info", 1, std::bind(&MapBasedDetector::cameraInfoCallback, this, _1));
+  route_sub_ = create_subscription<autoware_planning_msgs::msg::Route>("input/route", 1, std::bind(&MapBasedDetector::routeCallback, this, _1));
+
+  // publishers
+  roi_pub_ = this->create_publisher<autoware_perception_msgs::msg::TrafficLightRoiArray>("output/rois", 1);
+  viz_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("debug/markers", 1);
+  
+  // parameters
+  //  pnh_.getParam("max_vibration_pitch", config_.max_vibration_pitch);
+  // pnh_.getParam("max_vibration_yaw", config_.max_vibration_yaw);
+  // pnh_.getParam("max_vibration_height", config_.max_vibration_height);
+  // pnh_.getParam("max_vibration_width", config_.max_vibration_width);
+  // pnh_.getParam("max_vibration_depth", config_.max_vibration_depth);
+
+  // parameter declaration needs default values: are 0.0 goof defaults for this?
+  config_.max_vibration_pitch = declare_parameter<double>("max_vibration_pitch", 0.0);
+  config_.max_vibration_yaw = declare_parameter<double>("max_vibration_yaw", 0.0);
+  config_.max_vibration_height = declare_parameter<double>("max_vibration_height", 0.0);
+  config_.max_vibration_width = declare_parameter<double>("max_vibration_width", 0.0);
+  config_.max_vibration_depth = declare_parameter<double>("max_vibration_depth", 0.0);
 }
 
-void MapBasedDetector::cameraInfoCallback(const sensor_msgs::CameraInfo::ConstPtr & input_msg)
+  void MapBasedDetector::cameraInfoCallback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_msg)
 {
   camera_info_ptr_ = input_msg;
   if (lanelet_map_ptr_ == nullptr || camera_info_ptr_ == nullptr) return;
 
-  autoware_perception_msgs::TrafficLightRoiArray output_msg;
+  autoware_perception_msgs::msg::TrafficLightRoiArray output_msg;
   output_msg.header = camera_info_ptr_->header;
-  geometry_msgs::PoseStamped camera_pose_stamped;
+  geometry_msgs::msg::PoseStamped camera_pose_stamped;
   try {
-    geometry_msgs::TransformStamped transform;
+    geometry_msgs::msg::TransformStamped transform;
     transform = tf_buffer_.lookupTransform(
-      "map", input_msg->header.frame_id, input_msg->header.stamp, ros::Duration(0.2));
+       "map", input_msg->header.frame_id, tf2::TimePointZero);
     camera_pose_stamped.header = input_msg->header;
     camera_pose_stamped.pose.position.x = transform.transform.translation.x;
     camera_pose_stamped.pose.position.y = transform.transform.translation.y;
@@ -74,11 +91,12 @@ void MapBasedDetector::cameraInfoCallback(const sensor_msgs::CameraInfo::ConstPt
     camera_pose_stamped.pose.orientation.z = transform.transform.rotation.z;
     camera_pose_stamped.pose.orientation.w = transform.transform.rotation.w;
   } catch (tf2::TransformException & ex) {
-    ROS_WARN_THROTTLE(5, "cannot get transform frome map frame to camera frame");
+    // static constexpr auto duration = (std::literals::5000ms).count();
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5, "cannot get transform frome map frame to camera frame");
     return;
   }
 
-  const sensor_msgs::CameraInfo & camera_info = *input_msg;
+  const sensor_msgs::msg::CameraInfo & camera_info = *input_msg;
   std::vector<lanelet::ConstLineString3d> visible_traffic_lights;
   if (route_traffic_lights_ptr_ != nullptr)
     isInVisibility(
@@ -90,26 +108,26 @@ void MapBasedDetector::cameraInfoCallback(const sensor_msgs::CameraInfo::ConstPt
     return;
 
   for (const auto & traffic_light : visible_traffic_lights) {
-    autoware_perception_msgs::TrafficLightRoi tl_roi;
+    autoware_perception_msgs::msg::TrafficLightRoi tl_roi;
     if (!getTrafficLightRoi(camera_pose_stamped.pose, camera_info, traffic_light, config_, tl_roi))
       continue;
 
     output_msg.rois.push_back(tl_roi);
   }
-  roi_pub_.publish(output_msg);
+  roi_pub_->publish(output_msg);
   publishVisibleTrafficLights(camera_pose_stamped, visible_traffic_lights, viz_pub_);
 }
 
 bool MapBasedDetector::getTrafficLightRoi(
-  const geometry_msgs::Pose & camera_pose, const sensor_msgs::CameraInfo & camera_info,
+					  const geometry_msgs::msg::Pose & camera_pose, const sensor_msgs::msg::CameraInfo & camera_info,
   const lanelet::ConstLineString3d traffic_light, const Config & config,
-  autoware_perception_msgs::TrafficLightRoi & tl_roi)
+  autoware_perception_msgs::msg::TrafficLightRoi & tl_roi)
 {
   const double tl_height = traffic_light.attributeOr("height", 0.0);
-  const double & fx = camera_info.K[(0 * 3) + 0];
-  const double & fy = camera_info.K[(1 * 3) + 1];
-  const double & cx = camera_info.K[(0 * 3) + 2];
-  const double & cy = camera_info.K[(1 * 3) + 2];
+  const double & fx = camera_info.k[(0 * 3) + 0];
+  const double & fy = camera_info.k[(1 * 3) + 1];
+  const double & cx = camera_info.k[(0 * 3) + 2];
+  const double & cy = camera_info.k[(1 * 3) + 2];
   const auto & tl_left_down_point = traffic_light.front();
   const auto & tl_right_down_point = traffic_light.back();
   tf2::Transform tf_map2camera(
@@ -175,11 +193,11 @@ bool MapBasedDetector::getTrafficLightRoi(
   return true;
 }
 
-void MapBasedDetector::mapCallback(const autoware_lanelet2_msgs::MapBin & input_msg)
+void MapBasedDetector::mapCallback(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr input_msg)
 {
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
-  lanelet::utils::conversion::fromBinMsg(
-    input_msg, lanelet_map_ptr_, &traffic_rules_ptr_, &routing_graph_ptr_);
+
+  lanelet::utils::conversion::fromBinMsg(*input_msg, lanelet_map_ptr_);
   lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_ptr_);
   std::vector<lanelet::AutowareTrafficLightConstPtr> all_lanelet_traffic_lights =
     lanelet::utils::query::autowareTrafficLights(all_lanelets);
@@ -198,10 +216,10 @@ void MapBasedDetector::mapCallback(const autoware_lanelet2_msgs::MapBin & input_
   }
 }
 
-void MapBasedDetector::routeCallback(const autoware_planning_msgs::Route::ConstPtr & input_msg)
+void MapBasedDetector::routeCallback(const autoware_planning_msgs::msg::Route::ConstSharedPtr input_msg)
 {
   if (lanelet_map_ptr_ == nullptr) {
-    ROS_WARN("cannot set traffic light in route because don't recieve map");
+    RCLCPP_WARN(get_logger(), "cannot set traffic light in route because don't recieve map");
     return;
   }
   lanelet::ConstLanelets route_lanelets;
@@ -228,7 +246,7 @@ void MapBasedDetector::routeCallback(const autoware_planning_msgs::Route::ConstP
 
 void MapBasedDetector::isInVisibility(
   const MapBasedDetector::TrafficLightSet & all_traffic_lights,
-  const geometry_msgs::Pose & camera_pose, const sensor_msgs::CameraInfo & camera_info,
+  const geometry_msgs::msg::Pose & camera_pose, const sensor_msgs::msg::CameraInfo & camera_info,
   std::vector<lanelet::ConstLineString3d> & visible_traffic_lights)
 {
   for (const auto & traffic_light : all_traffic_lights) {
@@ -237,7 +255,7 @@ void MapBasedDetector::isInVisibility(
     const double tl_height = traffic_light.attributeOr("height", 0.0);
 
     // check distance range
-    geometry_msgs::Point tl_central_point;
+    geometry_msgs::msg::Point tl_central_point;
     tl_central_point.x = (tl_right_down_point.x() + tl_left_down_point.x()) / 2.0;
     tl_central_point.y = (tl_right_down_point.y() + tl_left_down_point.y()) / 2.0;
     tl_central_point.z = (tl_right_down_point.z() + tl_left_down_point.z() + tl_height) / 2.0;
@@ -274,7 +292,7 @@ void MapBasedDetector::isInVisibility(
     tf2::Transform tf_camera2tl;
     tf_camera2tl = tf_map2camera.inverse() * tf_map2tl;
 
-    geometry_msgs::Point camera2tl_point;
+    geometry_msgs::msg::Point camera2tl_point;
     camera2tl_point.x = tf_camera2tl.getOrigin().x();
     camera2tl_point.y = tf_camera2tl.getOrigin().y();
     camera2tl_point.z = tf_camera2tl.getOrigin().z();
@@ -284,7 +302,7 @@ void MapBasedDetector::isInVisibility(
 }
 
 bool MapBasedDetector::isInDistanceRange(
-  const geometry_msgs::Point & tl_point, const geometry_msgs::Point & camera_point,
+					 const geometry_msgs::msg::Point & tl_point, const geometry_msgs::msg::Point & camera_point,
   const double max_distance_range)
 {
   const double sq_dist = (tl_point.x - camera_point.x) * (tl_point.x - camera_point.x) +
@@ -303,15 +321,15 @@ bool MapBasedDetector::isInAngleRange(
 }
 
 bool MapBasedDetector::isInImageFrame(
-  const sensor_msgs::CameraInfo & camera_info, const geometry_msgs::Point & point)
+				      const sensor_msgs::msg::CameraInfo & camera_info, const geometry_msgs::msg::Point & point)
 {
   const double & camera_x = point.x;
   const double & camera_y = point.y;
   const double & camera_z = point.z;
-  const double & fx = camera_info.K[(0 * 3) + 0];
-  const double & fy = camera_info.K[(1 * 3) + 1];
-  const double & cx = camera_info.K[(0 * 3) + 2];
-  const double & cy = camera_info.K[(1 * 3) + 2];
+  const double & fx = camera_info.k[(0 * 3) + 0];
+  const double & fy = camera_info.k[(1 * 3) + 1];
+  const double & cx = camera_info.k[(0 * 3) + 2];
+  const double & cy = camera_info.k[(1 * 3) + 2];
   if (camera_z <= 0.0) return false;
   const double image_u = (fx * camera_x + cx * camera_z) / camera_z;
   const double image_v = (fy * camera_y + cy * camera_z) / camera_z;
@@ -321,23 +339,23 @@ bool MapBasedDetector::isInImageFrame(
 }
 
 void MapBasedDetector::publishVisibleTrafficLights(
-  const geometry_msgs::PoseStamped camera_pose_stamped,
+						   const geometry_msgs::msg::PoseStamped camera_pose_stamped,
   const std::vector<lanelet::ConstLineString3d> & visible_traffic_lights,
-  const ros::Publisher & pub)
+  const rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub)
 {
-  visualization_msgs::MarkerArray output_msg;
+  visualization_msgs::msg::MarkerArray output_msg;
   for (const auto & traffic_light : visible_traffic_lights) {
     const auto & tl_left_down_point = traffic_light.front();
     const auto & tl_right_down_point = traffic_light.back();
     const double tl_height = traffic_light.attributeOr("height", 0.0);
     const int id = traffic_light.id();
 
-    geometry_msgs::Point tl_central_point;
+    geometry_msgs::msg::Point tl_central_point;
     tl_central_point.x = (tl_right_down_point.x() + tl_left_down_point.x()) / 2.0;
     tl_central_point.y = (tl_right_down_point.y() + tl_left_down_point.y()) / 2.0;
     tl_central_point.z = (tl_right_down_point.z() + tl_left_down_point.z() + tl_height) / 2.0;
 
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
 
     tf2::Transform tf_map2camera(
       tf2::Quaternion(
@@ -354,10 +372,10 @@ void MapBasedDetector::publishVisibleTrafficLights(
 
     marker.header = camera_pose_stamped.header;
     marker.id = id;
-    marker.type = visualization_msgs::Marker::LINE_LIST;
+    marker.type = visualization_msgs::msg::Marker::LINE_LIST;
     marker.ns = std::string("beam");
     marker.scale.x = 0.05;
-    marker.action = visualization_msgs::Marker::MODIFY;
+    marker.action = visualization_msgs::msg::Marker::MODIFY;
     marker.pose.position.x = 0.0;
     marker.pose.position.y = 0.0;
     marker.pose.position.z = 0.0;
@@ -365,7 +383,7 @@ void MapBasedDetector::publishVisibleTrafficLights(
     marker.pose.orientation.y = 0.0;
     marker.pose.orientation.z = 0.0;
     marker.pose.orientation.w = 1.0;
-    geometry_msgs::Point point;
+    geometry_msgs::msg::Point point;
     point.x = 0.0;
     point.y = 0.0;
     point.z = 0.0;
@@ -375,7 +393,7 @@ void MapBasedDetector::publishVisibleTrafficLights(
     point.z = tf_camera2tl.getOrigin().z();
     marker.points.push_back(point);
 
-    marker.lifetime = ros::Duration(0.2);
+    marker.lifetime = rclcpp::Duration(0.2);
     marker.color.a = 1.0;  // Don't forget to set the alpha!
     marker.color.r = 0.0;
     marker.color.g = 1.0;
@@ -383,7 +401,7 @@ void MapBasedDetector::publishVisibleTrafficLights(
 
     output_msg.markers.push_back(marker);
   }
-  pub.publish(output_msg);
+  pub->publish(output_msg);
 
   return;
 }

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/src/node.cpp
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/src/node.cpp
@@ -40,7 +40,7 @@
 
 namespace traffic_light
 {
-  MapBasedDetector::MapBasedDetector() : Node("traffic_light_map_based_detector"), tf_listener_(tf_buffer_)
+  MapBasedDetector::MapBasedDetector() : Node("traffic_light_map_based_detector"), tf_buffer_(this->get_clock()), tf_listener_(tf_buffer_)
 {
 
   using std::placeholders::_1;
@@ -78,7 +78,10 @@ namespace traffic_light
   try {
     geometry_msgs::msg::TransformStamped transform;
     transform = tf_buffer_.lookupTransform(
-      "map", input_msg->header.frame_id, tf2::TimePointZero);
+      "map",
+      input_msg->header.frame_id,
+      input_msg->header.stamp,
+      rclcpp::Duration(0.2));
     camera_pose_stamped.header = input_msg->header;
     camera_pose_stamped.pose.position.x = transform.transform.translation.x;
     camera_pose_stamped.pose.position.y = transform.transform.translation.y;


### PR DESCRIPTION
Porting traffic light map detector module to ROS2.

Module has standard ROS interfaces, port:
[x] CMakeLists to use ament
[x] convert messages, rclcpp calls
[x] setup subscribers and publishers
