### PR TITLE
Convert calls of Duration to Duration::from_seconds where appropriate

### DIFF
--- a/control/mpc_follower/src/mpc_utils.cpp
+++ b/control/mpc_follower/src/mpc_utils.cpp
@@ -471,7 +471,7 @@ visualization_msgs::msg::MarkerArray MPCUtils::convertTrajToMarker(
   marker_poses.header.frame_id = frame_id;
   marker_poses.header.stamp = stamp;
   marker_poses.ns = ns + "/poses";
-  marker_poses.lifetime = rclcpp::Duration(0.5);
+  marker_poses.lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_poses.type = visualization_msgs::msg::Marker::ARROW;
   marker_poses.action = visualization_msgs::msg::Marker::ADD;
   marker_poses.scale.x = 0.2;

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -691,7 +691,7 @@ bool NDTScanMatcher::getTransform(
 
   try {
     *transform_stamped_ptr =
-      tf2_buffer_.lookupTransform(target_frame, source_frame, time_stamp, rclcpp::Duration(1.0));
+      tf2_buffer_.lookupTransform(target_frame, source_frame, time_stamp, rclcpp::Duration::from_seconds(1.0));
   } catch (tf2::TransformException & ex) {
     RCLCPP_WARN(get_logger(), "%s", ex.what());
     RCLCPP_ERROR(

--- a/perception/object_recognition/prediction/map_based_prediction/src/map_based_prediction_ros.cpp
+++ b/perception/object_recognition/prediction/map_based_prediction/src/map_based_prediction_ros.cpp
@@ -217,15 +217,15 @@ void MapBasedPredictionROS::objectsCallback(
     world2map_transform = tf_buffer_ptr_->lookupTransform(
       "map",                        // target
       in_objects->header.frame_id,  // src
-      in_objects->header.stamp, rclcpp::Duration(0.1));
+      in_objects->header.stamp, rclcpp::Duration::from_seconds(0.1));
     map2world_transform = tf_buffer_ptr_->lookupTransform(
       in_objects->header.frame_id,  // target
       "map",                        // src
-      in_objects->header.stamp, rclcpp::Duration(0.1));
+      in_objects->header.stamp, rclcpp::Duration::from_seconds(0.1));
     debug_map2lidar_transform = tf_buffer_ptr_->lookupTransform(
       "base_link",  // target
       "map",        // src
-      rclcpp::Time(), rclcpp::Duration(0.1));
+      rclcpp::Time(), rclcpp::Duration::from_seconds(0.1));
   } catch (tf2::TransformException & ex) {
     return;
   }

--- a/perception/traffic_light_recognition/traffic_light_map_based_detector/src/node.cpp
+++ b/perception/traffic_light_recognition/traffic_light_map_based_detector/src/node.cpp
@@ -81,7 +81,7 @@ namespace traffic_light
       "map",
       input_msg->header.frame_id,
       input_msg->header.stamp,
-      rclcpp::Duration(0.2));
+      rclcpp::Duration::from_seconds(0.2));
     camera_pose_stamped.header = input_msg->header;
     camera_pose_stamped.pose.position.x = transform.transform.translation.x;
     camera_pose_stamped.pose.position.y = transform.transform.translation.y;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/node.cpp
@@ -145,7 +145,7 @@ void BehaviorVelocityPlannerNode::onNoGroundPointCloud(
   geometry_msgs::msg::TransformStamped transform;
   try {
     transform = tf_buffer_.lookupTransform(
-      "map", msg->header.frame_id, msg->header.stamp, rclcpp::Duration(0.1));
+      "map", msg->header.frame_id, msg->header.stamp, rclcpp::Duration::from_seconds(0.1));
   } catch (tf2::LookupException & e) {
     RCLCPP_WARN(get_logger(), "no transform found for no_ground_pointcloud");
     return;
@@ -267,7 +267,7 @@ void BehaviorVelocityPlannerNode::publishDebugMarker(const autoware_planning_msg
     marker.scale.y = marker.scale.z = 0.05;
     marker.scale.x = 0.25;
     marker.action = visualization_msgs::msg::Marker::ADD;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.color.a = 0.999;  // Don't forget to set the alpha!
     marker.color.r = 1.0;
     marker.color.g = 1.0;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/debug.cpp
@@ -34,7 +34,7 @@ visualization_msgs::msg::MarkerArray createPolygonMarkerArray(
 
   marker.ns = ns;
   marker.id = uid;
-  marker.lifetime = rclcpp::Duration(0.3);
+  marker.lifetime = rclcpp::Duration::from_seconds(0.3);
   marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
   marker.action = visualization_msgs::msg::Marker::ADD;
   marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
@@ -69,7 +69,7 @@ visualization_msgs::msg::MarkerArray createObjectsMarkerArray(
   int32_t i = 0;
   for (const auto & object : objects.objects) {
     marker.id = uid + i++;
-    marker.lifetime = rclcpp::Duration(1.0);
+    marker.lifetime = rclcpp::Duration::from_seconds(1.0);
     marker.type = visualization_msgs::msg::Marker::SPHERE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose = object.state.pose_covariance.pose;
@@ -91,7 +91,7 @@ visualization_msgs::msg::MarkerArray createPathMarkerArray(
   marker.header.frame_id = "map";
   marker.ns = ns;
   marker.id = lane_id;
-  marker.lifetime = rclcpp::Duration(0.3);
+  marker.lifetime = rclcpp::Duration::from_seconds(0.3);
   marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
   marker.action = visualization_msgs::msg::Marker::ADD;
   marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
@@ -116,7 +116,7 @@ visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray(
   marker_virtual_wall.header.frame_id = "map";
   marker_virtual_wall.ns = "stop_virtual_wall";
   marker_virtual_wall.id = lane_id;
-  marker_virtual_wall.lifetime = rclcpp::Duration(0.5);
+  marker_virtual_wall.lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_virtual_wall.type = visualization_msgs::msg::Marker::CUBE;
   marker_virtual_wall.action = visualization_msgs::msg::Marker::ADD;
   marker_virtual_wall.pose = pose;
@@ -129,7 +129,7 @@ visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray(
   marker_factor_text.header.frame_id = "map";
   marker_factor_text.ns = "factor_text";
   marker_factor_text.id = lane_id;
-  marker_factor_text.lifetime = rclcpp::Duration(0.5);
+  marker_factor_text.lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_factor_text.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
   marker_factor_text.action = visualization_msgs::msg::Marker::ADD;
   marker_factor_text.pose = pose;
@@ -153,7 +153,7 @@ visualization_msgs::msg::MarkerArray createPoseMarkerArray(
     marker_line.header.frame_id = "map";
     marker_line.ns = ns + "_line";
     marker_line.id = id;
-    marker_line.lifetime = rclcpp::Duration(0.3);
+    marker_line.lifetime = rclcpp::Duration::from_seconds(0.3);
     marker_line.type = visualization_msgs::msg::Marker::LINE_STRIP;
     marker_line.action = visualization_msgs::msg::Marker::ADD;
     marker_line.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/debug.cpp
@@ -38,7 +38,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
 
     marker.ns = "crosswalk polygon line";
     marker.id = uid + i;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
@@ -65,7 +65,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
 
     marker.ns = "crosswalk polygon point";
     marker.id = i;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::POINTS;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
@@ -97,7 +97,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
     marker.header.frame_id = "map";
     marker.ns = "collision line";
     marker.id = uid + i;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
@@ -128,7 +128,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
     marker.header.frame_id = "map";
     marker.ns = "collision point";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::POINTS;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
@@ -163,7 +163,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
 
     marker.ns = "slow polygon line";
     marker.id = uid + i;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
@@ -195,7 +195,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
     marker.header.frame_id = "map";
     marker.ns = "slow point";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::POINTS;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
@@ -230,7 +230,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
 
     marker.ns = "stop polygon line";
     marker.id = uid + i;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
@@ -262,7 +262,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
     marker.header.frame_id = "map";
     marker.ns = "stop point";
     marker.id = module_id;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::POINTS;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
@@ -294,7 +294,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
     marker.header.frame_id = "map";
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::CUBE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -317,7 +317,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
     marker.header.frame_id = "map";
     marker.ns = "factor_text";
     marker.id = uid + j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -342,7 +342,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
     marker.header.frame_id = "map";
     marker.ns = "slow virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::CUBE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -365,7 +365,7 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
     marker.header.frame_id = "map";
     marker.ns = "slow factor_text";
     marker.id = uid + j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -401,7 +401,7 @@ visualization_msgs::msg::MarkerArray createWalkwayMarkers(
     marker.header.frame_id = "map";
     marker.ns = "stop point";
     marker.id = module_id;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::POINTS;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0;
@@ -433,7 +433,7 @@ visualization_msgs::msg::MarkerArray createWalkwayMarkers(
     marker.header.frame_id = "map";
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::CUBE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -456,7 +456,7 @@ visualization_msgs::msg::MarkerArray createWalkwayMarkers(
     marker.header.frame_id = "map";
     marker.ns = "factor_text";
     marker.id = uid + j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
@@ -38,7 +38,7 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
     marker.header.frame_id = "map";
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::CUBE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -61,7 +61,7 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
     marker.header.frame_id = "map";
     marker.ns = "dead_line_virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::CUBE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -84,7 +84,7 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
     marker.header.frame_id = "map";
     marker.ns = "factor_text";
     marker.id = j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
@@ -37,7 +37,7 @@ visualization_msgs::msg::MarkerArray createLaneletPolygonsMarkerArray(
 
     marker.ns = ns;
     marker.id = uid + i++;
-    marker.lifetime = rclcpp::Duration(0.3);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.3);
     marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
@@ -68,7 +68,7 @@ visualization_msgs::msg::MarkerArray createPolygonMarkerArray(
 
   marker.ns = ns;
   marker.id = lane_id;
-  marker.lifetime = rclcpp::Duration(0.3);
+  marker.lifetime = rclcpp::Duration::from_seconds(0.3);
   marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
   marker.action = visualization_msgs::msg::Marker::ADD;
   marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
@@ -101,7 +101,7 @@ visualization_msgs::msg::MarkerArray createObjectsMarkerArray(
   int32_t i = 0;
   for (const auto & object : objects.objects) {
     marker.id = uid + i++;
-    marker.lifetime = rclcpp::Duration(1.0);
+    marker.lifetime = rclcpp::Duration::from_seconds(1.0);
     marker.type = visualization_msgs::msg::Marker::CUBE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose = object.state.pose_covariance.pose;
@@ -125,7 +125,7 @@ visualization_msgs::msg::MarkerArray createPathMarkerArray(
     marker.header.frame_id = "map";
     marker.ns = ns;
     marker.id = uid + i++;
-    marker.lifetime = rclcpp::Duration(0.3);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.3);
     marker.type = visualization_msgs::msg::Marker::ARROW;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose = p.point.pose;
@@ -151,7 +151,7 @@ visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray(
   marker_virtual_wall.header.frame_id = "map";
   marker_virtual_wall.ns = "stop_virtual_wall";
   marker_virtual_wall.id = lane_id;
-  marker_virtual_wall.lifetime = rclcpp::Duration(0.5);
+  marker_virtual_wall.lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_virtual_wall.type = visualization_msgs::msg::Marker::CUBE;
   marker_virtual_wall.action = visualization_msgs::msg::Marker::ADD;
   marker_virtual_wall.pose = pose;
@@ -164,7 +164,7 @@ visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray(
   marker_factor_text.header.frame_id = "map";
   marker_factor_text.ns = "factor_text";
   marker_factor_text.id = lane_id;
-  marker_factor_text.lifetime = rclcpp::Duration(0.5);
+  marker_factor_text.lifetime = rclcpp::Duration::from_seconds(0.5);
   marker_factor_text.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
   marker_factor_text.action = visualization_msgs::msg::Marker::ADD;
   marker_factor_text.pose = pose;
@@ -187,7 +187,7 @@ visualization_msgs::msg::MarkerArray createPoseMarkerArray(
   marker_line.header.frame_id = "map";
   marker_line.ns = ns + "_line";
   marker_line.id = id;
-  marker_line.lifetime = rclcpp::Duration(0.3);
+  marker_line.lifetime = rclcpp::Duration::from_seconds(0.3);
   marker_line.type = visualization_msgs::msg::Marker::LINE_STRIP;
   marker_line.action = visualization_msgs::msg::Marker::ADD;
   marker_line.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
@@ -38,7 +38,7 @@ visualization_msgs::msg::MarkerArray createMarkers(
     marker.header.frame_id = "map";
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::CUBE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -61,7 +61,7 @@ visualization_msgs::msg::MarkerArray createMarkers(
     marker.header.frame_id = "map";
     marker.ns = "factor_text";
     marker.id = uid + j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/debug.cpp
@@ -38,7 +38,7 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
     marker.header.frame_id = "map";
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::CUBE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -61,7 +61,7 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
     marker.header.frame_id = "map";
     marker.ns = "factor_text";
     marker.id = uid + j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -85,7 +85,7 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
     marker.header.frame_id = "map";
     marker.ns = "dead line virtual_wall";
     marker.id = uid + j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::CUBE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -108,7 +108,7 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
     marker.header.frame_id = "map";
     marker.ns = "dead line factor_text";
     marker.id = uid + j;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/src/debug.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/src/debug.cpp
@@ -385,7 +385,7 @@ visualization_msgs::msg::MarkerArray getObjectsMarkerArray(
   int32_t i = 0;
   for (const auto & object : objects) {
     marker.id = i++;
-    marker.lifetime = rclcpp::Duration(1.0);
+    marker.lifetime = rclcpp::Duration::from_seconds(1.0);
     marker.type = visualization_msgs::msg::Marker::CUBE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose = object.state.pose_covariance.pose;
@@ -412,7 +412,7 @@ visualization_msgs::msg::MarkerArray getRectanglesMarkerArray(
   int unique_id = 0;
   for (const auto & rect : rects) {
     marker.id = unique_id++;
-    marker.lifetime = rclcpp::Duration(1.0);
+    marker.lifetime = rclcpp::Duration::from_seconds(1.0);
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.orientation.w = 1.0;
     marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
@@ -672,7 +672,7 @@ visualization_msgs::msg::MarkerArray getVirtualWallMarkerArray(
   marker.header.frame_id = "map";
   marker.header.stamp = current_time;
   marker.ns = ns;
-  marker.lifetime = rclcpp::Duration(1.0);
+  marker.lifetime = rclcpp::Duration::from_seconds(1.0);
   marker.type = visualization_msgs::msg::Marker::CUBE;
   marker.action = visualization_msgs::msg::Marker::ADD;
   marker.pose = pose;
@@ -694,7 +694,7 @@ visualization_msgs::msg::MarkerArray getVirtualWallTextMarkerArray(
   marker.header.frame_id = "map";
   marker.header.stamp = current_time;
   marker.ns = ns;
-  marker.lifetime = rclcpp::Duration(1.0);
+  marker.lifetime = rclcpp::Duration::from_seconds(1.0);
   marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
   marker.action = visualization_msgs::msg::Marker::ADD;
   marker.pose = pose;

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/src/node.cpp
@@ -374,7 +374,7 @@ std::unique_ptr<geometry_msgs::msg::Pose> ObstacleAvoidancePlanner::getCurrentEg
 
   try {
     tf_current_pose =
-      tf_buffer_ptr_->lookupTransform("map", "base_link", rclcpp::Time(0), rclcpp::Duration(1.0));
+      tf_buffer_ptr_->lookupTransform("map", "base_link", rclcpp::Time(0), rclcpp::Duration::from_seconds(1.0));
   } catch (tf2::TransformException ex) {
     RCLCPP_ERROR(get_logger(), "[ObstacleAvoidancePlanner] %s", ex.what());
     return nullptr;

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/debug_marker.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/debug_marker.cpp
@@ -139,7 +139,7 @@ visualization_msgs::msg::MarkerArray ObstacleStopPlannerDebugNode::makeVisualiza
     marker.header.stamp = current_time;
     marker.ns = "detection_polygons";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::LINE_LIST;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0.0;
@@ -190,7 +190,7 @@ visualization_msgs::msg::MarkerArray ObstacleStopPlannerDebugNode::makeVisualiza
     marker.header.stamp = current_time;
     marker.ns = "collision_polygons";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::LINE_LIST;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0.0;
@@ -241,7 +241,7 @@ visualization_msgs::msg::MarkerArray ObstacleStopPlannerDebugNode::makeVisualiza
     marker.header.stamp = current_time;
     marker.ns = "slow_down_detection_polygons";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::LINE_LIST;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0.0;
@@ -292,7 +292,7 @@ visualization_msgs::msg::MarkerArray ObstacleStopPlannerDebugNode::makeVisualiza
     marker.header.stamp = current_time;
     marker.ns = "slow_down_polygons";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::LINE_LIST;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position.x = 0.0;
@@ -343,7 +343,7 @@ visualization_msgs::msg::MarkerArray ObstacleStopPlannerDebugNode::makeVisualiza
     marker.header.stamp = current_time;
     marker.ns = "virtual_wall/stop";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::CUBE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -367,7 +367,7 @@ visualization_msgs::msg::MarkerArray ObstacleStopPlannerDebugNode::makeVisualiza
     marker.header.stamp = current_time;
     marker.ns = "factor_text/stop";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -392,7 +392,7 @@ visualization_msgs::msg::MarkerArray ObstacleStopPlannerDebugNode::makeVisualiza
     marker.header.stamp = current_time;
     marker.ns = "virtual_wall/slow_down_start";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::CUBE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -416,7 +416,7 @@ visualization_msgs::msg::MarkerArray ObstacleStopPlannerDebugNode::makeVisualiza
     marker.header.stamp = current_time;
     marker.ns = "factor_text/slow_down_start";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -441,7 +441,7 @@ visualization_msgs::msg::MarkerArray ObstacleStopPlannerDebugNode::makeVisualiza
     marker.header.stamp = current_time;
     marker.ns = "virtual_wall/slow_down_end";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::CUBE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -465,7 +465,7 @@ visualization_msgs::msg::MarkerArray ObstacleStopPlannerDebugNode::makeVisualiza
     marker.header.stamp = current_time;
     marker.ns = "factor_text/slow_down_end";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -490,7 +490,7 @@ visualization_msgs::msg::MarkerArray ObstacleStopPlannerDebugNode::makeVisualiza
     marker.header.stamp = current_time;
     marker.ns = "stop_obstacle_point";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::SPHERE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position = *stop_obstacle_point_ptr_;
@@ -514,7 +514,7 @@ visualization_msgs::msg::MarkerArray ObstacleStopPlannerDebugNode::makeVisualiza
     marker.header.stamp = current_time;
     marker.ns = "stop_obstacle_text";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position = *stop_obstacle_point_ptr_;
@@ -540,7 +540,7 @@ visualization_msgs::msg::MarkerArray ObstacleStopPlannerDebugNode::makeVisualiza
     marker.header.stamp = current_time;
     marker.ns = "slow_down_obstacle_point";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::SPHERE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position = *slow_down_obstacle_point_ptr_;
@@ -564,7 +564,7 @@ visualization_msgs::msg::MarkerArray ObstacleStopPlannerDebugNode::makeVisualiza
     marker.header.stamp = current_time;
     marker.ns = "slow_down_obstacle_text";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position = *slow_down_obstacle_point_ptr_;

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/src/node.cpp
@@ -198,7 +198,7 @@ void ObstacleStopPlannerNode::pathCallback(
     try {
       transform_stamped = tf_buffer_.lookupTransform(
         trajectory.header.frame_id, obstacle_ros_pointcloud_ptr_->header.frame_id,
-        obstacle_ros_pointcloud_ptr_->header.stamp, rclcpp::Duration(0.5));
+        obstacle_ros_pointcloud_ptr_->header.stamp, rclcpp::Duration::from_seconds(0.5));
     } catch (tf2::TransformException & ex) {
       RCLCPP_ERROR_STREAM(get_logger(),
         "[obstacle_stop_plannnr] Failed to look up transform from "
@@ -777,7 +777,7 @@ bool ObstacleStopPlannerNode::getSelfPose(
   try {
     geometry_msgs::msg::TransformStamped transform;
     transform =
-      tf_buffer.lookupTransform(header.frame_id, "base_link", header.stamp, rclcpp::Duration(0.1));
+      tf_buffer.lookupTransform(header.frame_id, "base_link", header.stamp, rclcpp::Duration::from_seconds(0.1));
     self_pose.position.x = transform.transform.translation.x;
     self_pose.position.y = transform.transform.translation.y;
     self_pose.position.z = transform.transform.translation.z;

--- a/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/src/debug_marker.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/src/debug_marker.cpp
@@ -79,7 +79,7 @@ visualization_msgs::msg::MarkerArray SurroundObstacleCheckerDebugNode::makeVisua
     marker.header.stamp = current_time;
     marker.ns = "virtual_wall/no_start";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::CUBE;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -104,7 +104,7 @@ visualization_msgs::msg::MarkerArray SurroundObstacleCheckerDebugNode::makeVisua
     marker.header.stamp = current_time;
     marker.ns = "factor_text/no_start";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker.action = visualization_msgs::msg::Marker::ADD;
     tf2::Transform tf_map2base_link;
@@ -130,7 +130,7 @@ visualization_msgs::msg::MarkerArray SurroundObstacleCheckerDebugNode::makeVisua
     marker.header.stamp = current_time;
     marker.ns = "no_start_obstacle_text";
     marker.id = 0;
-    marker.lifetime = rclcpp::Duration(0.5);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
     marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
     marker.action = visualization_msgs::msg::Marker::ADD;
     marker.pose.position = *stop_obstacle_point_ptr_;

--- a/planning/scenario_planning/parking/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp
+++ b/planning/scenario_planning/parking/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp
@@ -143,7 +143,7 @@ CostmapGenerator::CostmapGenerator() :
   // Wait for first tf
   while (rclcpp::ok()) {
     try {
-      tf_buffer_.lookupTransform(map_frame_, vehicle_frame_, rclcpp::Time(0), rclcpp::Duration(10.0));
+      tf_buffer_.lookupTransform(map_frame_, vehicle_frame_, rclcpp::Time(0), rclcpp::Duration::from_seconds(10.0));
       break;
     } catch (tf2::TransformException ex) {
       RCLCPP_ERROR(this->get_logger(),"waiting for initial pose...");
@@ -225,7 +225,7 @@ void CostmapGenerator::onTimer()
   geometry_msgs::msg::TransformStamped tf;
   try {
     tf =
-      tf_buffer_.lookupTransform(costmap_frame_, vehicle_frame_, rclcpp::Time(0), rclcpp::Duration(1.0));
+      tf_buffer_.lookupTransform(costmap_frame_, vehicle_frame_, rclcpp::Time(0), rclcpp::Duration::from_seconds(1.0));
   } catch (tf2::TransformException ex) {
     RCLCPP_ERROR(rclcpp::get_logger("Exception: "), "%s", ex.what());
     return;
@@ -290,7 +290,7 @@ autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr transformObjec
   geometry_msgs::msg::TransformStamped objects2costmap;
   try {
     objects2costmap =
-      tf_buffer.lookupTransform(target_frame_id, src_frame_id, rclcpp::Time(0), rclcpp::Duration(1.0));
+      tf_buffer.lookupTransform(target_frame_id, src_frame_id, rclcpp::Time(0), rclcpp::Duration::from_seconds(1.0));
   } catch (tf2::TransformException ex) {
     RCLCPP_ERROR(rclcpp::get_logger("Exception: "), "%s", ex.what());
   }

--- a/planning/scenario_planning/parking/costmap_generator/nodes/costmap_generator/object_map_utils.cpp
+++ b/planning/scenario_planning/parking/costmap_generator/nodes/costmap_generator/object_map_utils.cpp
@@ -75,7 +75,7 @@ void FillPolygonAreas(
 
   geometry_msgs::msg::TransformStamped transform;
   transform = in_tf_buffer.lookupTransform(
-      in_tf_target_frame, in_tf_source_frame, rclcpp::Time(0), rclcpp::Duration(1.0));
+      in_tf_target_frame, in_tf_source_frame, rclcpp::Time(0), rclcpp::Duration::from_seconds(1.0));
 
 
   // calculate out_grid_map position

--- a/planning/scenario_planning/parking/freespace_planner/src/freespace_planner/freespace_planner_node.cpp
+++ b/planning/scenario_planning/parking/freespace_planner/src/freespace_planner/freespace_planner_node.cpp
@@ -526,7 +526,7 @@ geometry_msgs::msg::TransformStamped AstarNavi::getTransform(
 {
   geometry_msgs::msg::TransformStamped tf;
   try {
-    tf = tf_buffer_->lookupTransform(from, to, rclcpp::Time(0), rclcpp::Duration(1.0));
+    tf = tf_buffer_->lookupTransform(from, to, rclcpp::Time(0), rclcpp::Duration::from_seconds(1.0));
   } catch (const tf2::TransformException & ex) {
     RCLCPP_ERROR(get_logger(), "%s", ex.what());
   }

--- a/simulator/util/dummy_perception_publisher/src/node.cpp
+++ b/simulator/util/dummy_perception_publisher/src/node.cpp
@@ -67,7 +67,7 @@ void DummyPerceptionPublisherNode::timerCallback()
   try {
     geometry_msgs::msg::TransformStamped ros_base_link2map;
     ros_base_link2map = tf_buffer_.lookupTransform(
-      /*target*/ "base_link", /*src*/ "map", current_time, rclcpp::Duration(0.5));
+      /*target*/ "base_link", /*src*/ "map", current_time, rclcpp::Duration::from_seconds(0.5));
     tf2::fromMsg(ros_base_link2map.transform, tf_base_link2map);
   } catch (tf2::TransformException & ex) {
     RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "%s", ex.what());
@@ -329,7 +329,7 @@ void DummyPerceptionPublisherNode::objectCallback(
           geometry_msgs::msg::TransformStamped ros_input2map;
           ros_input2map = tf_buffer_.lookupTransform(
             /*target*/ msg->header.frame_id, /*src*/ "map", msg->header.stamp,
-            rclcpp::Duration(0.5));
+            rclcpp::Duration::from_seconds(0.5));
           tf2::fromMsg(ros_input2map.transform, tf_input2map);
         } catch (tf2::TransformException & ex) {
           RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "%s", ex.what());
@@ -362,7 +362,7 @@ void DummyPerceptionPublisherNode::objectCallback(
               geometry_msgs::msg::TransformStamped ros_input2map;
               ros_input2map = tf_buffer_.lookupTransform(
                 /*target*/ msg->header.frame_id, /*src*/ "map", msg->header.stamp,
-                rclcpp::Duration(0.5));
+                rclcpp::Duration::from_seconds(0.5));
               tf2::fromMsg(ros_input2map.transform, tf_input2map);
             } catch (tf2::TransformException & ex) {
               RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "%s", ex.what());


### PR DESCRIPTION
The normal constructor uses nanoseconds instead. See https://github.com/tier4/AutowareArchitectureProposal/pull/135/files
