### PR TITLE
[ROS2] Fix behavior velocity planner

### DIFF
--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/CMakeLists.txt
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/CMakeLists.txt
@@ -186,7 +186,7 @@ target_link_libraries(scene_module_manager scene_module_lib)
 
 
 # Node
-add_executable(behavior_velocity_planner_node
+ament_auto_add_executable(behavior_velocity_planner_node
   src/node.cpp
   src/main.cpp
 )
@@ -211,4 +211,7 @@ target_link_libraries(behavior_velocity_planner_node
 )
 
 ament_export_dependencies(${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
-ament_package()
+ament_auto_package(INSTALL_TO_SHARE
+  launch
+  config
+)

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/config/blind_spot_param.yaml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/config/blind_spot_param.yaml
@@ -1,4 +1,6 @@
-blind_spot:
-  stop_line_margin: 1.0 # [m]
-  backward_length: 15.0 # [m]
-  max_future_movement_time: 10.0 # [second]
+/**:
+  ros__parameters:
+    blind_spot:
+      stop_line_margin: 1.0 # [m]
+      backward_length: 15.0 # [m]
+      max_future_movement_time: 10.0 # [second]

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/config/crosswalk_param.yaml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/config/crosswalk_param.yaml
@@ -1,9 +1,11 @@
-crosswalk:
-  crosswalk:
-    stop_margin: 1.0
-    slow_margin: 2.0
-    slow_velocity: 1.38 # 1.38 m/s = 5.0 kmph
-    stop_dynamic_object_prediction_time_margin: 3.0
+/**:
+  ros__parameters:
+    crosswalk:
+      crosswalk:
+        stop_margin: 1.0
+        slow_margin: 2.0
+        slow_velocity: 1.38 # 1.38 m/s = 5.0 kmph
+        stop_dynamic_object_prediction_time_margin: 3.0
 
-  walkway:
-    stop_margin: 1.0
+      walkway:
+        stop_margin: 1.0

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/config/detection_area_param.yaml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/config/detection_area_param.yaml
@@ -1,2 +1,4 @@
-detection_area:
-  stop_margin: 0.0
+/**:
+  ros__parameters:
+    detection_area:
+      stop_margin: 0.0

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/config/intersection_param.yaml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/config/intersection_param.yaml
@@ -1,10 +1,12 @@
-intersection:
-  state_transit_mergin_time: 2.0
-  decel_velocoity: 8.33 # 8.33m/s = 30.0km/h
-  path_expand_width: 2.0
-  stop_line_margin: 1.0
-  stuck_vehicle_detect_dist: 5.0
-  stuck_vehicle_ignore_dist: 5.0 # obstacle stop max ditance(5.0m) + stuck vehicle size / 2 (0.0m-)
-  stuck_vehicle_vel_thr: 0.833 # 0.833m/s = 3.0km/h
-  intersection_velocity: 2.778 # 2.778m/s = 10.0km/h
-  detection_area_length: 200.0 # [m]
+/**:
+  ros__parameters:
+    intersection:
+      state_transit_mergin_time: 2.0
+      decel_velocoity: 8.33 # 8.33m/s = 30.0km/h
+      path_expand_width: 2.0
+      stop_line_margin: 1.0
+      stuck_vehicle_detect_dist: 5.0
+      stuck_vehicle_ignore_dist: 5.0 # obstacle stop max ditance(5.0m) + stuck vehicle size / 2 (0.0m-)
+      stuck_vehicle_vel_thr: 0.833 # 0.833m/s = 3.0km/h
+      intersection_velocity: 2.778 # 2.778m/s = 10.0km/h
+      detection_area_length: 200.0 # [m]

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/config/stop_line_param.yaml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/config/stop_line_param.yaml
@@ -1,3 +1,5 @@
-stop_line:
-  stop_margin: 0.0
-  stop_check_dist: 2.0  # stopline is released when the vehicle is stopped within this distance from stopline.
+/**:
+  ros__parameters:
+    stop_line:
+      stop_margin: 0.0
+      stop_check_dist: 2.0  # stopline is released when the vehicle is stopped within this distance from stopline.

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/config/traffic_light_param.yaml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/config/traffic_light_param.yaml
@@ -1,3 +1,5 @@
-traffic_light:
-  stop_margin: 0.0
-  tl_state_timeout: 1.0
+/**:
+  ros__parameters:
+    traffic_light:
+      stop_margin: 0.0
+      tl_state_timeout: 1.0

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
@@ -15,14 +15,16 @@
   <arg name="max_accel" default="-2.8" />
   <arg name="delay_response_time" default="1.3" />
 
+  <arg name="vehicle_param_file" default="$(find-pkg-share lexus_description)/config/vehicle_info.yaml"/>
 
-  <node pkg="behavior_velocity_planner" type="behavior_velocity_planner_node" name="behavior_velocity_planner" output="screen">
-    <rosparam command="load" file="$(find-pkg-share behavior_velocity_planner)/config/blind_spot_param.yaml" />
-    <rosparam command="load" file="$(find-pkg-share behavior_velocity_planner)/config/crosswalk_param.yaml" />
-    <rosparam command="load" file="$(find-pkg-share behavior_velocity_planner)/config/detection_area_param.yaml" />
-    <rosparam command="load" file="$(find-pkg-share behavior_velocity_planner)/config/intersection_param.yaml" />
-    <rosparam command="load" file="$(find-pkg-share behavior_velocity_planner)/config/stop_line_param.yaml" />
-    <rosparam command="load" file="$(find-pkg-share behavior_velocity_planner)/config/traffic_light_param.yaml" />
+  <node pkg="behavior_velocity_planner" exec="behavior_velocity_planner_node" name="behavior_velocity_planner" output="screen">
+    <param from="$(find-pkg-share behavior_velocity_planner)/config/blind_spot_param.yaml" />
+    <param from="$(find-pkg-share behavior_velocity_planner)/config/crosswalk_param.yaml" />
+    <param from="$(find-pkg-share behavior_velocity_planner)/config/detection_area_param.yaml" />
+    <param from="$(find-pkg-share behavior_velocity_planner)/config/intersection_param.yaml" />
+    <param from="$(find-pkg-share behavior_velocity_planner)/config/stop_line_param.yaml" />
+    <param from="$(find-pkg-share behavior_velocity_planner)/config/traffic_light_param.yaml" />
+    <param from="$(var vehicle_param_file)" />
 
     <remap from="input/path_with_lane_id" to="path_with_lane_id" />
     <remap from="input/vector_map" to="$(var map_topic_name)" />

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -59,13 +59,14 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
 {
   const std::string ns(getModuleName());
   auto & p = planner_param_;
+  vehicle_info_util::VehicleInfo vehicle_info = vehicle_info_util::VehicleInfo::create(node);
   p.state_transit_mergin_time = node.declare_parameter(ns + "/state_transit_mergin_time", 2.0);
   p.decel_velocoity = node.declare_parameter(ns + "/decel_velocoity", 30.0 / 3.6);
   p.path_expand_width = node.declare_parameter(ns + "/path_expand_width", 2.0);
   p.stop_line_margin = node.declare_parameter(ns + "/stop_line_margin", 1.0);
   p.stuck_vehicle_detect_dist = node.declare_parameter(ns + "/stuck_vehicle_detect_dist", 5.0);
   p.stuck_vehicle_ignore_dist = node.declare_parameter(ns + "/stuck_vehicle_ignore_dist", 5.0) +
-                                planner_data_->vehicle_info_.max_longitudinal_offset_m_;
+                                vehicle_info.max_longitudinal_offset_m_;
   p.stuck_vehicle_vel_thr = node.declare_parameter(ns + "/stuck_vehicle_vel_thr", 3.0 / 3.6);
   p.intersection_velocity = node.declare_parameter(ns + "/intersection_velocity", 10.0 / 3.6);
   p.detection_area_length = node.declare_parameter(ns + "/detection_area_length", 200.0);

--- a/vehicle/util/vehicle_info_util/include/vehicle_info_util/vehicle_info.hpp
+++ b/vehicle/util/vehicle_info_util/include/vehicle_info_util/vehicle_info.hpp
@@ -69,6 +69,10 @@ public:
   const double max_lateral_offset_m_;
   const double min_height_offset_m_;
   const double max_height_offset_m_;
+private:
+  // Used to check if parameters are already declared or not in order to avoid
+  // declaring parameters multiple times.
+  static bool parametersAlreadyDeclared(rclcpp::Node & node);
 };
 
 }  // namespace vehicle_info_util

--- a/vehicle/util/vehicle_info_util/src/vehicle_info.cpp
+++ b/vehicle/util/vehicle_info_util/src/vehicle_info.cpp
@@ -44,20 +44,54 @@ VehicleInfo::VehicleInfo(
 {
 }
 
+bool VehicleInfo::parametersAlreadyDeclared(rclcpp::Node & node)
+{
+  return (
+    node.has_parameter("wheel_radius") &&
+    node.has_parameter("wheel_width") &&
+    node.has_parameter("wheel_base") &&
+    node.has_parameter("wheel_tread") &&
+    node.has_parameter("front_overhang") &&
+    node.has_parameter("rear_overhang") &&
+    node.has_parameter("left_overhang") &&
+    node.has_parameter("right_overhang") &&
+    node.has_parameter("vehicle_height")
+  );
+}
+
 VehicleInfo VehicleInfo::create(rclcpp::Node & node)
 {
-  const double wheel_radius_m = node.declare_parameter("wheel_radius").get<double>();
-  const double wheel_width_m = node.declare_parameter("wheel_width").get<double>();
-  const double wheel_base_m = node.declare_parameter("wheel_base").get<double>();
-  const double wheel_tread_m = node.declare_parameter("wheel_tread").get<double>();
-  const double front_overhang_m = node.declare_parameter("front_overhang").get<double>();
-  const double rear_overhang_m = node.declare_parameter("rear_overhang").get<double>();
-  const double left_overhang_m = node.declare_parameter("left_overhang").get<double>();
-  const double right_overhang_m = node.declare_parameter("right_overhang").get<double>();
-  const double vehicle_height_m = node.declare_parameter("vehicle_height").get<double>();
-  return VehicleInfo(
-    wheel_radius_m, wheel_width_m, wheel_base_m, wheel_tread_m, front_overhang_m, rear_overhang_m,
-    left_overhang_m, right_overhang_m, vehicle_height_m);
+  if(!parametersAlreadyDeclared(node))
+  {
+    const double wheel_radius_m = node.declare_parameter("wheel_radius").get<double>();
+    const double wheel_width_m = node.declare_parameter("wheel_width").get<double>();
+    const double wheel_base_m = node.declare_parameter("wheel_base").get<double>();
+    const double wheel_tread_m = node.declare_parameter("wheel_tread").get<double>();
+    const double front_overhang_m = node.declare_parameter("front_overhang").get<double>();
+    const double rear_overhang_m = node.declare_parameter("rear_overhang").get<double>();
+    const double left_overhang_m = node.declare_parameter("left_overhang").get<double>();
+    const double right_overhang_m = node.declare_parameter("right_overhang").get<double>();
+    const double vehicle_height_m = node.declare_parameter("vehicle_height").get<double>();
+    return VehicleInfo(
+      wheel_radius_m, wheel_width_m, wheel_base_m, wheel_tread_m, front_overhang_m, rear_overhang_m,
+      left_overhang_m, right_overhang_m, vehicle_height_m);
+  }
+  else
+  {
+    const double wheel_radius_m = node.get_parameter("wheel_radius").as_double();
+    const double wheel_width_m = node.get_parameter("wheel_width").as_double();
+    const double wheel_base_m = node.get_parameter("wheel_base").as_double();
+    const double wheel_tread_m = node.get_parameter("wheel_tread").as_double();
+    const double front_overhang_m = node.get_parameter("front_overhang").as_double();
+    const double rear_overhang_m = node.get_parameter("rear_overhang").as_double();
+    const double left_overhang_m = node.get_parameter("left_overhang").as_double();
+    const double right_overhang_m = node.get_parameter("right_overhang").as_double();
+    const double vehicle_height_m = node.get_parameter("vehicle_height").as_double();
+    return VehicleInfo(
+      wheel_radius_m, wheel_width_m, wheel_base_m, wheel_tread_m, front_overhang_m, rear_overhang_m,
+      left_overhang_m, right_overhang_m, vehicle_height_m);
+  }
+
 }
 
 }  // namespace vehicle_info_util


### PR DESCRIPTION
### Description
behavior_velocity_planner dies at intersection_module, where it refers to planner_data pointer before object is created in constructor.
This fixes the issue by handing over planner_data at constructor.

It also finishes porting of launch files (which I missed to review at first porting).

### How To Review
Make sure that node does not dies with segmentation fault with following command:
`ros2 launch behavior_velocity_planner behavior_velocity_planner.launch.xml`