### PR TITLE
[simple_planning_simulator] add rostopic relay in launch file

### DIFF
--- a/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.xml
+++ b/simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.xml
@@ -33,5 +33,10 @@
     <param name="initial_engage_state" value="$(var initial_engage_state)"/>
   </node>
 
-  <!-- <node pkg="topic_tools" exec="relay" name="relay" args="/vehicle/status/twist /localization/twist" /> -->
+  <node pkg="topic_tools" exec="relay" name="twist_relay" output="log" >
+    <param name="input_topic" value="/vehicle/status/twist" />
+    <param name="output_topic" value="/localization/twist" />
+    <param name="type" value="geometry_msgs/msg/TwistStamped" />
+  </node>
+
 </launch>

--- a/simulator/simple_planning_simulator/package.xml
+++ b/simulator/simple_planning_simulator/package.xml
@@ -23,6 +23,7 @@
   <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This re-enables topic relay which was not available when this package was ported. 