### PR TITLE
[gnss_poser] switch broadcaster to full member...

### DIFF
--- a/sensing/preprocessor/gnss/gnss_poser/CMakeLists.txt
+++ b/sensing/preprocessor/gnss/gnss_poser/CMakeLists.txt
@@ -18,8 +18,8 @@ set(GNSS_POSER_HEADERS
   include/gnss_poser/gnss_stat.hpp
  )
 
-ament_auto_add_library(gnss_poser_node SHARED 
-	src/gnss_poser_core.cpp 
+ament_auto_add_library(gnss_poser_node SHARED
+	src/gnss_poser_core.cpp
 	${GNSS_POSER_HEADERS}
 )
 

--- a/sensing/preprocessor/gnss/gnss_poser/include/gnss_poser/gnss_poser_core.hpp
+++ b/sensing/preprocessor/gnss/gnss_poser/include/gnss_poser/gnss_poser_core.hpp
@@ -67,7 +67,7 @@ private:
 
   tf2::BufferCore tf2_buffer_;
   tf2_ros::TransformListener tf2_listener_;
-  std::shared_ptr<tf2_ros::TransformBroadcaster> tf2_broadcaster_;
+  tf2_ros::TransformBroadcaster tf2_broadcaster_;
 
   rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr nav_sat_fix_sub_;
   rclcpp::Subscription<ublox_msgs::msg::NavPVT>::SharedPtr nav_pvt_sub_;

--- a/sensing/preprocessor/gnss/gnss_poser/src/gnss_poser_core.cpp
+++ b/sensing/preprocessor/gnss/gnss_poser/src/gnss_poser_core.cpp
@@ -24,7 +24,7 @@ namespace GNSSPoser
 GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
 : rclcpp::Node("gnss_poser", node_options),
   tf2_listener_(tf2_buffer_),
-  tf2_broadcaster_(std::make_shared<tf2_ros::TransformBroadcaster>(shared_from_this())),
+  tf2_broadcaster_(*this),
   base_frame_(declare_parameter("base_frame", "base_link")),
   gnss_frame_(declare_parameter("gnss_frame", "gnss")),
   gnss_base_frame_(declare_parameter("gnss_base_frame", "gnss_base_link")),
@@ -342,7 +342,7 @@ void GNSSPoser::publishTF(
   transform_stamped.transform.rotation.z = tf_quaternion.z();
   transform_stamped.transform.rotation.w = tf_quaternion.w();
 
-  tf2_broadcaster_->sendTransform(transform_stamped);
+  tf2_broadcaster_.sendTransform(transform_stamped);
 }
 
 RCLCPP_COMPONENTS_REGISTER_NODE(GNSSPoser)


### PR DESCRIPTION
In porting `sensing_launch`, I started a node with the gnss_poser and ran into 

```
[INFO] [ublox_gps_node-1]: process started with pid [31684]
[ublox_gps_node-1] terminate called after throwing an instance of 'std::runtime_error'
[ublox_gps_node-1]   what():  U-Blox: Could not open serial port :/dev/ttyACM0 open: No such file or directory
[ERROR] [ublox_gps_node-1]: process has died [pid 31684, exit code -6, cmd '/home/frederik.beaujean/AutowareArchitectureProposal/install/ublox_gps/lib/ublox_gps/ublox_gps_node --ros-args -r __node:=ublox -r ublox/fix:=ublox/nav_sat_fix -r __ns:=/sensing/gnss'].
```

This PR avoids this problem by using a proper member instead of a shared pointer because `shared_from_this()` must not be called in the constructor of `this`. It looked like a `shared_ptr` was unnecessary here anyways.

@esteve @mitsudome-r

@jilaada do you remember if you ever started this node when you ported the package? 