### PR TITLE
Enable lints in astar_search

### DIFF
--- a/planning/scenario_planning/parking/astar_search/CMakeLists.txt
+++ b/planning/scenario_planning/parking/astar_search/CMakeLists.txt
@@ -3,6 +3,8 @@ project(astar_search)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
@@ -12,6 +14,11 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(astar_search src/astar_search.cpp)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE

--- a/planning/scenario_planning/parking/astar_search/include/astar_search/astar_search.hpp
+++ b/planning/scenario_planning/parking/astar_search/include/astar_search/astar_search.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SCENARIO_PLANNING_PARKING_ASTAR_PLANNER_H
-#define SCENARIO_PLANNING_PARKING_ASTAR_PLANNER_H
+#ifndef ASTAR_SEARCH__ASTAR_SEARCH_HPP_
+#define ASTAR_SEARCH__ASTAR_SEARCH_HPP_
 
 #include <cmath>
 #include <functional>
@@ -54,7 +54,7 @@ struct AstarNode
   bool is_back;                          // true if the current direction of the vehicle is back
   AstarNode * parent = nullptr;          // parent node
 
-  double cost() const { return gc + hc; }
+  double cost() const {return gc + hc;}
 };
 
 struct NodeComparison
@@ -150,13 +150,13 @@ public:
 
   explicit AstarSearch(const AstarParam & astar_param);
 
-  void setRobotShape(const RobotShape & robot_shape) { astar_param_.robot_shape = robot_shape; }
+  void setRobotShape(const RobotShape & robot_shape) {astar_param_.robot_shape = robot_shape;}
   void initializeNodes(const nav_msgs::msg::OccupancyGrid & costmap);
   bool makePlan(
     const geometry_msgs::msg::Pose & start_pose, const geometry_msgs::msg::Pose & goal_pose);
   bool hasObstacleOnTrajectory(const geometry_msgs::msg::PoseArray & trajectory);
 
-  const AstarWaypoints & getWaypoints() const { return waypoints_; }
+  const AstarWaypoints & getWaypoints() const {return waypoints_;}
 
 private:
   bool search();
@@ -170,7 +170,7 @@ private:
   bool isObs(const IndexXYT & index);
   bool isGoal(const AstarNode & node);
 
-  AstarNode * getNodeRef(const IndexXYT & index) { return &nodes_[index.y][index.x][index.theta]; }
+  AstarNode * getNodeRef(const IndexXYT & index) {return &nodes_[index.y][index.x][index.theta];}
 
   AstarParam astar_param_;
 
@@ -190,4 +190,4 @@ private:
   AstarWaypoints waypoints_;
 };
 
-#endif
+#endif  // ASTAR_SEARCH__ASTAR_SEARCH_HPP_

--- a/planning/scenario_planning/parking/astar_search/include/astar_search/helper.hpp
+++ b/planning/scenario_planning/parking/astar_search/include/astar_search/helper.hpp
@@ -12,32 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
+#ifndef ASTAR_SEARCH__HELPER_HPP_
+#define ASTAR_SEARCH__HELPER_HPP_
 
-constexpr double deg2rad(const double deg) { return deg * M_PI / 180.0; }
+constexpr double deg2rad(const double deg) {return deg * M_PI / 180.0;}
 
-constexpr double rad2deg(const double rad) { return rad * 180.0 / M_PI; }
+constexpr double rad2deg(const double rad) {return rad * 180.0 / M_PI;}
 
-constexpr double kmph2mps(const double kmph) { return kmph * 1000.0 / 3600.0; }
+constexpr double kmph2mps(const double kmph) {return kmph * 1000.0 / 3600.0;}
 
-constexpr double mps2kmph(const double mps) { return mps * 3600.0 / 1000.0; }
+constexpr double mps2kmph(const double mps) {return mps * 3600.0 / 1000.0;}
 
-constexpr double normalizeDegree(
+double normalizeDegree(
   const double deg, const double min_deg = -180, const double max_deg = 180)
 {
   const auto value = std::fmod(deg, 360.0);
-  if (min_deg < value && value <= max_deg)
+  if (min_deg < value && value <= max_deg) {
     return value;
-  else
+  } else {
     return value - std::copysign(360.0, value);
+  }
 }
 
-constexpr double normalizeRadian(
+double normalizeRadian(
   const double rad, const double min_rad = -M_PI, const double max_rad = M_PI)
 {
   const auto value = std::fmod(rad, 2 * M_PI);
-  if (min_rad < value && value <= max_rad)
+  if (min_rad < value && value <= max_rad) {
     return value;
-  else
+  } else {
     return value - std::copysign(2 * M_PI, value);
+  }
 }
+
+#endif  // ASTAR_SEARCH__HELPER_HPP_

--- a/planning/scenario_planning/parking/astar_search/package.xml
+++ b/planning/scenario_planning/parking/astar_search/package.xml
@@ -5,7 +5,6 @@
   <version>0.1.0</version>
   <description>The astar_search package</description>
   <maintainer email="aohsato@gmail.com">Akihito Ohsato</maintainer>
-  <author email="aohsato@gmail.com">Akihito Ohsato</author>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
@@ -16,6 +15,9 @@
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend> 
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/planning/scenario_planning/parking/astar_search/package.xml
+++ b/planning/scenario_planning/parking/astar_search/package.xml
@@ -6,6 +6,7 @@
   <description>The astar_search package</description>
   <maintainer email="aohsato@gmail.com">Akihito Ohsato</maintainer>
   <license>Apache License 2.0</license>
+  <author email="aohsato@gmail.com">Akihito Ohsato</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 

--- a/planning/scenario_planning/parking/astar_search/src/astar_search.cpp
+++ b/planning/scenario_planning/parking/astar_search/src/astar_search.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "astar_search/astar_search.hpp"
+
 #include "astar_search/helper.hpp"
 
 #include "tf2/utils.h"
@@ -179,7 +180,8 @@ AstarSearch::TransitionTable createTransitionTable(
 
 }  // namespace
 
-AstarSearch::AstarSearch(const AstarParam & astar_param) : astar_param_(astar_param)
+AstarSearch::AstarSearch(const AstarParam & astar_param)
+: astar_param_(astar_param)
 {
   transition_table_ = createTransitionTable(
     astar_param_.minimum_turning_radius, astar_param_.theta_size, astar_param_.use_back);
@@ -435,14 +437,14 @@ bool AstarSearch::hasObstacleOnTrajectory(const geometry_msgs::msg::PoseArray & 
 
 bool AstarSearch::isOutOfRange(const IndexXYT & index)
 {
-  if (index.x < 0 || static_cast<int>(costmap_.info.width) <= index.x) return true;
-  if (index.y < 0 || static_cast<int>(costmap_.info.height) <= index.y) return true;
+  if (index.x < 0 || static_cast<int>(costmap_.info.width) <= index.x) {return true;}
+  if (index.y < 0 || static_cast<int>(costmap_.info.height) <= index.y) {return true;}
   return false;
 }
 
 bool AstarSearch::isObs(const IndexXYT & index)
 {
-  return (nodes_[index.y][index.x][0].status == NodeStatus::Obstacle);
+  return nodes_[index.y][index.x][0].status == NodeStatus::Obstacle;
 }
 
 bool AstarSearch::isGoal(const AstarNode & node)
@@ -460,7 +462,8 @@ bool AstarSearch::isGoal(const AstarNode & node)
 
   if (
     std::fabs(relative_pose.position.x) > longitudinal_goal_range ||
-    std::fabs(relative_pose.position.y) > lateral_goal_range) {
+    std::fabs(relative_pose.position.y) > lateral_goal_range)
+  {
     return false;
   }
 


### PR DESCRIPTION
clang-tidy also pointed out that the `fmod` function is not `constexpr`, so the function will never return a `constexpr` value.