### PR TITLE
Enable lints in lane_change_planner

### DIFF
--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/CMakeLists.txt
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/CMakeLists.txt
@@ -3,6 +3,8 @@ project(lane_change_planner)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -22,7 +24,7 @@ ament_auto_add_executable(lane_change_planner
   src/lane_change_planner_node.cpp
   src/lane_changer.cpp
   src/data_manager.cpp
-	src/route_handler.cpp
+  src/route_handler.cpp
   src/state_machine.cpp
   src/utilities.cpp
 
@@ -38,6 +40,11 @@ ament_auto_add_executable(lane_change_planner
 target_link_libraries(lane_change_planner
   ${OpenCV_LIBRARIES}
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(
 )

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.hpp
@@ -12,8 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANE_CHANGE_PLANNER_DATA_MANAGER_H
-#define LANE_CHANGE_PLANNER_DATA_MANAGER_H
+#ifndef LANE_CHANGE_PLANNER__DATA_MANAGER_HPP_
+#define LANE_CHANGE_PLANNER__DATA_MANAGER_HPP_
+
+#include <memory>
+
+// Own package
+#include "lane_change_planner/parameters.hpp"
+
+// Autoware
+#include "autoware_lanelet2_msgs/msg/map_bin.hpp"
+#include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
+#include "autoware_planning_msgs/msg/path_with_lane_id.hpp"
+#include "autoware_planning_msgs/msg/route.hpp"
 
 // ROS
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -23,20 +34,11 @@
 #include "std_msgs/msg/bool.hpp"
 #include "tf2_ros/transform_listener.h"
 
-// Autoware
-#include "autoware_lanelet2_msgs/msg/map_bin.hpp"
-#include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
-#include "autoware_planning_msgs/msg/path_with_lane_id.hpp"
-#include "autoware_planning_msgs/msg/route.hpp"
-#include "lane_change_planner/parameters.hpp"
-
 // lanelet
 #include "lanelet2_core/LaneletMap.h"
 #include "lanelet2_routing/RoutingGraph.h"
 #include "lanelet2_traffic_rules/TrafficRulesFactory.h"
 
-// other
-#include <memory>
 
 namespace lane_change_planner
 {
@@ -57,8 +59,7 @@ private:
 struct BoolStamped
 {
   explicit BoolStamped(bool in_data)
-  : data(in_data), 
-    stamp(0, 0, RCL_ROS_TIME) {}
+  : data(in_data) {}
   bool data = false;
   rclcpp::Time stamp;
 };
@@ -113,4 +114,4 @@ public:
 };
 }  // namespace lane_change_planner
 
-#endif  // LANE_CHANGE_PLANNER_DATA_MANAGER_H
+#endif  // LANE_CHANGE_PLANNER__DATA_MANAGER_HPP_

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/lane_changer.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/lane_changer.hpp
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANE_CHANGE_PLANNER_LANE_CHANGER_H
-#define LANE_CHANGE_PLANNER_LANE_CHANGER_H
+#ifndef LANE_CHANGE_PLANNER__LANE_CHANGER_HPP_
+#define LANE_CHANGE_PLANNER__LANE_CHANGER_HPP_
 
-// ROS
-#include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/bool.hpp"
-#include "tf2_ros/transform_listener.h"
-#include "visualization_msgs/msg/marker_array.hpp"
+#include <memory>
+#include <vector>
+
+#include "lane_change_planner/data_manager.hpp"
+#include "lane_change_planner/route_handler.hpp"
+#include "lane_change_planner/state_machine.hpp"
 
 // Autoware
 #include "autoware_lanelet2_msgs/msg/map_bin.hpp"
@@ -29,16 +30,16 @@
 #include "autoware_planning_msgs/msg/route.hpp"
 #include "autoware_planning_msgs/msg/stop_reason_array.hpp"
 
-#include "lane_change_planner/data_manager.hpp"
-#include "lane_change_planner/route_handler.hpp"
-#include "lane_change_planner/state_machine.hpp"
+// ROS
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/bool.hpp"
+#include "tf2_ros/transform_listener.h"
+#include "visualization_msgs/msg/marker_array.hpp"
 
 // lanelet
 #include "lanelet2_core/LaneletMap.h"
 #include "lanelet2_routing/RoutingGraph.h"
 #include "lanelet2_traffic_rules/TrafficRulesFactory.h"
-
-#include <memory>
 
 namespace lane_change_planner
 {
@@ -84,4 +85,4 @@ public:
 };
 }  // namespace lane_change_planner
 
-#endif  // LANE_CHANGE_PLANNER_LANE_CHANGER_H
+#endif  // LANE_CHANGE_PLANNER__LANE_CHANGER_HPP_

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/parameters.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/parameters.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANE_CHANGE_PLANNER_PARAMETERS_H
-#define LANE_CHANGE_PLANNER_PARAMETERS_H
+#ifndef LANE_CHANGE_PLANNER__PARAMETERS_HPP_
+#define LANE_CHANGE_PLANNER__PARAMETERS_HPP_
 
 struct LaneChangerParameters
 {
@@ -42,4 +42,4 @@ struct LaneChangerParameters
   bool enable_abort_lane_change;
 };
 
-#endif
+#endif  // LANE_CHANGE_PLANNER__PARAMETERS_HPP_

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/route_handler.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/route_handler.hpp
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANE_CHANGE_PLANNER_ROUTE_HANDLER_H
-#define LANE_CHANGE_PLANNER_ROUTE_HANDLER_H
+#ifndef LANE_CHANGE_PLANNER__ROUTE_HANDLER_HPP_
+#define LANE_CHANGE_PLANNER__ROUTE_HANDLER_HPP_
 
+#include <limits>
+#include <memory>
+#include <vector>
 // Autoware
 #include "autoware_lanelet2_msgs/msg/map_bin.hpp"
 #include "autoware_planning_msgs/msg/path_with_lane_id.hpp"
@@ -31,8 +34,6 @@
 #include "lane_change_planner/parameters.hpp"
 
 #include "rclcpp/rclcpp.hpp"
-
-#include <vector>
 
 namespace lane_change_planner
 {
@@ -151,4 +152,4 @@ public:
   std::vector<lanelet::ConstLanelet> getLanesAfterGoal(const double vehicle_length) const;
 };
 }  // namespace lane_change_planner
-#endif  // LANE_CHANGE_PLANNER_ROUTE_HANDLER_H
+#endif  // LANE_CHANGE_PLANNER__ROUTE_HANDLER_HPP_

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/aborting_lane_change.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/aborting_lane_change.hpp
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANE_CHANGE_PLANNER_STATE_ABORTING_LANE_CHANGE_H
-#define LANE_CHANGE_PLANNER_STATE_ABORTING_LANE_CHANGE_H
+#ifndef LANE_CHANGE_PLANNER__STATE__ABORTING_LANE_CHANGE_HPP_
+#define LANE_CHANGE_PLANNER__STATE__ABORTING_LANE_CHANGE_HPP_
+
+#include <memory>
 
 #include "lane_change_planner/state/state_base_class.hpp"
 
@@ -39,4 +41,4 @@ public:
 };
 }  // namespace lane_change_planner
 
-#endif  // LANE_CHANGE_PLANNER_STATE_ABORTING_LANE_CHANGE_H
+#endif  // LANE_CHANGE_PLANNER__STATE__ABORTING_LANE_CHANGE_HPP_

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/blocked_by_obstacle.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/blocked_by_obstacle.hpp
@@ -12,15 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANE_CHANGE_PLANNER_STATE_BLOCKED_BY_OBSTACLE_H
-#define LANE_CHANGE_PLANNER_STATE_BLOCKED_BY_OBSTACLE_H
+#ifndef LANE_CHANGE_PLANNER__STATE__BLOCKED_BY_OBSTACLE_HPP_
+#define LANE_CHANGE_PLANNER__STATE__BLOCKED_BY_OBSTACLE_HPP_
+
+#include <memory>
+#include <vector>
+
+#include "lane_change_planner/state/state_base_class.hpp"
 
 #include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
+
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
-#include "lane_change_planner/state/state_base_class.hpp"
 #include "lanelet2_core/primitives/Primitive.h"
-#include <memory>
 
 namespace lane_change_planner
 {
@@ -65,4 +69,4 @@ public:
 };
 }  // namespace lane_change_planner
 
-#endif  // LANE_CHANGE_PLANNER_STATE_BLOCKED_BY_OBSTACLE_H
+#endif  // LANE_CHANGE_PLANNER__STATE__BLOCKED_BY_OBSTACLE_HPP_

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/common_functions.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/common_functions.hpp
@@ -11,14 +11,18 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#pragma once
+#ifndef LANE_CHANGE_PLANNER__STATE__COMMON_FUNCTIONS_HPP_
+#define LANE_CHANGE_PLANNER__STATE__COMMON_FUNCTIONS_HPP_
+
+#include <memory>
+#include <vector>
+
+#include "lane_change_planner/state/state_base_class.hpp"
 
 #include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
-#include "lane_change_planner/state/state_base_class.hpp"
 #include "lanelet2_core/primitives/Primitive.h"
-#include <memory>
 
 namespace lane_change_planner
 {
@@ -56,3 +60,5 @@ bool isObjectFront(
 }  // namespace common_functions
 }  // namespace state_machine
 }  // namespace lane_change_planner
+
+#endif  // LANE_CHANGE_PLANNER__STATE__COMMON_FUNCTIONS_HPP_

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/executing_lane_change.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/executing_lane_change.hpp
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANE_CHANGE_PLANNER_STATE_EXECUTING_LANE_CHANGE_H
-#define LANE_CHANGE_PLANNER_STATE_EXECUTING_LANE_CHANGE_H
-
-#include "autoware_planning_msgs/msg/path_with_lane_id.hpp"
-#include "lane_change_planner/state/state_base_class.hpp"
-
-#include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
-#include "geometry_msgs/msg/pose_stamped.hpp"
-#include "geometry_msgs/msg/twist_stamped.hpp"
-
-#include "lanelet2_core/primitives/Lanelet.h"
+#ifndef LANE_CHANGE_PLANNER__STATE__EXECUTING_LANE_CHANGE_HPP_
+#define LANE_CHANGE_PLANNER__STATE__EXECUTING_LANE_CHANGE_HPP_
 
 #include <memory>
+
+#include "lane_change_planner/state/state_base_class.hpp"
+
+#include "autoware_planning_msgs/msg/path_with_lane_id.hpp"
+#include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
+#include "lanelet2_core/primitives/Lanelet.h"
 
 namespace lane_change_planner
 {
@@ -58,4 +58,4 @@ public:
 };
 }  // namespace lane_change_planner
 
-#endif  // LANE_CHANGE_PLANNER_STATE_EXECUTING_LANE_CHANGE_H
+#endif  // LANE_CHANGE_PLANNER__STATE__EXECUTING_LANE_CHANGE_HPP_

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/following_lane.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/following_lane.hpp
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANE_CHANGE_PLANNER_STATE_FOLLOWING_LANE_H
-#define LANE_CHANGE_PLANNER_STATE_FOLLOWING_LANE_H
-
-#include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
-#include "geometry_msgs/msg/pose_stamped.hpp"
-#include "geometry_msgs/msg/twist_stamped.hpp"
-#include "lane_change_planner/state/state_base_class.hpp"
-#include "lanelet2_core/primitives/Primitive.h"
+#ifndef LANE_CHANGE_PLANNER__STATE__FOLLOWING_LANE_HPP_
+#define LANE_CHANGE_PLANNER__STATE__FOLLOWING_LANE_HPP_
 
 #include <memory>
+
+#include "lane_change_planner/state/state_base_class.hpp"
+
+#include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
+#include "lanelet2_core/primitives/Primitive.h"
 
 namespace lane_change_planner
 {
@@ -60,4 +62,4 @@ public:
 };
 }  // namespace lane_change_planner
 
-#endif  // LANE_CHANGE_PLANNER_STATE_FOLLOWING_LANE_H
+#endif  // LANE_CHANGE_PLANNER__STATE__FOLLOWING_LANE_HPP_

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/forcing_lane_change.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/forcing_lane_change.hpp
@@ -12,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANE_CHANGE_PLANNER_STATE_FORCING_LANE_CHANGE_H
-#define LANE_CHANGE_PLANNER_STATE_FORCING_LANE_CHANGE_H
+#ifndef LANE_CHANGE_PLANNER__STATE__FORCING_LANE_CHANGE_HPP_
+#define LANE_CHANGE_PLANNER__STATE__FORCING_LANE_CHANGE_HPP_
+
+#include <memory>
 
 #include "lane_change_planner/state/state_base_class.hpp"
 
 #include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
+
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
-
 #include "lanelet2_core/primitives/Lanelet.h"
 
 namespace lane_change_planner
@@ -50,4 +52,4 @@ public:
 };
 }  // namespace lane_change_planner
 
-#endif  // LANE_CHANGE_PLANNER_STATE_FORCING_LANE_CHANGE_H
+#endif  // LANE_CHANGE_PLANNER__STATE__FORCING_LANE_CHANGE_HPP_

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/state_base_class.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/state_base_class.hpp
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANE_CHANGE_PLANNER_STATE_STATE_BASE_CLASS_H
-#define LANE_CHANGE_PLANNER_STATE_STATE_BASE_CLASS_H
+#ifndef LANE_CHANGE_PLANNER__STATE__STATE_BASE_CLASS_HPP_
+#define LANE_CHANGE_PLANNER__STATE__STATE_BASE_CLASS_HPP_
 
-#include "autoware_planning_msgs/msg/path_with_lane_id.hpp"
-#include "geometry_msgs/msg/point.hpp"
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "lane_change_planner/data_manager.hpp"
 #include "lane_change_planner/parameters.hpp"
 #include "lane_change_planner/route_handler.hpp"
-#include <iostream>
-#include <string>
+
+#include "autoware_planning_msgs/msg/path_with_lane_id.hpp"
+
+#include "geometry_msgs/msg/point.hpp"
 
 namespace lane_change_planner
 {
@@ -68,6 +73,7 @@ protected:
   DebugData debug_data_;
 
 public:
+  virtual ~StateBase() = default;
   virtual void entry() = 0;
   virtual void update() = 0;
   virtual State getNextState() const = 0;
@@ -79,4 +85,4 @@ public:
 };
 }  // namespace lane_change_planner
 
-#endif  // LANE_CHANGE_PLANNER_STATE_STATE_BASE_CLASS_H
+#endif  // LANE_CHANGE_PLANNER__STATE__STATE_BASE_CLASS_HPP_

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/stopping_lane_change.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state/stopping_lane_change.hpp
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANE_CHANGE_PLANNER_STATE_STOPPING_LANE_CHANGE_H
-#define LANE_CHANGE_PLANNER_STATE_STOPPING_LANE_CHANGE_H
+#ifndef LANE_CHANGE_PLANNER__STATE__STOPPING_LANE_CHANGE_HPP_
+#define LANE_CHANGE_PLANNER__STATE__STOPPING_LANE_CHANGE_HPP_
+
+#include <memory>
 
 #include "lane_change_planner/state/state_base_class.hpp"
 
@@ -50,4 +52,4 @@ public:
 };
 }  // namespace lane_change_planner
 
-#endif  // LANE_CHANGE_PLANNER_STATE_ABORTING_LANE_CHANGE_H
+#endif  // LANE_CHANGE_PLANNER__STATE__STOPPING_LANE_CHANGE_HPP_

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state_machine.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/state_machine.hpp
@@ -12,14 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANE_CHANGE_PLANNER_STATE_MACHINE_H
-#define LANE_CHANGE_PLANNER_STATE_MACHINE_H
+#ifndef LANE_CHANGE_PLANNER__STATE_MACHINE_HPP_
+#define LANE_CHANGE_PLANNER__STATE_MACHINE_HPP_
+
+#include <memory>
 
 #include "lane_change_planner/state/state_base_class.hpp"
-#include "lanelet2_core/primitives/Lanelet.h"
+
 #include "autoware_planning_msgs/msg/path_with_lane_id.hpp"
 #include "autoware_planning_msgs/msg/route.hpp"
-#include <memory>
+
+#include "lanelet2_core/primitives/Lanelet.h"
 #include "rclcpp/rclcpp.hpp"
 
 namespace lane_change_planner
@@ -52,4 +55,4 @@ private:
 };
 }  // namespace lane_change_planner
 
-#endif  // LANE_CHANGE_PLANNER_STATE_MACHINE_H
+#endif  // LANE_CHANGE_PLANNER__STATE_MACHINE_HPP_

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/utilities.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/utilities.hpp
@@ -12,18 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANE_CHANGE_PLANNER_UTILITIES_H
-#define LANE_CHANGE_PLANNER_UTILITIES_H
+#ifndef LANE_CHANGE_PLANNER__UTILITIES_HPP_
+#define LANE_CHANGE_PLANNER__UTILITIES_HPP_
+
+#include <limits>
+#include <vector>
+
+#include "lane_change_planner/route_handler.hpp"
+
+#include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
+#include "autoware_planning_msgs/msg/path.hpp"
+#include "autoware_planning_msgs/msg/path_with_lane_id.hpp"
 
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/pose_array.hpp"
 #include "rclcpp/rclcpp.hpp"
-
-#include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
-#include "autoware_planning_msgs/msg/path.hpp"
-#include "autoware_planning_msgs/msg/path_with_lane_id.hpp"
 
 #include "boost/geometry/geometries/box.hpp"
 #include "boost/geometry/geometries/point_xy.hpp"
@@ -34,11 +39,6 @@
 #include "lanelet2_routing/Route.h"
 #include "lanelet2_routing/RoutingGraph.h"
 #include "lanelet2_routing/RoutingGraphContainer.h"
-
-#include "lane_change_planner/route_handler.hpp"
-
-#include <limits>
-#include <vector>
 
 namespace lane_change_planner
 {
@@ -166,7 +166,7 @@ class SplineInterpolate
   rclcpp::Logger logger_;
 
 public:
-  SplineInterpolate(const rclcpp::Logger & logger);
+  explicit SplineInterpolate(const rclcpp::Logger & logger);
   bool interpolate(
     const std::vector<double> & base_index, const std::vector<double> & base_value,
     const std::vector<double> & return_index, std::vector<double> & return_value);
@@ -188,4 +188,4 @@ private:
 }  // namespace util
 }  // namespace lane_change_planner
 
-#endif  // LANE_CHANGE_PLANNER_UTILITIES_H
+#endif  // LANE_CHANGE_PLANNER__UTILITIES_HPP_

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/package.xml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/package.xml
@@ -21,6 +21,9 @@
   <depend>tf2_ros</depend>
   <depend>libopencv-dev</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/data_manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/data_manager.cpp
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 #include "lane_change_planner/data_manager.hpp"
+
+#include <memory>
+#include <string>
+
 #include "lanelet2_extension/utility/message_conversion.hpp"
 
 namespace lane_change_planner

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_change_planner_node.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_change_planner_node.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+
 #include "lane_change_planner/lane_changer.hpp"
 #include "rclcpp/rclcpp.hpp"
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_changer.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/lane_changer.cpp
@@ -13,6 +13,13 @@
 // limitations under the License.
 
 #include "lane_change_planner/lane_changer.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "lane_change_planner/utilities.hpp"
 
 std_msgs::msg::ColorRGBA toRainbow(double ratio);
@@ -110,7 +117,7 @@ void LaneChanger::init()
   // route_handler
   vector_map_subscriber_ =
     create_subscription<autoware_lanelet2_msgs::msg::MapBin>(
-    "input/vector_map", rclcpp::QoS{1}.transient_local(), std::bind(
+    "input/vector_map", rclcpp::QoS{1}, std::bind(
       &RouteHandler::mapCallback, &(*route_handler_ptr_),
       std::placeholders::_1));
   route_subscriber_ =
@@ -369,7 +376,7 @@ void LaneChanger::publishDebugMarkers()
     }
   }
 
-  //create stop reason array from debug_data and state
+  // create stop reason array from debug_data and state
   stop_reason_array = makeStopReasonArray(debug_data, state_machine_ptr_->getState());
 
   path_marker_publisher_->publish(debug_markers);
@@ -379,16 +386,16 @@ void LaneChanger::publishDebugMarkers()
 autoware_planning_msgs::msg::StopReasonArray LaneChanger::makeStopReasonArray(
   const DebugData & debug_data, const State & state)
 {
-  //create header
+  // create header
   std_msgs::msg::Header header;
   header.frame_id = "map";
   header.stamp = this->now();
 
-  //create stop reason array
+  // create stop reason array
   autoware_planning_msgs::msg::StopReasonArray stop_reason_array;
   stop_reason_array.header = header;
 
-  //create stop reason stamped
+  // create stop reason stamped
   autoware_planning_msgs::msg::StopReason stop_reason_msg;
   autoware_planning_msgs::msg::StopFactor stop_factor;
 
@@ -397,7 +404,7 @@ autoware_planning_msgs::msg::StopReasonArray LaneChanger::makeStopReasonArray(
   } else if (state == lane_change_planner::State::STOPPING_LANE_CHANGE) {
     stop_reason_msg.reason = autoware_planning_msgs::msg::StopReason::STOPPING_LANE_CHANGE;
   } else {
-    //not stop. return empty reason_point
+    // not stop. return empty reason_point
     stop_reason_array.stop_reasons = makeEmptyStopReasons();
     return stop_reason_array;
   }
@@ -432,7 +439,7 @@ std_msgs::msg::ColorRGBA toRainbow(double ratio)
 {
   // we want to normalize ratio so that it fits in to 6 regions
   // where each region is 256 units long
-  int normalized = int(ratio * 256 * 6);
+  int normalized = static_cast<int>(ratio * 256 * 6);
 
   // find the distance to the start of the closest region
   int x = normalized % 256;

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/route_handler.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/route_handler.cpp
@@ -13,21 +13,25 @@
 // limitations under the License.
 
 #include "lane_change_planner/route_handler.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <vector>
+
 #include "lane_change_planner/utilities.hpp"
 
-#include "lanelet2_core/LaneletMap.h"
-#include "lanelet2_core/geometry/Lanelet.h"
-#include "lanelet2_core/primitives/LaneletSequence.h"
+#include "autoware_planning_msgs/msg/path_with_lane_id.hpp"
 #include "lanelet2_extension/utility/message_conversion.hpp"
 #include "lanelet2_extension/utility/query.hpp"
 #include "lanelet2_extension/utility/utilities.hpp"
-#include "autoware_planning_msgs/msg/path_with_lane_id.hpp"
 
+#include "lanelet2_core/geometry/Lanelet.h"
+#include "lanelet2_core/LaneletMap.h"
+#include "lanelet2_core/primitives/LaneletSequence.h"
 #include "rclcpp/rclcpp.hpp"
-
 #include "tf2/utils.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
-#include <unordered_set>
 
 using autoware_planning_msgs::msg::PathPointWithLaneId;
 using autoware_planning_msgs::msg::PathWithLaneId;
@@ -75,7 +79,7 @@ PathWithLaneId combineReferencePath(
     path2.points.front().point.pose.position.y - path1.points.back().point.pose.position.y;
   const double ds = std::hypot(dx, dy);
   if (interval < ds) {
-    //calculate samples
+    // calculate samples
     std::vector<double> base_x;
     std::vector<double> base_y;
     std::vector<double> base_z;
@@ -109,7 +113,7 @@ PathWithLaneId combineReferencePath(
       base_s.push_back(base_s.at(i - 1) + std::hypot(base_dx, base_dy));
     }
 
-    //calculate query
+    // calculate query
     std::vector<double> inner_s;
     for (double d = (base_s.at(n_sample_path1 - 1) + interval); d < base_s.at(n_sample_path1);
       d += interval)
@@ -127,7 +131,7 @@ PathWithLaneId combineReferencePath(
       spline.interpolate(base_s, base_y, inner_s, inner_y) &&
       spline.interpolate(base_s, base_z, inner_s, inner_z))
     {
-      //set position and other data
+      // set position and other data
       for (size_t i = 0; i < inner_s.size(); ++i) {
         PathPointWithLaneId inner_point;
         inner_point.lane_ids.insert(
@@ -144,7 +148,7 @@ PathWithLaneId combineReferencePath(
         inner_points.push_back(inner_point);
       }
 
-      //set yaw
+      // set yaw
       for (size_t i = 0; i < inner_points.size(); ++i) {
         geometry_msgs::msg::Point prev, next;
         if (i == 0) {
@@ -863,7 +867,7 @@ double RouteHandler::getLaneChangeableDistance(
       lane_length = std::min(goal_arc_coordinates.length, lane_length);
     }
 
-    //subtract distance up to current position for first lane
+    // subtract distance up to current position for first lane
     if (lane == current_lane) {
       const auto current_position =
         lanelet::utils::conversion::toLaneletPoint(current_pose.position);

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/aborting_lane_change.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/aborting_lane_change.cpp
@@ -14,6 +14,9 @@
 
 #include "lane_change_planner/state/aborting_lane_change.hpp"
 
+#include <limits>
+#include <memory>
+
 namespace lane_change_planner
 {
 AbortingLaneChangeState::AbortingLaneChangeState(

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/blocked_by_obstacle.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/blocked_by_obstacle.cpp
@@ -12,9 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lane_change_planner/state/blocked_by_obstacle.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <vector>
+
 #include "lane_change_planner/data_manager.hpp"
 #include "lane_change_planner/route_handler.hpp"
-#include "lane_change_planner/state/blocked_by_obstacle.hpp"
 #include "lane_change_planner/state/common_functions.hpp"
 #include "lane_change_planner/utilities.hpp"
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/common_functions.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/common_functions.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "lane_change_planner/state/common_functions.hpp"
+
+#include <algorithm>
+#include <vector>
+
 #include "lane_change_planner/utilities.hpp"
 #include "lanelet2_extension/utility/utilities.hpp"
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/executing_lane_change.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/executing_lane_change.cpp
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lane_change_planner/state/executing_lane_change.hpp"
+
+#include <algorithm>
+#include <memory>
+
 #include "lane_change_planner/data_manager.hpp"
 #include "lane_change_planner/route_handler.hpp"
 #include "lane_change_planner/state/common_functions.hpp"
-#include "lane_change_planner/state/executing_lane_change.hpp"
 #include "lane_change_planner/utilities.hpp"
 
 #include "lanelet2_extension/utility/utilities.hpp"

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/following_lane.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/following_lane.cpp
@@ -12,10 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lane_change_planner/state/following_lane.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+
 #include "lane_change_planner/data_manager.hpp"
 #include "lane_change_planner/route_handler.hpp"
 #include "lane_change_planner/state/common_functions.hpp"
-#include "lane_change_planner/state/following_lane.hpp"
 #include "lane_change_planner/utilities.hpp"
 #include "lanelet2_extension/utility/message_conversion.hpp"
 #include "lanelet2_extension/utility/utilities.hpp"

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/forcing_lane_change.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/forcing_lane_change.cpp
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lane_change_planner/state/forcing_lane_change.hpp"
+
+#include <memory>
+
 #include "lane_change_planner/data_manager.hpp"
 #include "lane_change_planner/route_handler.hpp"
-#include "lane_change_planner/state/forcing_lane_change.hpp"
 #include "lane_change_planner/utilities.hpp"
 
 namespace lane_change_planner

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/state_base_class.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/state_base_class.cpp
@@ -14,6 +14,10 @@
 
 #include "lane_change_planner/state/state_base_class.hpp"
 
+#include <ostream>
+#include <memory>
+#include <string>
+
 namespace lane_change_planner
 {
 std::ostream & operator<<(std::ostream & ostream, const State & state)

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/stopping_lane_change.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/stopping_lane_change.cpp
@@ -11,10 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include "lane_change_planner/state/stopping_lane_change.hpp"
+
+#include <memory>
+#include <vector>
+
 #include "lane_change_planner/data_manager.hpp"
 #include "lane_change_planner/route_handler.hpp"
 #include "lane_change_planner/state/common_functions.hpp"
-#include "lane_change_planner/state/stopping_lane_change.hpp"
 #include "lane_change_planner/utilities.hpp"
 
 #include "lanelet2_extension/utility/utilities.hpp"

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state_machine.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state_machine.cpp
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lane_change_planner/state_machine.hpp"
+
+#include <memory>
+
 #include "lane_change_planner/state/aborting_lane_change.hpp"
 #include "lane_change_planner/state/blocked_by_obstacle.hpp"
 #include "lane_change_planner/state/executing_lane_change.hpp"
 #include "lane_change_planner/state/following_lane.hpp"
 #include "lane_change_planner/state/forcing_lane_change.hpp"
 #include "lane_change_planner/state/stopping_lane_change.hpp"
-#include "lane_change_planner/state_machine.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "visualization_msgs/msg/marker.hpp"

--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/utilities.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/utilities.cpp
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 #include "lane_change_planner/utilities.hpp"
+
+#include <limits>
+#include <vector>
+
 #include "lanelet2_extension/utility/message_conversion.hpp"
 #include "lanelet2_extension/utility/query.hpp"
 #include "lanelet2_extension/utility/utilities.hpp"
@@ -892,10 +896,8 @@ nav_msgs::msg::OccupancyGrid generateDrivableArea(
       cv::bitwise_and(cv_image, cv_image_single_lane, cv_image);
     }
 
-    const auto & cv_image_reshaped = cv_image.reshape(1, 1);
     imageToOccupancyGrid(cv_image, &occupancy_grid);
     occupancy_grid.data[0] = 0;
-    // cv_image_reshaped.copyTo(occupancy_grid.data);
   }
   return occupancy_grid;
 }
@@ -960,7 +962,7 @@ double getDistanceToCrosswalk(
           boost::geometry::append(centerline, Point(point.x(), point.y()));
         }
 
-        //create crosswalk polygon and calculate distance
+        // create crosswalk polygon and calculate distance
         double min_distance_to_crosswalk = std::numeric_limits<double>::max();
         for (const auto & crosswalk : conflicting_crosswalks) {
           lanelet::CompoundPolygon2d lanelet_crosswalk_polygon = crosswalk.polygon2d();


### PR DESCRIPTION
The linters found a few issues (missing explicit constructor, non-virtual destructor in virtual base class).