### PR TITLE
add preprocessor.launch.xml launch

### DIFF
--- a/sensing/preprocessor/pointcloud/pointcloud_preprocessor/launch/preprocessor.launch.xml
+++ b/sensing/preprocessor/pointcloud/pointcloud_preprocessor/launch/preprocessor.launch.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<launch>
+
+<!-- Input pointcloud topic_name list as a string_array.
+     To subscribe miultiple topics, write as: 
+     "['/points_raw0', '/points_raw1', '/points_raw2', ...]"
+     This syntax is also available from command line -->
+    <arg name="input_points_raw_list" default="['/points_raw']" desc="define as string_array"/>
+
+    <arg name="output_points_raw" default="/points_raw/cropbox/filtered" desc=""/>
+    <arg name="tf_output_frame" default="base_link" desc=""/>
+  
+    <include file="$(find-pkg-share pointcloud_preprocessor)/launch/preprocessor.launch.py">
+        <param name="input_points_raw_list" value="$(var input_points_raw_list)" />
+        <param name="output_points_raw" value="$(var output_points_raw)" />
+        <param name="tf_output_frame" value="$(var tf_output_frame)" />
+    </include>  
+
+</launch>


### PR DESCRIPTION
This is just an XML wrapper of the `preprocessor.launch.py`, but it might be useful to merge this as an example to load the python launch file from xml.