### PR TITLE
Pointcloud preprocessor link opencv

### DIFF
--- a/sensing/preprocessor/pointcloud/pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/preprocessor/pointcloud/pointcloud_preprocessor/CMakeLists.txt
@@ -110,6 +110,7 @@ rclcpp_components_register_node(downsample_filter
 ament_auto_add_library(ray_ground_filter SHARED
   src/ground_filter/ray_ground_filter_nodelet.cpp
   src/filter.cpp)
+target_link_libraries(ray_ground_filter ${OpenCV_LIBS})
 if (OPENMP_FOUND)
   set_target_properties(ray_ground_filter PROPERTIES
     COMPILE_FLAGS ${OpenMP_CXX_FLAGS}


### PR DESCRIPTION
In porting `sensing_launch`, I ran into a linker error with this [commit](https://github.com/tier4/autoware_launcher.iv.universe/pull/14/commits/c94ed6920fa4a2aab52e9246555c855a9ef4f13d)

```
[component_container-1] [INFO] [1606769855.352323941] [ray_ground_filter]: Filter (as Component) successfully created with the following parameters:
[component_container-1]  - approximate_sync : false
[component_container-1]  - use_indices      : false
[component_container-1]  - latched_indices  : false
[component_container-1]  - max_queue_size   : 3
[component_container-1] /opt/ros/foxy/lib/rclcpp_components/component_container: symbol lookup error: /home/frederik.beaujean/AutowareArchitectureProposal/install/pointcloud_preprocessor/lib/libray_ground_filter.so: undefined symbol: _ZN2cv3Mat6createEiPKii
[ERROR] [component_container-1]: process has died [pid 31122, exit code 127, cmd '/opt/ros/foxy/lib/rclcpp_components/component_container --ros-args -r __node:=pointcloud_preprocessor_container -r __ns:=/sensing/lidar/pointcloud_preprocessor'].
```

This PR links the missing opencv libraries and fixes the above issue

@TakaHoribe @mitsudome-r 


