### PR TITLE
Fix launch files

### DIFF
--- a/planning/scenario_planning/common/motion_velocity_optimizer/launch/motion_velocity_optimizer.launch.xml
+++ b/planning/scenario_planning/common/motion_velocity_optimizer/launch/motion_velocity_optimizer.launch.xml
@@ -6,6 +6,8 @@
   <arg name="show_debug_info" default="false"/>
   <arg name="show_debug_info_all" default="false"/>
   <arg name="publish_debug_trajs" default="true"/>
+  <arg name="input_trajectory" default="input/trajectory" />
+  <arg name="output_trajectory" default="output/trajectory" />
 
   <arg name="param_path" default="$(find-pkg-share motion_velocity_optimizer)/config/default_motion_velocity_optimizer.yaml" />
 
@@ -15,6 +17,8 @@
     <param name="show_debug_info_all" value="$(var show_debug_info_all)"/>
     <param name="publish_debug_trajs" value="$(var publish_debug_trajs)"/>
     <remap from="external_velocity_limit_mps" to="/planning/scenario_planning/max_velocity"/>
+    <remap from="input/trajectory" to="$(var input_trajectory)" />
+    <remap from="output/trajectory" to="$(var output_trajectory)" />
   </node>
 
 </launch>

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/launch/obstacle_avoidance_planner.launch.xml
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/launch/obstacle_avoidance_planner.launch.xml
@@ -1,11 +1,16 @@
 <launch>
   <arg name="input_objects" default="/perception/object_recognition/objects" />
+  <arg name="input_path_topic" default="input/path" />
+  <arg name="output_path_topic" default="output/path" />
   <arg name="is_showing_debug_info" default="false"/>
   <arg name="is_stopping_if_outside_drivable_area" default="true"/>
   <arg name="param_path" default="$(find-pkg-share obstacle_avoidance_planner)/config/default_obstacle_avoidance_planner.yaml" />
+
   <node pkg="obstacle_avoidance_planner" exec="obstacle_avoidance_planner_node"
     name="obstacle_avoidance_planner" output="screen">
     <remap from="input/objects" to="$(var input_objects)"/>
+    <remap from="input/path" to="$(var input_path_topic)" />
+    <remap from="output/path" to="$(var output_path_topic)" />
 
     <param from="$(var param_path)" />
     <param name="is_showing_debug_info" value="$(var is_showing_debug_info)"/>

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/launch/obstacle_stop_planner.launch.xml
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/launch/obstacle_stop_planner.launch.xml
@@ -1,6 +1,9 @@
 <launch>
   <arg name="input_objects" default="/perception/object_recognition/objects" />
+  <arg name="input_pointcloud" default="input/pointcloud" />
+  <arg name="input_trajectory" default="input/trajectory" />
   <arg name="input_twist" default="/localization/twist" />
+  <arg name="output_trajectory" default="output/trajectory" />
   <arg name="enable_slow_down" default="false" />
   <arg name="param_file" default="$(find-pkg-share obstacle_stop_planner)/config/obstacle_stop_planner.yaml" />
 
@@ -9,7 +12,10 @@
     <param from="$(var param_file)" />
     <remap from="output/stop_reason" to="/planning/scenario_planning/status/stop_reason" />
     <remap from="output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons" />
+    <remap from="output/trajectory" to="$(var output_trajectory)" />
     <remap from="input/objects" to="$(var input_objects)" />
+    <remap from="input/pointcloud" to="$(var input_pointcloud)" />
+    <remap from="input/trajectory" to="$(var input_trajectory)" />
     <remap from="input/twist" to="$(var input_twist)" />
     <param name="enable_slow_down" value="$(var enable_slow_down)" />
   </node>

--- a/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/launch/surround_obstacle_checker.launch.xml
+++ b/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/launch/surround_obstacle_checker.launch.xml
@@ -1,17 +1,23 @@
 <launch>
   <arg name="param_path" default="$(find-pkg-share surround_obstacle_checker)/config/default_surround_obstacle_checker.yaml" />
+  <arg name="vehicle_info_param" default="$(find-pkg-share lexus_description)/config/vehicle_info.yaml" />
 
+  <arg name="input_trajectory" default="input/trajectory" />
   <arg name="input_objects" default="/perception/object_recognition/objects" />
   <arg name="input_twist" default="/localization/twist" />
   <arg name="input_pointcloud" default="/sensing/lidar/no_ground/pointcloud" />
+  <arg name="output_trajectory" default="output/trajectory" />
 
   <node pkg="surround_obstacle_checker" exec="surround_obstacle_checker_node" name="surround_obstacle_checker" output="screen">
     <param from="$(var param_path)" />
+    <param from="$(var vehicle_info_param)" />
     <remap from="output/no_start_reason" to="/planning/scenario_planning/status/no_start_reason" />
     <remap from="output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons" />
+    <remap from="output/trajectory" to="$(var output_trajectory)" />
     <remap from="input/pointcloud" to="$(var input_pointcloud)" />
     <remap from="input/objects" to="$(var input_objects)" />
     <remap from="input/twist" to="$(var input_twist)" />
+    <remap from="input/trajectory" to="$(var input_trajectory)" />
   </node>
 
 </launch>


### PR DESCRIPTION
This modifies launch files so that they can be used from autoware_launcher.iv.universe as in https://github.com/tier4/autoware_launcher.iv.universe/pull/9.

This will modify launch files so that some of the topics can be remapped through arguments.