### PR TITLE
Enable lints in map_based_prediction

### DIFF
--- a/perception/object_recognition/prediction/map_based_prediction/CMakeLists.txt
+++ b/perception/object_recognition/prediction/map_based_prediction/CMakeLists.txt
@@ -3,6 +3,8 @@ project(map_based_prediction)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -20,7 +22,12 @@ ament_auto_add_executable(map_based_prediction
   src/map_based_prediction.cpp
 )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_auto_package(
   INSTALL_TO_SHARE
   launch
-) 
+)

--- a/perception/object_recognition/prediction/map_based_prediction/include/cubic_spline.hpp
+++ b/perception/object_recognition/prediction/map_based_prediction/include/cubic_spline.hpp
@@ -1,36 +1,34 @@
-/*
- * MIT License
- *
- * Copyright (c) 2018 Forrest
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
-*/
-#ifndef CUBIC_SPLINE_H
-#define CUBIC_SPLINE_H
+// Copyright 2018 Forrest
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
-#include "eigen3/Eigen/Eigen"
+#ifndef CUBIC_SPLINE_HPP_
+#define CUBIC_SPLINE_HPP_
+
 #include <algorithm>
 #include <array>
 #include <iostream>
 #include <stdexcept>
 #include <string>
 #include <vector>
+
+#include "eigen3/Eigen/Eigen"
 
 static std::vector<double> vec_diff(const std::vector<double> & input)
 {
@@ -253,4 +251,4 @@ private:
   }
 };
 
-#endif  // CUBIC_SPLINE_H
+#endif  // CUBIC_SPLINE_HPP_

--- a/perception/object_recognition/prediction/map_based_prediction/include/map_based_prediction.hpp
+++ b/perception/object_recognition/prediction/map_based_prediction/include/map_based_prediction.hpp
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MAP_BASED_PREDICTION_H
-#define MAP_BASED_PREDICTION_H
+#ifndef MAP_BASED_PREDICTION_HPP_
+#define MAP_BASED_PREDICTION_HPP_
+
+#include <vector>
 
 #include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
 #include "autoware_perception_msgs/msg/dynamic_object.hpp"
 #include "autoware_perception_msgs/msg/predicted_path.hpp"
+
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 
@@ -49,15 +52,14 @@ private:
     Spline2D & spline2d,
     autoware_perception_msgs::msg::PredictedPath & path);
 
-  bool getLinearPredictedPath(
+  void getLinearPredictedPath(
     const geometry_msgs::msg::Pose & object_pose, const geometry_msgs::msg::Twist & object_twist,
     const std_msgs::msg::Header & origin_header,
     autoware_perception_msgs::msg::PredictedPath & predicted_path);
 
-  // double calculateLikelyhood(const double desired_yaw, const double current_d, const double current_yaw);
-  double calculateLikelyhood(const double current_d);
+  double calculateLikelihood(const double current_d);
 
-  bool normalizeLikelyhood(std::vector<autoware_perception_msgs::msg::PredictedPath> & paths);
+  void normalizeLikelihood(std::vector<autoware_perception_msgs::msg::PredictedPath> & paths);
 
 public:
   MapBasedPrediction(
@@ -73,4 +75,4 @@ public:
     std::vector<autoware_perception_msgs::msg::DynamicObject> & out_objects);
 };
 
-#endif  // MAP_BASED_PREDICTION_H
+#endif  // MAP_BASED_PREDICTION_HPP_

--- a/perception/object_recognition/prediction/map_based_prediction/include/map_based_prediction_ros.hpp
+++ b/perception/object_recognition/prediction/map_based_prediction/include/map_based_prediction_ros.hpp
@@ -12,17 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MAP_BASED_PREDICTION_ROS_H
-#define MAP_BASED_PREDICTION_ROS_H
+#ifndef MAP_BASED_PREDICTION_ROS_HPP_
+#define MAP_BASED_PREDICTION_ROS_HPP_
 
+#include <memory>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
-#include "rclcpp/rclcpp.hpp"
-
-#include "autoware_lanelet2_msgs/msg/map_bin.hpp"
 #include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
 #include "autoware_perception_msgs/msg/dynamic_object.hpp"
+
+#include "autoware_lanelet2_msgs/msg/map_bin.hpp"
 #include "geometry_msgs/msg/pose.hpp"
+#include "rclcpp/rclcpp.hpp"
 #include "unique_identifier_msgs/msg/uuid.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 
@@ -89,4 +92,4 @@ public:
   MapBasedPredictionROS();
 };
 
-#endif  // MAP_BASED_PREDICTION_H
+#endif  // MAP_BASED_PREDICTION_ROS_HPP_

--- a/perception/object_recognition/prediction/map_based_prediction/package.xml
+++ b/perception/object_recognition/prediction/map_based_prediction/package.xml
@@ -18,6 +18,9 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>unique_identifier_msgs</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/perception/object_recognition/prediction/map_based_prediction/src/map_based_prediction_main.cpp
+++ b/perception/object_recognition/prediction/map_based_prediction/src/map_based_prediction_main.cpp
@@ -1,23 +1,22 @@
-/*
- * Copyright 2018 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- *
- */
+// Copyright 2018 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "map_based_prediction_ros.hpp"
 
 #include "rclcpp/rclcpp.hpp"
-#include "map_based_prediction_ros.hpp"
 
 int main(int argc, char ** argv)
 {

--- a/perception/object_recognition/prediction/map_based_prediction/src/map_based_prediction_ros.cpp
+++ b/perception/object_recognition/prediction/map_based_prediction/src/map_based_prediction_ros.cpp
@@ -12,18 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// headers in local files
+#include "map_based_prediction.hpp"
+#include "map_based_prediction_ros.hpp"
+
 // headers in STL
 #include <chrono>
 #include <cmath>
+#include <memory>
+#include <string>
 #include <unordered_map>
-
-#include "unique_identifier_msgs/msg/uuid.hpp"
+#include <utility>
+#include <vector>
 
 // headers in ROS
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 #include "tf2_ros/transform_listener.h"
+#include "unique_identifier_msgs/msg/uuid.hpp"
 
 // lanelet
 #include "lanelet2_core/LaneletMap.h"
@@ -35,9 +42,6 @@
 #include "lanelet2_routing/RoutingGraph.h"
 #include "lanelet2_traffic_rules/TrafficRulesFactory.h"
 
-// headers in local files
-#include "map_based_prediction.hpp"
-#include "map_based_prediction_ros.hpp"
 
 std::string toHexString(const unique_identifier_msgs::msg::UUID & id)
 {


### PR DESCRIPTION
Deleted a few unused variables & changed functions without `return` from `bool` to `void`.
I ignored the "loop variable of floating point type" from clang-tidy.