### PR TITLE
ROS2 Porting: scenario_selector

### DIFF
--- a/planning/scenario_planning/scenario_selector/CMakeLists.txt
+++ b/planning/scenario_planning/scenario_selector/CMakeLists.txt
@@ -1,69 +1,62 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(scenario_selector)
 
-add_compile_options(-std=c++14)
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
+endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  autoware_lanelet2_msgs
-  autoware_planning_msgs
-  lanelet2_extension
-  roscpp
-  tf2
-  tf2_ros
-  tf2_geometry_msgs
-)
-
-catkin_package(
-  INCLUDE_DIRS
-    include
-  CATKIN_DEPENDS
-    autoware_lanelet2_msgs
-    autoware_planning_msgs
-    lanelet2_extension
-    tf2
-    tf2_ros
-    tf2_geometry_msgs
-)
-
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-)
+## Dependencies
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 # Target
-## scenario_selector_node
-add_executable(scenario_selector
-  src/scenario_selector_node/main.cpp
+
+## Target executable
+set(SCENARIO_SELECTOR_SRC
   src/scenario_selector_node/scenario_selector_node.cpp
 )
 
-target_link_libraries(scenario_selector
-  ${catkin_LIBRARIES}
+## scenario_selector_node
+ament_auto_add_executable(scenario_selector
+  src/scenario_selector_node/main.cpp
+  ${SCENARIO_SELECTOR_SRC}
 )
 
-add_dependencies(scenario_selector
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
-)
+# target_link_libraries(scenario_selector
+#   ${catkin_LIBRARIES}
+# )
 
-# Install
-## executables and libraries
-install(
-  TARGETS
-    scenario_selector
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
+# add_dependencies(scenario_selector
+#   ${${PROJECT_NAME}_EXPORTED_TARGETS}
+#   ${catkin_EXPORTED_TARGETS}
+# )
 
-## project namespaced headers
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
+# # Install
+# ## executables and libraries
+# install(
+#   TARGETS
+#     scenario_selector
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
 
-## launch files
-install(
-  DIRECTORY
-    launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# ## project namespaced headers
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+# )
+
+# ## launch files
+# install(
+#   DIRECTORY
+#     launch
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+ament_auto_package(INSTALL_TO_SHARE
+  launch
 )

--- a/planning/scenario_planning/scenario_selector/CMakeLists.txt
+++ b/planning/scenario_planning/scenario_selector/CMakeLists.txt
@@ -26,37 +26,6 @@ ament_auto_add_executable(scenario_selector
   ${SCENARIO_SELECTOR_SRC}
 )
 
-# target_link_libraries(scenario_selector
-#   ${catkin_LIBRARIES}
-# )
-
-# add_dependencies(scenario_selector
-#   ${${PROJECT_NAME}_EXPORTED_TARGETS}
-#   ${catkin_EXPORTED_TARGETS}
-# )
-
-# # Install
-# ## executables and libraries
-# install(
-#   TARGETS
-#     scenario_selector
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-# ## project namespaced headers
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-# )
-
-# ## launch files
-# install(
-#   DIRECTORY
-#     launch
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
 ament_auto_package(INSTALL_TO_SHARE
   launch
 )

--- a/planning/scenario_planning/scenario_selector/include/scenario_selector/scenario_selector_node.h
+++ b/planning/scenario_planning/scenario_selector/include/scenario_selector/scenario_selector_node.h
@@ -37,14 +37,14 @@
 
 struct Input
 {
-  // ros::Subscriber sub_trajectory;
+  rclcpp::Subscription<autoware_planning_msgs::msg::Trajectory>::SharedPtr sub_trajectory;
   autoware_planning_msgs::msg::Trajectory::ConstSharedPtr buf_trajectory;
 };
 
 struct Output
 {
-  // ros::Publisher pub_scenario;
-  // ros::Publisher pub_trajectory;
+  rclcpp::Publisher<autoware_planning_msgs::msg::Scenario>::SharedPtr pub_scenario;
+  rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr pub_trajectory;
 };
 
 class ScenarioSelectorNode : public rclcpp::Node
@@ -63,17 +63,14 @@ public:
   Input getScenarioInput(const std::string & scenario);
 
 private:
-  // ros::NodeHandle nh_;
-  // ros::NodeHandle private_nh_;
-
   rclcpp::TimerBase::SharedPtr timer_;
 
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 
-  // ros::Subscriber sub_lanelet_map_;
-  // ros::Subscriber sub_route_;
-  // ros::Subscriber sub_twist_;
+  rclcpp::Subscription<autoware_lanelet2_msgs::msg::MapBin>::SharedPtr sub_lanelet_map_;
+  rclcpp::Subscription<autoware_planning_msgs::msg::Route>::SharedPtr sub_route_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_twist_;
 
   Input input_lane_driving_;
   Input input_parking_;

--- a/planning/scenario_planning/scenario_selector/include/scenario_selector/scenario_selector_node.h
+++ b/planning/scenario_planning/scenario_selector/include/scenario_selector/scenario_selector_node.h
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-#pragma once
+#ifndef SCENARIO_SELECTOR_SCENARIO_SELECTOR_NODE_H_
+#define SCENARIO_SELECTOR_SCENARIO_SELECTOR_NODE_H_
 
 #include <deque>
 #include <memory>
@@ -23,68 +24,68 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/TrafficRules.h>
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
-#include <autoware_lanelet2_msgs/MapBin.h>
-#include <autoware_planning_msgs/Route.h>
-#include <autoware_planning_msgs/Scenario.h>
-#include <autoware_planning_msgs/Trajectory.h>
-#include <geometry_msgs/TwistStamped.h>
+#include <autoware_lanelet2_msgs/msg/map_bin.hpp>
+#include <autoware_planning_msgs/msg/route.hpp>
+#include <autoware_planning_msgs/msg/scenario.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 
 struct Input
 {
-  ros::Subscriber sub_trajectory;
-  autoware_planning_msgs::Trajectory::ConstPtr buf_trajectory;
+  // ros::Subscriber sub_trajectory;
+  autoware_planning_msgs::msg::Trajectory::ConstSharedPtr buf_trajectory;
 };
 
 struct Output
 {
-  ros::Publisher pub_scenario;
-  ros::Publisher pub_trajectory;
+  // ros::Publisher pub_scenario;
+  // ros::Publisher pub_trajectory;
 };
 
-class ScenarioSelectorNode
+class ScenarioSelectorNode : public rclcpp::Node
 {
 public:
   ScenarioSelectorNode();
 
-  void onMap(const autoware_lanelet2_msgs::MapBin & msg);
-  void onRoute(const autoware_planning_msgs::Route::ConstPtr & msg);
-  void onTwist(const geometry_msgs::TwistStamped::ConstPtr & msg);
+  void onMap(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr msg);
+  void onRoute(const autoware_planning_msgs::msg::Route::ConstSharedPtr msg);
+  void onTwist(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
 
-  void onTimer(const ros::TimerEvent & event);
+  void onTimer();
 
-  autoware_planning_msgs::Scenario selectScenario();
+  autoware_planning_msgs::msg::Scenario selectScenario();
   std::string selectScenarioByPosition();
   Input getScenarioInput(const std::string & scenario);
 
 private:
-  ros::NodeHandle nh_;
-  ros::NodeHandle private_nh_;
+  // ros::NodeHandle nh_;
+  // ros::NodeHandle private_nh_;
 
-  ros::Timer timer_;
+  rclcpp::TimerBase::SharedPtr timer_;
 
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 
-  ros::Subscriber sub_lanelet_map_;
-  ros::Subscriber sub_route_;
-  ros::Subscriber sub_twist_;
+  // ros::Subscriber sub_lanelet_map_;
+  // ros::Subscriber sub_route_;
+  // ros::Subscriber sub_twist_;
 
   Input input_lane_driving_;
   Input input_parking_;
 
   Output output_;
 
-  autoware_planning_msgs::Route::ConstPtr route_;
-  geometry_msgs::PoseStamped::ConstPtr current_pose_;
-  geometry_msgs::TwistStamped::ConstPtr twist_;
+  autoware_planning_msgs::msg::Route::ConstSharedPtr route_;
+  geometry_msgs::msg::PoseStamped::ConstSharedPtr current_pose_;
+  geometry_msgs::msg::TwistStamped::ConstSharedPtr twist_;
 
   std::string current_scenario_;
-  std::deque<geometry_msgs::TwistStamped::ConstPtr> twist_buffer_;
+  std::deque<geometry_msgs::msg::TwistStamped::ConstSharedPtr> twist_buffer_;
 
   std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr_;
   std::shared_ptr<lanelet::routing::RoutingGraph> routing_graph_ptr_;
@@ -97,3 +98,5 @@ private:
   double th_stopped_time_sec_;
   double th_stopped_velocity_mps_;
 };
+
+#endif

--- a/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_lane_driving.launch.xml
+++ b/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_lane_driving.launch.xml
@@ -9,6 +9,10 @@
   <arg name="input_twist" default="" />
   <arg name="is_parking_completed" default="" />
 
-  <node pkg="topic_tools" type="relay" name="scenario_trajectory_relay" args="$(arg input_lane_driving_trajectory) $(arg output_trajectory)" output="screen"/>
-  <node pkg="rostopic" type="rostopic" name="scenario_pub" args="pub $(arg output_scenario) autoware_planning_msgs/Scenario '{current_scenario: LaneDriving, activating_scenarios: [LaneDriving]}'" output="screen"/>
+  <node pkg="topic_tools" exec="relay" name="scenario_trajectory_relay" output="log" >
+    <param name="input_topic" value="$(var input_lane_driving_trajectory)" />
+    <param name="output_topic" value="$(var output_trajectory)" />
+    <param name="type" value="autoware_planning_msgs/msg/Trajectory" />
+  </node>
+  <!-- <node pkg="ros2topic" type="ros2topic" name="scenario_pub" args="pub $(var output_scenario) autoware_planning_msgs/msg/Scenario '{current_scenario: LaneDriving, activating_scenarios: [LaneDriving]}'" output="screen"/> -->
 </launch>

--- a/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_lane_driving.launch.xml
+++ b/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_lane_driving.launch.xml
@@ -15,6 +15,6 @@
     <param name="type" value="autoware_planning_msgs/msg/Trajectory" />
   </node>
 
-  <executable cmd="ros2 topic pub $(var output_scenario) autoware_planning_msgs/msg/Scenario '{current_scenario: LaneDriving, activating_scenarios: [LaneDriving]}'"
-              name="scenario_pub" output="screen" shell="true"/>
+  <arg name="cmd" default="ros2 topic pub $(var output_scenario) autoware_planning_msgs/msg/Scenario '{current_scenario: LaneDriving, activating_scenarios: [LaneDriving]}'" />
+  <executable cmd="$(var cmd)" name="scenario_pub" output="screen" shell="true"/>
 </launch>

--- a/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_lane_driving.launch.xml
+++ b/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_lane_driving.launch.xml
@@ -14,5 +14,7 @@
     <param name="output_topic" value="$(var output_trajectory)" />
     <param name="type" value="autoware_planning_msgs/msg/Trajectory" />
   </node>
-  <!-- <node pkg="ros2topic" type="ros2topic" name="scenario_pub" args="pub $(var output_scenario) autoware_planning_msgs/msg/Scenario '{current_scenario: LaneDriving, activating_scenarios: [LaneDriving]}'" output="screen"/> -->
+
+  <executable cmd="ros2 topic pub $(var output_scenario) autoware_planning_msgs/msg/Scenario '{current_scenario: LaneDriving, activating_scenarios: [LaneDriving]}'"
+              name="scenario_pub" output="screen" shell="true"/>
 </launch>

--- a/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_parking.launch.xml
+++ b/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_parking.launch.xml
@@ -15,5 +15,6 @@
     <param name="type" value="autoware_planning_msgs/msg/Trajectory" />
   </node>
 
-  <!-- <node pkg="ros2cli" type="ros2topic" name="scenario_pub" args="pub $(var output_scenario) autoware_planning_msgs/msg/Scenario '{current_scenario: Parking, activating_scenarios: [Parking]}'" output="screen"/> -->
+  <executable cmd="ros2 topic pub $(var output_scenario) autoware_planning_msgs/msg/Scenario '{current_scenario: Parking, activating_scenarios: [Parking]}'"
+              name="scenario_pub" output="screen" shell="true"/>
 </launch>

--- a/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_parking.launch.xml
+++ b/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_parking.launch.xml
@@ -9,6 +9,11 @@
   <arg name="input_twist" default="" />
   <arg name="is_parking_completed" default="" />
 
-  <node pkg="topic_tools" type="relay" name="scenario_trajectory_relay" args="$(arg input_parking_trajectory) $(arg output_trajectory)" output="screen"/>
-  <node pkg="rostopic" type="rostopic" name="scenario_pub" args="pub $(arg output_scenario) autoware_planning_msgs/Scenario '{current_scenario: Parking, activating_scenarios: [Parking]}'" output="screen"/>
+  <node pkg="topic_tools" exec="relay" name="scenario_trajectory_relay" output="log" >
+    <param name="input_topic" value="$(var input_parking_trajectory)" />
+    <param name="output_topic" value="$(var output_trajectory)" />
+    <param name="type" value="autoware_planning_msgs/msg/Trajectory" />
+  </node>
+
+  <!-- <node pkg="ros2cli" type="ros2topic" name="scenario_pub" args="pub $(var output_scenario) autoware_planning_msgs/msg/Scenario '{current_scenario: Parking, activating_scenarios: [Parking]}'" output="screen"/> -->
 </launch>

--- a/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_parking.launch.xml
+++ b/planning/scenario_planning/scenario_selector/launch/dummy_scenario_selector_parking.launch.xml
@@ -15,6 +15,6 @@
     <param name="type" value="autoware_planning_msgs/msg/Trajectory" />
   </node>
 
-  <executable cmd="ros2 topic pub $(var output_scenario) autoware_planning_msgs/msg/Scenario '{current_scenario: Parking, activating_scenarios: [Parking]}'"
-              name="scenario_pub" output="screen" shell="true"/>
+  <arg name="cmd" default="ros2 topic pub $(var output_scenario) autoware_planning_msgs/msg/Scenario '{current_scenario: Parking, activating_scenarios: [Parking]}'" />
+  <executable cmd="$(var cmd)" name="scenario_pub" output="screen" shell="true"/>
 </launch>

--- a/planning/scenario_planning/scenario_selector/launch/scenario_selector.launch.xml
+++ b/planning/scenario_planning/scenario_selector/launch/scenario_selector.launch.xml
@@ -1,13 +1,13 @@
 <launch>
-  <arg name="input_lane_driving_trajectory" default="test_1" />
-  <arg name="input_parking_trajectory" default="test_2" />
-  <arg name="input_lanelet_map" default="test_" />
-  <arg name="input_route" default="test_3" />
-  <arg name="input_twist" default="test_4" />
-  <arg name="is_parking_completed" default="test_5" />
+  <arg name="input_lane_driving_trajectory" />
+  <arg name="input_parking_trajectory" />
+  <arg name="input_lanelet_map" />
+  <arg name="input_route" />
+  <arg name="input_twist" />
+  <arg name="is_parking_completed" />
 
-  <arg name="output_scenario" default="test_6" />
-  <arg name="output_trajectory" default="test_7" />
+  <arg name="output_scenario" />
+  <arg name="output_trajectory" />
 
   <node pkg="scenario_selector" exec="scenario_selector" name="scenario_selector" output="screen">
     <remap from="input/lane_driving/trajectory" to="$(var input_lane_driving_trajectory)"/>

--- a/planning/scenario_planning/scenario_selector/launch/scenario_selector.launch.xml
+++ b/planning/scenario_planning/scenario_selector/launch/scenario_selector.launch.xml
@@ -1,24 +1,24 @@
 <launch>
-  <arg name="input_lane_driving_trajectory" />
-  <arg name="input_parking_trajectory" />
-  <arg name="input_lanelet_map" />
-  <arg name="input_route" />
-  <arg name="input_twist" />
-  <arg name="is_parking_completed" />
+  <arg name="input_lane_driving_trajectory" default="test_1" />
+  <arg name="input_parking_trajectory" default="test_2" />
+  <arg name="input_lanelet_map" default="test_" />
+  <arg name="input_route" default="test_3" />
+  <arg name="input_twist" default="test_4" />
+  <arg name="is_parking_completed" default="test_5" />
 
-  <arg name="output_scenario" />
-  <arg name="output_trajectory" />
+  <arg name="output_scenario" default="test_6" />
+  <arg name="output_trajectory" default="test_7" />
 
-  <node pkg="scenario_selector" type="scenario_selector" name="scenario_selector" output="screen">
-    <remap from="~input/lane_driving/trajectory" to="$(arg input_lane_driving_trajectory)"/>
-    <remap from="~input/parking/trajectory" to="$(arg input_parking_trajectory)"/>
-    <remap from="~input/lanelet_map" to="$(arg input_lanelet_map)"/>
-    <remap from="~input/route" to="$(arg input_route)"/>
-    <remap from="~input/twist" to="$(arg input_twist)"/>
-    <remap from="is_parking_completed" to="$(arg is_parking_completed)"/>
+  <node pkg="scenario_selector" exec="scenario_selector" name="scenario_selector" output="screen">
+    <remap from="input/lane_driving/trajectory" to="$(var input_lane_driving_trajectory)"/>
+    <remap from="input/parking/trajectory" to="$(var input_parking_trajectory)"/>
+    <remap from="input/lanelet_map" to="$(var input_lanelet_map)"/>
+    <remap from="input/route" to="$(var input_route)"/>
+    <remap from="input/twist" to="$(var input_twist)"/>
+    <remap from="is_parking_completed" to="$(var is_parking_completed)"/>
 
-    <remap from="~output/scenario" to="$(arg output_scenario)"/>
-    <remap from="~output/trajectory" to="$(arg output_trajectory)"/>
+    <remap from="output/scenario" to="$(var output_scenario)"/>
+    <remap from="output/trajectory" to="$(var output_trajectory)"/>
 
     <param name="update_rate" value="10.0" />
     <param name="th_max_message_delay_sec" value="1.0" />

--- a/planning/scenario_planning/scenario_selector/package.xml
+++ b/planning/scenario_planning/scenario_selector/package.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>scenario_selector</name>
   <version>0.1.0</version>
-  <description>The scenario_selector package</description>
+  <description>The scenario_selector ROS2 package</description>
   <maintainer email="kenji.miyake@tier4.jp">Kenji Miyake</maintainer>
-  <license>Apache 2</license>
+  <license>Apache License 2.0</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>autoware_lanelet2_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>lanelet2_extension</depend>
-  <depend>roscpp</depend>
+  <depend>rclcpp</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
 
   <export>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/planning/scenario_planning/scenario_selector/package.xml
+++ b/planning/scenario_planning/scenario_selector/package.xml
@@ -18,6 +18,7 @@
   <depend>tf2_geometry_msgs</depend>
 
   <exec_depend>topic_tools</exec_depend>
+  <exec_depend>ros2cli</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/planning/scenario_planning/scenario_selector/package.xml
+++ b/planning/scenario_planning/scenario_selector/package.xml
@@ -17,6 +17,8 @@
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
 
+  <exec_depend>topic_tools</exec_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/planning/scenario_planning/scenario_selector/src/scenario_selector_node/main.cpp
+++ b/planning/scenario_planning/scenario_selector/src/scenario_selector_node/main.cpp
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
+
 #include <scenario_selector/scenario_selector_node.h>
 
-int main(int argc, char * argv[])
+int main(int argc, char ** argv)
 {
-  ros::init(argc, argv, "scenario_selector");
-
-  ScenarioSelectorNode node;
-
-  ros::spin();
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<ScenarioSelectorNode>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
 
   return 0;
 }

--- a/planning/scenario_planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
+++ b/planning/scenario_planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
@@ -20,8 +20,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/bind.hpp>
-
 #include <lanelet2_core/geometry/BoundingBox.h>
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/geometry/LineString.h>

--- a/planning/scenario_planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
+++ b/planning/scenario_planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
@@ -75,7 +75,7 @@ geometry_msgs::msg::PoseStamped::ConstSharedPtr getCurrentPose(const tf2_ros::Bu
 
   try {
     tf_current_pose =
-      tf_buffer.lookupTransform("map", "base_link", rclcpp::Time(0), rclcpp::Duration(1.0));
+      tf_buffer.lookupTransform("map", "base_link", tf2::TimePointZero);
   } catch (tf2::TransformException & ex) {
     RCLCPP_ERROR(logger, "%s", ex.what());
     return nullptr;
@@ -347,10 +347,9 @@ ScenarioSelectorNode::ScenarioSelectorNode()
   this->get_node_timers_interface()->add_timer(timer_, nullptr);
 
   // Wait for first tf
-  // Maybe use wait for transform
   while (rclcpp::ok()) {
     try {
-      tf_buffer_.lookupTransform("map", "base_link", rclcpp::Time(0), rclcpp::Duration(10.0));
+      tf_buffer_.lookupTransform("map", "base_link", tf2::TimePointZero);
       break;
     } catch (tf2::TransformException & ex) {
       RCLCPP_DEBUG(this->get_logger(), "waiting for initial pose...");

--- a/planning/scenario_planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
+++ b/planning/scenario_planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
@@ -167,7 +167,7 @@ Input ScenarioSelectorNode::getScenarioInput(const std::string & scenario)
 
 std::string ScenarioSelectorNode::selectScenarioByPosition()
 {
-  // const auto is_in_lane = isInLane(lanelet_map_ptr_, current_pose_->pose);
+  const auto is_in_lane = isInLane(lanelet_map_ptr_, current_pose_->pose);
   const auto is_goal_in_lane = isInLane(lanelet_map_ptr_, route_->goal_pose);
   const auto is_in_parking_lot = isInParkingLot(lanelet_map_ptr_, current_pose_->pose);
 
@@ -186,11 +186,12 @@ std::string ScenarioSelectorNode::selectScenarioByPosition()
   }
 
   if (current_scenario_ == autoware_planning_msgs::msg::Scenario::PARKING) {
-    // const auto is_parking_completed = nh_.param<bool>("is_parking_completed", false);
-    // if (is_parking_completed && is_in_lane) {
-      // nh_.setParam("is_parking_completed", false);
+    bool is_parking_completed;
+    this->get_parameter<bool>("is_parking_completed", is_parking_completed);
+    if (is_parking_completed && is_in_lane) {
+      this->set_parameter(rclcpp::Parameter("is_parking_completed", false));
       return autoware_planning_msgs::msg::Scenario::LANEDRIVING;
-    // }
+    }
   }
 
   return current_scenario_;
@@ -299,11 +300,13 @@ ScenarioSelectorNode::ScenarioSelectorNode()
   current_scenario_(autoware_planning_msgs::msg::Scenario::EMPTY)
 {
   // Parameters
-  // private_nh_.param<double>("update_rate", update_rate_, 10.0);
-  // private_nh_.param<double>("th_max_message_delay_sec", th_max_message_delay_sec_, 1.0);
-  // private_nh_.param<double>("th_arrived_distance_m", th_arrived_distance_m_, 1.0);
-  // private_nh_.param<double>("th_stopped_time_sec", th_stopped_time_sec_, 1.0);
-  // private_nh_.param<double>("th_stopped_velocity_mps", th_stopped_velocity_mps_, 0.01);
+  update_rate_ = this->declare_parameter<double>("update_rate", 10.0);
+  th_max_message_delay_sec_ = this->declare_parameter<double>("th_max_message_delay_sec", 1.0);
+  th_arrived_distance_m_ = this->declare_parameter<double>("th_arrived_distance_m", 1.0);
+  th_stopped_time_sec_ = this->declare_parameter<double>("th_stopped_time_sec", 1.0);
+  th_stopped_velocity_mps_ = this->declare_parameter<double>("th_stopped_velocity_mps", 0.01);
+
+  this->declare_parameter<bool>("is_parking_completed", false);
 
   // Input
   // input_lane_driving_.sub_trajectory = private_nh_.subscribe(

--- a/planning/scenario_planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
+++ b/planning/scenario_planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
@@ -31,7 +31,7 @@
 namespace
 {
 template <class T>
-void onData(const T data, T * buffer)
+void onData(const T & data, T * buffer)
 {
   *buffer = data;
 }
@@ -228,7 +228,8 @@ autoware_planning_msgs::msg::Scenario ScenarioSelectorNode::selectScenario()
 void ScenarioSelectorNode::onMap(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr msg)
 {
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
-  lanelet::utils::conversion::fromBinMsg(*msg, lanelet_map_ptr_);
+  lanelet::utils::conversion::fromBinMsg(
+    *msg, lanelet_map_ptr_, &traffic_rules_ptr_, &routing_graph_ptr_);
 }
 
 void ScenarioSelectorNode::onRoute(const autoware_planning_msgs::msg::Route::ConstSharedPtr msg)
@@ -296,14 +297,14 @@ ScenarioSelectorNode::ScenarioSelectorNode()
 : Node("scenario_selector"),
   tf_buffer_(this->get_clock()),
   tf_listener_(tf_buffer_),
-  current_scenario_(autoware_planning_msgs::msg::Scenario::EMPTY)
+  current_scenario_(autoware_planning_msgs::msg::Scenario::EMPTY),
+  update_rate_(this->declare_parameter<double>("update_rate", 10.0)),
+  th_max_message_delay_sec_(this->declare_parameter<double>("th_max_message_delay_sec", 1.0)),
+  th_arrived_distance_m_(this->declare_parameter<double>("th_arrived_distance_m", 1.0)),
+  th_stopped_time_sec_(this->declare_parameter<double>("th_stopped_time_sec", 1.0)),
+  th_stopped_velocity_mps_(this->declare_parameter<double>("th_stopped_velocity_mps", 0.01))
 {
   // Parameters
-  update_rate_ = this->declare_parameter<double>("update_rate", 10.0);
-  th_max_message_delay_sec_ = this->declare_parameter<double>("th_max_message_delay_sec", 1.0);
-  th_arrived_distance_m_ = this->declare_parameter<double>("th_arrived_distance_m", 1.0);
-  th_stopped_time_sec_ = this->declare_parameter<double>("th_stopped_time_sec", 1.0);
-  th_stopped_velocity_mps_ = this->declare_parameter<double>("th_stopped_velocity_mps", 0.01);
 
   this->declare_parameter<bool>("is_parking_completed", false);
 


### PR DESCRIPTION
## Summary

Fairly straightforward port of the scenario_selector package - dependencies to topic tools package so ensure that the `ros2` branch of AutowareArchitectureProposal is up to date. 

Notable Changes:
* Remove boost dependencies
  * `boost::function` -> `std::function`
  * `boost::bind` -> `std::bind`
* Pull in `topic_tools` dependencies

## Testing

Compilation should be successful and launch files should launch with issue. The launch files here do not come with default parameters so you will need to input these manually during launch, i.e:

```
ros2 launch scenario_selector dummy_scenario_selector_parking.launch.xml output_scenario:=test_out_scenario input_parking_trajectory:=test_in_traj output_trajectory:=test_out_traj
```

## Discussion Points

* Launch rostopic as a node in the launch file has been commented out - I am not sure if there is a different way of achieving the publishing of topics via the launch file.
* `fromMapBin` now only takes in two argument - is this correct?