### PR TITLE
[ROS2 Porting] fix motion_velocity_optimizer

### DIFF
--- a/planning/scenario_planning/common/motion_velocity_optimizer/config/default_motion_velocity_optimizer.yaml
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/config/default_motion_velocity_optimizer.yaml
@@ -1,36 +1,39 @@
-max_velocity: 20.0      # max velocity limit [m/s]
-max_accel: 1.0          # max acceleration limit [m/ss]
-min_decel: -1.0         # min deceleration limit [m/ss]
+/**:
+  ros__parameters:
 
-# curve parameters
-max_lateral_accel: 0.5             # max lateral acceleration limit [m/ss]
-min_curve_velocity: 2.74           # min velocity at lateral acceleration limit [m/ss]
-decel_distance_before_curve: 3.5   # slow speed distance before a curve for lateral acceleration limit
-decel_distance_after_curve: 2.0    # slow speed distance after a curve for lateral acceleration limit
+    max_velocity: 20.0      # max velocity limit [m/s]
+    max_accel: 1.0          # max acceleration limit [m/ss]
+    min_decel: -1.0         # min deceleration limit [m/ss]
 
-# engage & replan parameters
-replan_vel_deviation: 5.53         # velocity deviation to replan initial velocity [m/s]
-engage_velocity: 0.25              # engage velocity threshold [m/s] (if the trajectory velocity is higher than this value, use this velocity for engage vehicle speed)
-engage_acceleration: 0.1           # engage acceleration [m/ss] (use this acceleration when engagement)
-engage_exit_ratio: 0.5             # exit engage sequence to normal velocity plannning when the velocity exceeds engage_exit_ratio x engage_velocity.
-stop_dist_to_prohibit_engage: 0.5  # if the stop point is in this distance, the speed is set to 0 not to move the vehicle [m]
+    # curve parameters
+    max_lateral_accel: 0.5             # max lateral acceleration limit [m/ss]
+    min_curve_velocity: 2.74           # min velocity at lateral acceleration limit [m/ss]
+    decel_distance_before_curve: 3.5   # slow speed distance before a curve for lateral acceleration limit
+    decel_distance_after_curve: 2.0    # slow speed distance after a curve for lateral acceleration limit
 
-extract_ahead_dist: 200.0         # forward trajectory distance used for planning [m]
-extract_behind_dist: 5.0          # backward trajectory distance used for planning [m]
-delta_yaw_threshold: 1.0472       # Allowed delta yaw between ego pose and trajecotory pose [radian]
+    # engage & replan parameters
+    replan_vel_deviation: 5.53         # velocity deviation to replan initial velocity [m/s]
+    engage_velocity: 0.25              # engage velocity threshold [m/s] (if the trajectory velocity is higher than this value, use this velocity for engage vehicle speed)
+    engage_acceleration: 0.1           # engage acceleration [m/ss] (use this acceleration when engagement)
+    engage_exit_ratio: 0.5             # exit engage sequence to normal velocity plannning when the velocity exceeds engage_exit_ratio x engage_velocity.
+    stop_dist_to_prohibit_engage: 0.5  # if the stop point is in this distance, the speed is set to 0 not to move the vehicle [m]
 
-max_trajectory_length: 200.0          # max trajectory length for resampling [m]
-min_trajectory_length: 30.0           # min trajectory length for resampling [m]
-resample_time: 10.0                   # resample total time [s]
-resample_dt: 0.1                      # resample time interval [s]
-min_trajectory_interval_distance: 0.1 # resample points-interval length [m]
+    extract_ahead_dist: 200.0         # forward trajectory distance used for planning [m]
+    extract_behind_dist: 5.0          # backward trajectory distance used for planning [m]
+    delta_yaw_threshold: 1.0472       # Allowed delta yaw between ego pose and trajecotory pose [radian]
 
-# default weights
-# L2: jerk = 100.0, v_weight = 100000.0, a_weight = 1000.0
-# Linf: jerk = 200.0, v_weight = 100000.0, a_weight = 5000.0
+    max_trajectory_length: 200.0          # max trajectory length for resampling [m]
+    min_trajectory_length: 30.0           # min trajectory length for resampling [m]
+    resample_time: 10.0                   # resample total time [s]
+    resample_dt: 0.1                      # resample time interval [s]
+    min_trajectory_interval_distance: 0.1 # resample points-interval length [m]
 
-pseudo_jerk_weight: 100.0 # weight for "smoothness" cost
-over_v_weight: 100000.0   # weight for "overspeed limit" cost
-over_a_weight: 1000.0     # weight for "overaccel limit" cost
+    # default weights
+    # L2: jerk = 100.0, v_weight = 100000.0, a_weight = 1000.0
+    # Linf: jerk = 200.0, v_weight = 100000.0, a_weight = 5000.0
 
-algorithm_type: "L2" # Option : L2, Linf
+    pseudo_jerk_weight: 100.0 # weight for "smoothness" cost
+    over_v_weight: 100000.0   # weight for "overspeed limit" cost
+    over_a_weight: 1000.0     # weight for "overaccel limit" cost
+
+    algorithm_type: "L2" # Option : L2, Linf

--- a/planning/scenario_planning/common/motion_velocity_optimizer/include/motion_velocity_optimizer/motion_velocity_optimizer.hpp
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/include/motion_velocity_optimizer/motion_velocity_optimizer.hpp
@@ -41,8 +41,8 @@ private:
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_current_velocity_;  //!< @brief subscriber for current velocity
   rclcpp::Subscription<autoware_planning_msgs::msg::Trajectory>::SharedPtr sub_current_trajectory_;  //!< @brief subscriber for reference trajectory
   rclcpp::Subscription<autoware_planning_msgs::msg::VelocityLimit>::SharedPtr sub_external_velocity_limit_;//!< @brief subscriber for external velocity limit
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;  //!< @brief tf butter
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;  //!< @brief tf listener
+  tf2::BufferCore tf_buffer_;  //!< @brief tf butter
+  tf2_ros::TransformListener tf_listener_;  //!< @brief tf listener
 
   double external_velocity_limit_update_rate_;
   rclcpp::TimerBase::SharedPtr timer_;

--- a/planning/scenario_planning/common/motion_velocity_optimizer/launch/motion_velocity_optimizer.launch.xml
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/launch/motion_velocity_optimizer.launch.xml
@@ -7,14 +7,14 @@
   <arg name="show_debug_info_all" default="false"/>
   <arg name="publish_debug_trajs" default="true"/>
 
-  <arg name="param_path" default="$(find motion_velocity_optimizer)/config/default_motion_velocity_optimizer.yaml" />
+  <arg name="param_path" default="$(find-pkg-share motion_velocity_optimizer)/config/default_motion_velocity_optimizer.yaml" />
 
-  <node pkg="motion_velocity_optimizer" type="motion_velocity_optimizer" name="motion_velocity_optimizer" output="$(arg output)">
-    <rosparam command="load" file="$(arg param_path)" />
-    <param name="show_debug_info" value="$(arg show_debug_info)"/>
-    <param name="show_debug_info_all" value="$(arg show_debug_info_all)"/>
-    <param name="publish_debug_trajs" value="$(arg publish_debug_trajs)"/>
-    <remap from="~external_velocity_limit_mps" to="/planning/scenario_planning/max_velocity"/>
+  <node pkg="motion_velocity_optimizer" exec="motion_velocity_optimizer" name="motion_velocity_optimizer" output="log">
+    <param from="$(var param_path)" />
+    <param name="show_debug_info" value="$(var show_debug_info)"/>
+    <param name="show_debug_info_all" value="$(var show_debug_info_all)"/>
+    <param name="publish_debug_trajs" value="$(var publish_debug_trajs)"/>
+    <remap from="external_velocity_limit_mps" to="/planning/scenario_planning/max_velocity"/>
   </node>
 
 </launch>


### PR DESCRIPTION
motion_velocity_optimizer failed to startup from launch file.

This PR fixes:
* fix launch file: looks like the first port missed porting of launch file
* parameter file: parameter file did not have namespace declaration
* tf_buffer: it was using pointer without memory allocation. This PR changes it to member variable rather than pointer.
* parameter declaration: over_a_weight was declared twice in the code which throws an error. The latter was changed to getter function.

How to test:
Make sure that the node launch with the following command and does not terminate with segmentation fault.
`ros2 launch motion_velocity_optimizer motion_velocity_optimizer.launch.xml`