### PR TITLE
Enable lints in costmap_generator

### DIFF
--- a/planning/scenario_planning/parking/costmap_generator/CMakeLists.txt
+++ b/planning/scenario_planning/parking/costmap_generator/CMakeLists.txt
@@ -4,6 +4,8 @@ project(costmap_generator)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -35,6 +37,8 @@ target_link_libraries(costmap_generator ${PCL_LIBRARIES})
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE launch)

--- a/planning/scenario_planning/parking/costmap_generator/include/costmap_generator/costmap_generator.hpp
+++ b/planning/scenario_planning/parking/costmap_generator/include/costmap_generator/costmap_generator.hpp
@@ -42,11 +42,12 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ********************/
 
-#ifndef COSTMAP_GENERATOR_H
-#define COSTMAP_GENERATOR_H
+#ifndef COSTMAP_GENERATOR__COSTMAP_GENERATOR_HPP_
+#define COSTMAP_GENERATOR__COSTMAP_GENERATOR_HPP_
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "costmap_generator/objects_to_costmap.hpp"
 #include "costmap_generator/points_to_costmap.hpp"
@@ -104,7 +105,6 @@ private:
   rclcpp::Publisher<grid_map_msgs::msg::GridMap>::SharedPtr pub_costmap_;
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr pub_occupancy_grid_;
 
-  //rclcpp::Subscription<CostmapGenerator::onWaypoint>::SharedPtr sub_waypoint_;
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_points_;
   rclcpp::Subscription<autoware_perception_msgs::msg::DynamicObjectArray>::SharedPtr sub_objects_;
   rclcpp::Subscription<autoware_lanelet2_msgs::msg::MapBin>::SharedPtr sub_lanelet_bin_map_;
@@ -187,4 +187,4 @@ private:
   grid_map::Matrix generateCombinedCostmap();
 };
 
-#endif  // COSTMAP_GENERATOR_H
+#endif  // COSTMAP_GENERATOR__COSTMAP_GENERATOR_HPP_

--- a/planning/scenario_planning/parking/costmap_generator/include/costmap_generator/object_map_utils.hpp
+++ b/planning/scenario_planning/parking/costmap_generator/include/costmap_generator/object_map_utils.hpp
@@ -30,8 +30,11 @@
  *
  */
 
-#ifndef PROJECT_OBJECT_MAP_UTILS_H
-#define PROJECT_OBJECT_MAP_UTILS_H
+#ifndef COSTMAP_GENERATOR__OBJECT_MAP_UTILS_HPP_
+#define COSTMAP_GENERATOR__OBJECT_MAP_UTILS_HPP_
+
+#include <string>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -91,4 +94,4 @@ void FillPolygonAreas(
 
 }  // namespace object_map
 
-#endif  // PROJECT_OBJECT_MAP_UTILS_H
+#endif  // COSTMAP_GENERATOR__OBJECT_MAP_UTILS_HPP_

--- a/planning/scenario_planning/parking/costmap_generator/include/costmap_generator/objects_to_costmap.hpp
+++ b/planning/scenario_planning/parking/costmap_generator/include/costmap_generator/objects_to_costmap.hpp
@@ -42,13 +42,15 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ********************/
 
-#ifndef OBJECTS_TO_COSTMAP_H
-#define OBJECTS_TO_COSTMAP_H
+#ifndef COSTMAP_GENERATOR__OBJECTS_TO_COSTMAP_HPP_
+#define COSTMAP_GENERATOR__OBJECTS_TO_COSTMAP_HPP_
+
+#include <string>
+
+#include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "grid_map_ros/grid_map_ros.hpp"
-
-#include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
 
 class ObjectsToCostmap
 {
@@ -118,4 +120,4 @@ private:
     grid_map::GridMap & objects_costmap);
 };
 
-#endif  // OBJECTS_TO_COSTMAP_H
+#endif  // COSTMAP_GENERATOR__OBJECTS_TO_COSTMAP_HPP_

--- a/planning/scenario_planning/parking/costmap_generator/include/costmap_generator/points_to_costmap.hpp
+++ b/planning/scenario_planning/parking/costmap_generator/include/costmap_generator/points_to_costmap.hpp
@@ -42,8 +42,11 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ********************/
 
-#ifndef POINTS_TO_COSTMAP_H
-#define POINTS_TO_COSTMAP_H
+#ifndef COSTMAP_GENERATOR__POINTS_TO_COSTMAP_HPP_
+#define COSTMAP_GENERATOR__POINTS_TO_COSTMAP_HPP_
+
+#include <string>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "grid_map_ros/grid_map_ros.hpp"
@@ -94,12 +97,10 @@ private:
   grid_map::Index fetchGridIndexFromPoint(const pcl::PointXYZ & point);
 
   /// \brief Assign pointcloud to appropriate cell in gridmap
-  /// \param[in] gridmap: costmap based on gridmap
   /// \param[in] in_sensor_points: subscribed pointcloud
   /// \param[out] grid-x-length x grid-y-length size grid stuffed with point's height in
   /// corresponding grid cell
   std::vector<std::vector<std::vector<double>>> assignPoints2GridCell(
-    const grid_map::GridMap & gridmap,
     const pcl::PointCloud<pcl::PointXYZ>::Ptr & in_sensor_points);
 
   /// \brief calculate costmap from subscribed pointcloud
@@ -118,4 +119,4 @@ private:
     const std::vector<std::vector<std::vector<double>>> grid_vec);
 };
 
-#endif  // POINTS_TO_COSTMAP_H
+#endif  // COSTMAP_GENERATOR__POINTS_TO_COSTMAP_HPP_

--- a/planning/scenario_planning/parking/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp
+++ b/planning/scenario_planning/parking/costmap_generator/nodes/costmap_generator/costmap_generator_node.cpp
@@ -1,18 +1,16 @@
-/*
- * Copyright 2020 Tier IV, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use private_node file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /*
  *  Copyright (c) 2018, Nagoya University
@@ -45,6 +43,11 @@
  ********************/
 
 #include "costmap_generator/costmap_generator.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "lanelet2_extension/utility/message_conversion.hpp"
 #include "lanelet2_extension/utility/query.hpp"
@@ -120,7 +123,7 @@ CostmapGenerator::CostmapGenerator()
   sub_points_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
     "input/points_no_ground", 1, std::bind(&CostmapGenerator::onPoints, this, _1));
   sub_lanelet_bin_map_ = this->create_subscription<autoware_lanelet2_msgs::msg::MapBin>(
-    "input/vector_map", rclcpp::QoS(1).transient_local(), std::bind(&CostmapGenerator::onLaneletMapBin, this, _1));
+    "input/vector_map", 1, std::bind(&CostmapGenerator::onLaneletMapBin, this, _1));
   sub_scenario_ = this->create_subscription<autoware_planning_msgs::msg::Scenario>(
     "input/scenario", 1, std::bind(&CostmapGenerator::onScenario, this, _1));
 
@@ -149,7 +152,7 @@ CostmapGenerator::CostmapGenerator()
         map_frame_, vehicle_frame_, rclcpp::Time(
           0), rclcpp::Duration::from_seconds(10.0));
       break;
-    } catch (tf2::TransformException ex) {
+    } catch (tf2::TransformException & ex) {
       RCLCPP_ERROR(this->get_logger(), "waiting for initial pose...");
     }
   }
@@ -237,7 +240,7 @@ void CostmapGenerator::onTimer()
       tf_buffer_.lookupTransform(
       costmap_frame_, vehicle_frame_, rclcpp::Time(
         0), rclcpp::Duration::from_seconds(1.0));
-  } catch (tf2::TransformException ex) {
+  } catch (tf2::TransformException & ex) {
     RCLCPP_ERROR(rclcpp::get_logger("Exception: "), "%s", ex.what());
     return;
   }
@@ -304,12 +307,11 @@ autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr transformObjec
       tf_buffer.lookupTransform(
       target_frame_id, src_frame_id, rclcpp::Time(
         0), rclcpp::Duration::from_seconds(1.0));
-  } catch (tf2::TransformException ex) {
+  } catch (tf2::TransformException & ex) {
     RCLCPP_ERROR(rclcpp::get_logger("Exception: "), "%s", ex.what());
   }
 
   for (auto & object : objects->objects) {
-
     geometry_msgs::msg::PoseStamped output_stamped, input_stamped;
     input_stamped.pose = object.state.pose_covariance.pose;
     tf2::doTransform(input_stamped, output_stamped, objects2costmap);

--- a/planning/scenario_planning/parking/costmap_generator/nodes/costmap_generator/main.cpp
+++ b/planning/scenario_planning/parking/costmap_generator/nodes/costmap_generator/main.cpp
@@ -43,6 +43,8 @@
  ********************
  */
 
+#include <memory>
+
 #include "costmap_generator/costmap_generator.hpp"
 #include "rclcpp/rclcpp.hpp"
 

--- a/planning/scenario_planning/parking/costmap_generator/nodes/costmap_generator/object_map_utils.cpp
+++ b/planning/scenario_planning/parking/costmap_generator/nodes/costmap_generator/object_map_utils.cpp
@@ -32,6 +32,9 @@
 
 #include "costmap_generator/object_map_utils.hpp"
 
+#include <string>
+#include <vector>
+
 namespace object_map
 {
 void PublishGridMap(

--- a/planning/scenario_planning/parking/costmap_generator/nodes/costmap_generator/objects_to_costmap.cpp
+++ b/planning/scenario_planning/parking/costmap_generator/nodes/costmap_generator/objects_to_costmap.cpp
@@ -43,6 +43,7 @@
  ********************/
 
 #include <cmath>
+#include <string>
 
 #include "tf2/utils.h"
 

--- a/planning/scenario_planning/parking/costmap_generator/nodes/costmap_generator/points_to_costmap.cpp
+++ b/planning/scenario_planning/parking/costmap_generator/nodes/costmap_generator/points_to_costmap.cpp
@@ -44,6 +44,9 @@
 
 #include "costmap_generator/points_to_costmap.hpp"
 
+#include <string>
+#include <vector>
+
 // Constructor
 PointsToCostmap::PointsToCostmap() {}
 
@@ -89,7 +92,7 @@ grid_map::Index PointsToCostmap::fetchGridIndexFromPoint(const pcl::PointXYZ & p
 }
 
 std::vector<std::vector<std::vector<double>>> PointsToCostmap::assignPoints2GridCell(
-  const grid_map::GridMap & gridmap, const pcl::PointCloud<pcl::PointXYZ>::Ptr & in_sensor_points)
+  const pcl::PointCloud<pcl::PointXYZ>::Ptr & in_sensor_points)
 {
   double y_cell_size = std::ceil(grid_length_y_ * (1 / grid_resolution_));
   double x_cell_size = std::ceil(grid_length_x_ * (1 / grid_resolution_));
@@ -139,7 +142,7 @@ grid_map::Matrix PointsToCostmap::makeCostmapFromPoints(
 {
   initGridmapParam(gridmap);
   std::vector<std::vector<std::vector<double>>> grid_vec =
-    assignPoints2GridCell(gridmap, in_sensor_points);
+    assignPoints2GridCell(in_sensor_points);
   grid_map::Matrix costmap = calculateCostmap(
     maximum_height_thres, minimum_lidar_height_thres, grid_min_value, grid_max_value, gridmap,
     gridmap_layer_name, grid_vec);

--- a/planning/scenario_planning/parking/costmap_generator/package.xml
+++ b/planning/scenario_planning/parking/costmap_generator/package.xml
@@ -26,6 +26,9 @@
 
   <test_depend>ament_cmake_gtest</test_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
The usual: Many header guards and includes needed fixing. clang-tidy found nothing in this package.