### PR TITLE
[turn_signal_decider] change weak_ptr to raw pointer

### DIFF
--- a/planning/scenario_planning/lane_driving/behavior_planning/turn_signal_decider/include/turn_signal_decider/data_manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/turn_signal_decider/include/turn_signal_decider/data_manager.h
@@ -38,7 +38,7 @@ private:
   bool is_path_ready_;
   bool is_pose_ready_;
 
-  rclcpp::Node::WeakPtr node_;
+  rclcpp::Node * node_;
 
   // tf
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
@@ -57,7 +57,7 @@ private:
   bool isPoseValid() const;
 
 public:
-  explicit DataManager(rclcpp::Node::SharedPtr node);
+  explicit DataManager(rclcpp::Node * node);
 
   // callbacks
   void onPathWithLaneId(autoware_planning_msgs::msg::PathWithLaneId::SharedPtr msg);

--- a/planning/scenario_planning/lane_driving/behavior_planning/turn_signal_decider/src/turn_signal_decider_core.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/turn_signal_decider/src/turn_signal_decider_core.cpp
@@ -31,7 +31,7 @@ double getDistance3d(const geometry_msgs::msg::Point & p1, const geometry_msgs::
 namespace turn_signal_decider
 {
 TurnSignalDecider::TurnSignalDecider(const std::string & node_name, const rclcpp::NodeOptions & node_options)
-: rclcpp::Node(node_name, node_options), data_(this->Node::shared_from_this())
+: rclcpp::Node(node_name, node_options), data_(this)
 {
   // setup data manager
   constexpr double vehicle_pose_update_period = 0.1;


### PR DESCRIPTION
When turn_signal_decider is launched, it fails with bad weak_ptr.
```
terminate called after throwing an instance of 'std::bad_weak_ptr'
  what():  bad_weak_ptr
```

This probably is due to calling shared_from_this() in constructor.
The document states that this must be referred by other shared_ptr(). Although the object is handled as shared_ptr in the main function, but that is the case after constructor has finished running.
This PR changes shared_from_this to raw pointer to avoid this error.

For reviewers:
Please test with `ros2 run turn_signal_decider turn_signal_decider` and make sure that the node does not die.