### PR TITLE
Compilation fix for arm architecture

### DIFF
--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
@@ -30,12 +30,14 @@ target_include_directories(ndt_omp
     $<INSTALL_INTERFACE:include> 
 )
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  target_compile_options(ndt_omp
-    PRIVATE
-      # -mavx causes a lot of errors!!
-      -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2
-  )
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(ndt_omp
+      PRIVATE
+        # -mavx causes a lot of errors!!
+        -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2
+    )
+  endif()
 endif()
 
 set(NDT_OMP_DEPENDENCIES


### PR DESCRIPTION
As mentioned in #139. The `ndt_omp` package is using some compilation flags that are tied to x86 architecture causing the package to fail building on arm64. The PR enables the compilation options when building on x86

Signed-off-by: Servando German Serrano <servando.german.serrano@linaro.org>