### PR TITLE
Port initial-pose-button-panel

### DIFF
--- a/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/CMakeLists.txt
+++ b/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/CMakeLists.txt
@@ -1,54 +1,32 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(initial_pose_button_panel)
 
-add_compile_options(-std=c++14)
-
-find_package(catkin REQUIRED COMPONENTS
-  rviz
-  std_msgs
-  geometry_msgs
-  autoware_localization_srvs
-)
-
-if(rviz_QT_VERSION VERSION_LESS "5")
-  message(STATUS "Using Qt4 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt4 ${rviz_QT_VERSION} EXACT REQUIRED QtCore QtGui)
-  include(${QT_USE_FILE})
-else()
-  message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
-  set(QT_LIBRARIES Qt5::Widgets)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wno-unused-parameter)
 endif()
 
-catkin_package(
-  DEPENDS rviz
-)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
-include_directories(
-  ${catkin_INCLUDE_DIRS}
-)
-SET(CMAKE_CXX_FLAGS "-O2 -g -Wall -Wno-unused-result -DROS ${CMAKE_CXX_FLAGS}")
-
+find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+set(QT_LIBRARIES Qt5::Widgets)
 
 add_definitions(-DQT_NO_KEYWORDS -g)
-
 set(CMAKE_AUTOMOC ON)
-set(SOURCE_FILES
-  src/initial_pose_button_panel.cpp
-)
 
-add_library(initial_pose_button_panel ${SOURCE_FILES} ${UIC_FILES})
-target_link_libraries(initial_pose_button_panel ${QT_LIBRARIES} ${catkin_LIBRARIES} ${rviz_DEFAULT_PLUGIN_LIBRARIES})
+ament_auto_add_library(initial_pose_button_panel 
+  src/initial_pose_button_panel.cpp)
+target_link_libraries(initial_pose_button_panel 
+  ${QT_LIBRARIES})
 
-install(TARGETS
-  ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
+# Export the plugin to be imported by rviz2
+pluginlib_export_plugin_description_file(rviz_common plugins/plugin_description.xml)
 
-install(
-  DIRECTORY
-    plugins
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+ament_auto_package(
+  INSTALL_TO_SHARE
+  plugins
 )

--- a/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/package.xml
+++ b/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/package.xml
@@ -9,7 +9,7 @@
 
   <license>Apache 2</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <depend>rviz_common</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-widgets</depend>

--- a/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/package.xml
+++ b/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/package.xml
@@ -9,16 +9,17 @@
 
   <license>Apache 2</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <depend>rviz</depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rviz_common</depend>
+  <depend>libqt5-core</depend>
+  <depend>libqt5-widgets</depend>
   <depend>qtbase5-dev</depend>
   <depend>geometry_msgs</depend>
   <depend>autoware_localization_srvs</depend>
 
-  <exec_depend>libqt5-core</exec_depend>
-  <exec_depend>libqt5-widgets</exec_depend>
 
   <export>
+    <build_type>ament_cmake</build_type>
     <rviz plugin="${prefix}/plugins/plugin_description.xml"/>
   </export>
 </package>

--- a/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/package.xml
+++ b/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="yamato.ando@gmail.com">Yamato ANDO</maintainer>
   <author>Yamato ANDO</author>
 
-  <license>Apache 2</license>
+  <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <depend>rviz_common</depend>

--- a/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/plugins/plugin_description.xml
+++ b/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/plugins/plugin_description.xml
@@ -1,7 +1,7 @@
 <library path="lib/libinitial_pose_button_panel">
     <class name="autoware_localization_rviz_plugin/InitialPoseButtonPanel"
            type="autoware_localization_rviz_plugin::InitialPoseButtonPanel"
-           base_class_type="rviz::Panel">
+           base_class_type="rviz_common::Panel">
         <description>
           initial button.
         </description>

--- a/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/src/initial_pose_button_panel.cpp
+++ b/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/src/initial_pose_button_panel.cpp
@@ -131,10 +131,11 @@ void InitialPoseButtonPanel::pushInitializeButton()
         result){
           status_label_->setStyleSheet("QLabel { background-color : lightgreen;}");
           status_label_->setText("OK!!!");
+          
+          // unlock button
+          initialize_button_->setEnabled(true);
     });
 
-    // unlock button
-    initialize_button_->setEnabled(true);
   });
 
   thread.detach();

--- a/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/src/initial_pose_button_panel.cpp
+++ b/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/src/initial_pose_button_panel.cpp
@@ -45,11 +45,12 @@
 #include "QTimer"
 #include "QVBoxLayout"
 
+#include "rviz_common/display_context.hpp"
 #include "initial_pose_button_panel.hpp"
 
 namespace autoware_localization_rviz_plugin
 {
-InitialPoseButtonPanel::InitialPoseButtonPanel(QWidget * parent) : rviz::Panel(parent)
+InitialPoseButtonPanel::InitialPoseButtonPanel(QWidget * parent) : rviz_common::Panel(parent)
 {
   topic_label_ = new QLabel("PoseWithCovarianceStamped ");
   topic_label_->setAlignment(Qt::AlignCenter);
@@ -59,7 +60,7 @@ InitialPoseButtonPanel::InitialPoseButtonPanel(QWidget * parent) : rviz::Panel(p
 
   initialize_button_ = new QPushButton("Wait for subscribe topic");
   initialize_button_->setEnabled(false);
-  connect(initialize_button_, SIGNAL(clicked(bool)), SLOT(pushInitialzeButton()));
+  connect(initialize_button_, SIGNAL(clicked(bool)), SLOT(pushInitializeButton()));
 
   status_label_ = new QLabel("Not Initialze");
   status_label_->setAlignment(Qt::AlignCenter);
@@ -79,48 +80,59 @@ InitialPoseButtonPanel::InitialPoseButtonPanel(QWidget * parent) : rviz::Panel(p
 
   setLayout(v_layout);
 
-  pose_cov_sub_ = nh_.subscribe(
-    topic_edit_->text().toStdString(), 10, &InitialPoseButtonPanel::callbackPoseCov, this);
+  rclcpp::Node::SharedPtr raw_node = 
+    this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
 
-  client_ = nh_.serviceClient<autoware_localization_srvs::PoseWithCovarianceStamped>(
+  pose_cov_sub_ = raw_node->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>
+    (topic_edit_->text().toStdString(), 10, 
+    std::bind(&InitialPoseButtonPanel::callbackPoseCov, this, std::placeholders::_1));
+
+  client_ = 
+    raw_node->create_client<autoware_localization_srvs::srv::PoseWithCovarianceStamped>(
     "/localization/util/pose_initializer_srv");
 }
 
 void InitialPoseButtonPanel::callbackPoseCov(
-  const geometry_msgs::PoseWithCovarianceStamped::ConstPtr & msg)
+  const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg)
 {
   pose_cov_msg_ = *msg;
-  initialize_button_->setText("Pose Initializer   Let's GO!");
+  initialize_button_->setText("Pose Initializer Let's GO!");
   initialize_button_->setEnabled(true);
 }
 
 void InitialPoseButtonPanel::editTopic()
 {
-  pose_cov_sub_.shutdown();
-  pose_cov_sub_ = nh_.subscribe(
-    topic_edit_->text().toStdString(), 10, &InitialPoseButtonPanel::callbackPoseCov, this);
+  pose_cov_sub_.reset();
+  rclcpp::Node::SharedPtr raw_node = 
+    this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
+  pose_cov_sub_ = raw_node->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>
+    (topic_edit_->text().toStdString(), 10, 
+    std::bind(&InitialPoseButtonPanel::callbackPoseCov, this, std::placeholders::_1));
   initialize_button_->setText("Wait for subscribe topic");
   initialize_button_->setEnabled(false);
 }
 
-void InitialPoseButtonPanel::pushInitialzeButton()
+void InitialPoseButtonPanel::pushInitializeButton()
 {
   // lock button
   initialize_button_->setEnabled(false);
 
   status_label_->setStyleSheet("QLabel { background-color : dodgerblue;}");
-  status_label_->setText("Initialzing...");
+  status_label_->setText("Initializing...");
 
   std::thread thread([this] {
-    autoware_localization_srvs::PoseWithCovarianceStamped srv;
-    srv.request.pose_with_cov = pose_cov_msg_;
-    if (client_.call(srv)) {
-      status_label_->setStyleSheet("QLabel { background-color : lightgreen;}");
-      status_label_->setText("OK!!!");
-    } else {
-      status_label_->setStyleSheet("QLabel { background-color : red;}");
-      status_label_->setText("Faild!");
-    }
+    auto req =
+      std::make_shared<autoware_localization_srvs::srv::PoseWithCovarianceStamped::Request>();
+    req->pose_with_cov = pose_cov_msg_;
+
+    client_->async_send_request(
+      req, 
+      [this](rclcpp::Client<autoware_localization_srvs::srv::PoseWithCovarianceStamped>::SharedFuture
+        result){
+          status_label_->setStyleSheet("QLabel { background-color : lightgreen;}");
+          status_label_->setText("OK!!!");
+    });
+
     // unlock button
     initialize_button_->setEnabled(true);
   });
@@ -130,5 +142,6 @@ void InitialPoseButtonPanel::pushInitialzeButton()
 
 }  // end namespace autoware_localization_rviz_plugin
 
-#include "pluginlib/class_list_macros.h"
-PLUGINLIB_EXPORT_CLASS(autoware_localization_rviz_plugin::InitialPoseButtonPanel, rviz::Panel)
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(autoware_localization_rviz_plugin::InitialPoseButtonPanel, rviz_common::Panel)
+

--- a/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/src/initial_pose_button_panel.hpp
+++ b/localization/util/autoware_localization_rviz_plugin/initial_pose_button_panel/src/initial_pose_button_panel.hpp
@@ -35,41 +35,41 @@
 #include "QPushButton"
 #include "QSettings"
 #ifndef Q_MOC_RUN
-#include "ros/ros.h"
-#include "rviz/panel.h"
-#include "rviz/properties/ros_topic_property.h"
-#endif
-#include "geometry_msgs/PoseWithCovarianceStamped.h"
 
-#include "autoware_localization_srvs/PoseWithCovarianceStamped.h"
+#include "rclcpp/rclcpp.hpp"
+#include "rviz_common/panel.hpp"
+#include "rviz_common/properties/ros_topic_property.hpp"
+#endif
+#include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+
+#include "autoware_localization_srvs/srv/pose_with_covariance_stamped.hpp"
 
 namespace autoware_localization_rviz_plugin
 {
-class InitialPoseButtonPanel : public rviz::Panel
+class InitialPoseButtonPanel : public rviz_common::Panel
 {
   Q_OBJECT
 public:
   InitialPoseButtonPanel(QWidget * parent = 0);
-  void callbackPoseCov(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr & msg);
+  void callbackPoseCov(const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg);
 
 public Q_SLOTS:
   void editTopic();
-  void pushInitialzeButton();
+  void pushInitializeButton();
 
 protected:
-  ros::NodeHandle nh_;
-  ros::Subscriber pose_cov_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_cov_sub_;
 
-  ros::ServiceClient client_;
+  rclcpp::Client<autoware_localization_srvs::srv::PoseWithCovarianceStamped>::SharedPtr client_;
 
   QLabel * topic_label_;
   QLineEdit * topic_edit_;
   QPushButton * initialize_button_;
   QLabel * status_label_;
 
-  rviz::RosTopicProperty * property_topic_;
+  rviz_common::properties::RosTopicProperty * property_topic_;
 
-  geometry_msgs::PoseWithCovarianceStamped pose_cov_msg_;
+  geometry_msgs::msg::PoseWithCovarianceStamped pose_cov_msg_;
 };
 
 }  // end namespace autoware_localization_rviz_plugin


### PR DESCRIPTION
Port `initial-pose-button-panel` to ROS2.

To note:
- As the [client call](https://github.com/tier4/Pilot.Auto/pull/125/files#diff-37aff11e5ae763f660e9df6c6df2d63aeac085d24eeb967d1ce3971493337c44R128) is non-blocking now I've moved the intialization of the button inside the request scope otherwise it'll be initalized before getting a response. 

Signed-off-by: Servando German Serrano <servando.german.serrano@linaro.org>
