### PR TITLE
Enable cppcheck lints in behavior_velocity_planner

### DIFF
--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/CMakeLists.txt
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/CMakeLists.txt
@@ -4,6 +4,8 @@ project(behavior_velocity_planner)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
@@ -211,6 +213,12 @@ target_link_libraries(behavior_velocity_planner_node
 )
 
 ament_export_dependencies(${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_auto_package(INSTALL_TO_SHARE
   launch
   config

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/scene_module_interface.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/scene_module_interface.hpp
@@ -15,6 +15,7 @@
 
 #include <memory>
 #include <set>
+#include <string>
 
 #include "autoware_planning_msgs/msg/path.hpp"
 #include "autoware_planning_msgs/msg/path_with_lane_id.hpp"

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.hpp
@@ -15,6 +15,8 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
+#include <vector>
 
 #include "boost/assert.hpp"
 #include "boost/geometry.hpp"

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/boost_geometry_helper.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/boost_geometry_helper.hpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 #pragma once
 
+#include <algorithm>
 #include <vector>
 
 #include "boost/assign/list_of.hpp"
@@ -43,11 +44,11 @@ using LineString2d = boost::geometry::model::linestring<Point2d>;
 using Polygon2d =
   boost::geometry::model::polygon<Point2d, false, false>;  // counter-clockwise, open
 
+// cppcheck-suppress unknownMacro
 BOOST_GEOMETRY_REGISTER_POINT_3D(geometry_msgs::msg::Point, double, cs::cartesian, x, y, z)
 BOOST_GEOMETRY_REGISTER_POINT_3D(
   geometry_msgs::msg::PoseWithCovarianceStamped, double, cs::cartesian, pose.pose.position.x,
   pose.pose.position.y, pose.pose.position.z)
-
 BOOST_GEOMETRY_REGISTER_POINT_3D(
   autoware_planning_msgs::msg::PathPoint, double, cs::cartesian, pose.position.x, pose.position.y,
   pose.position.z)
@@ -105,7 +106,7 @@ inline Polygon2d lines2polygon(const LineString2d & left_line, const LineString2
 inline Polygon2d obj2polygon(
   const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Vector3 & shape)
 {
-  //rename
+  // rename
   const double x = pose.position.x;
   const double y = pose.position.y;
   const double h = shape.x;
@@ -135,27 +136,27 @@ inline double calcOverlapAreaRate(const Polygon2d & target, const Polygon2d & ba
   /* OverlapAreaRate: common area(target && base) / target area */
 
   if (boost::geometry::within(target, base)) {
-    //target is within base, common area = target area
+    // target is within base, common area = target area
     return 1.0;
   }
 
   if (!boost::geometry::intersects(target, base)) {
-    //target and base has not intersect area
+    // target and base has not intersect area
     return 0.0;
   }
 
-  //calculate intersect polygon
+  // calculate intersect polygon
   std::vector<Polygon2d> intersects;
   boost::geometry::intersection(target, base, intersects);
 
-  //calculate area of polygon
+  // calculate area of polygon
   double intersect_area = 0.0;
   for (const auto intersect : intersects) {
     intersect_area += boost::geometry::area(intersect);
   }
   const double target_area = boost::geometry::area(target);
-  //specification of boost1.65
-  //common area is not intersect area
+  // specification of boost1.65
+  // common area is not intersect area
   const double common_area = target_area - intersect_area;
 
   return common_area / target_area;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/interpolate.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/interpolate.hpp
@@ -14,6 +14,7 @@
 
 #ifndef BEHAVIOR_VELOCITY_PLANNER_UTILIZATION_INTERPOLATE_H_
 #define BEHAVIOR_VELOCITY_PLANNER_UTILIZATION_INTERPOLATE_H_
+
 #include <cmath>
 #include <vector>
 
@@ -37,7 +38,7 @@ public:
 bool isIncrease(const std::vector<double> & x);
 bool isValidInput(
   const std::vector<double> & base_index, const std::vector<double> & base_value,
-  const std::vector<double> & return_index, std::vector<double> & return_value);
+  const std::vector<double> & return_index);
 std::vector<double> calcEuclidDist(const std::vector<double> & x, const std::vector<double> & y);
 
 }  // namespace interpolation

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/interpolation/cubic_spline.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/interpolation/cubic_spline.hpp
@@ -1,26 +1,23 @@
-/*
- * MIT License
- *
- * Copyright (c) 2018 Forrest
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
-*/
+// Copyright 2018 Forrest
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 #ifndef CUBIC_SPLINE_H
 #define CUBIC_SPLINE_H
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/util.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/util.hpp
@@ -1,23 +1,21 @@
-/*
- * Copyright 2015-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
+// Copyright 2015-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef COMMON_MATH_PLANNING_UTILS_H
 #define COMMON_MATH_PLANNING_UTILS_H
 
+#include <string>
 #include <vector>
 
 #include "pcl/point_types.h"

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/package.xml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/package.xml
@@ -30,7 +30,7 @@
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_cppcheck</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/package.xml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/package.xml
@@ -29,6 +29,9 @@
   <depend>vehicle_info_util</depend>
   <depend>visualization_msgs</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_cppcheck</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/main.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/main.cpp
@@ -14,6 +14,8 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+#include <memory>
+
 #include "behavior_velocity_planner/node.hpp"
 
 int main(int argc, char ** argv)

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/node.cpp
@@ -14,6 +14,8 @@
 
 #include <functional>
 
+#include <memory>
+
 #include "behavior_velocity_planner/node.hpp"
 
 #include "pcl/common/transforms.h"

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/planner_manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/planner_manager.cpp
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #include "behavior_velocity_planner/planner_manager.hpp"
+
+#include <string>
+#include <memory>
 #include "boost/format.hpp"
 
 namespace

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/debug.cpp
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include <string>
+
 #include "scene_module/blind_spot/scene.hpp"
 
 #include "utilization/marker_helper.hpp"

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/manager.cpp
@@ -11,7 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "scene_module/blind_spot/manager.hpp"
+
+#include <vector>
+#include <set>
+#include <string>
+#include <memory>
 
 #include "lanelet2_core/primitives/BasicRegulatoryElements.h"
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -11,19 +11,25 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "scene_module/blind_spot/scene.hpp"
-#include "boost/geometry/algorithms/distance.hpp"
+
+#include <memory>
+#include <string>
+#include <algorithm>
+#include <vector>
+
+#include "scene_module/intersection/util.hpp"
+#include "utilization/boost_geometry_helper.hpp"
+#include "utilization/interpolate.hpp"
+#include "utilization/util.hpp"
 
 #include "lanelet2_core/geometry/Polygon.h"
 #include "lanelet2_core/primitives/BasicRegulatoryElements.h"
 #include "lanelet2_extension/regulatory_elements/road_marking.hpp"
 #include "lanelet2_extension/utility/query.hpp"
 #include "lanelet2_extension/utility/utilities.hpp"
-
-#include "scene_module/intersection/util.hpp"
-#include "utilization/boost_geometry_helper.hpp"
-#include "utilization/interpolate.hpp"
-#include "utilization/util.hpp"
+#include "boost/geometry/algorithms/distance.hpp"
 
 namespace bg = boost::geometry;
 
@@ -331,7 +337,7 @@ lanelet::ConstLanelet BlindSpotModule::generateHalfLanelet(
   auto half_lanelet = lanelet::Lanelet(lanelet::InvalId, left_bound, right_bound);
   const auto centerline = lanelet::utils::generateFineCenterline(half_lanelet, 5.0);
   half_lanelet.setCenterline(centerline);
-  return half_lanelet;
+  return std::move(half_lanelet);
 }
 
 BlindSpotPolygons BlindSpotModule::generateBlindSpotPolygons(

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/debug.cpp
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include <vector>
+
 #include "scene_module/crosswalk/scene_crosswalk.hpp"
 #include "scene_module/crosswalk/scene_walkway.hpp"
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
@@ -11,7 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "scene_module/crosswalk/manager.hpp"
+
+#include <vector>
+#include <memory>
+#include <set>
+#include <string>
 
 namespace
 {

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -11,7 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "scene_module/crosswalk/scene_crosswalk.hpp"
+
+#include <vector>
 #include "utilization/util.hpp"
 
 #include <cmath>

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
@@ -11,10 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "scene_module/crosswalk/scene_walkway.hpp"
-#include "utilization/util.hpp"
 
 #include <cmath>
+
+#include "utilization/util.hpp"
 
 namespace bg = boost::geometry;
 using Point = bg::model::d2::point_xy<double>;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/util.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/util.cpp
@@ -11,12 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "scene_module/crosswalk/util.hpp"
-#include "utilization/util.hpp"
 
+#include "scene_module/crosswalk/util.hpp"
+
+#include <algorithm>
 #include <cmath>
 #include <string>
 #include <vector>
+
+#include "utilization/util.hpp"
 
 #include "boost/assert.hpp"
 #include "boost/assign/list_of.hpp"
@@ -116,8 +119,8 @@ bool insertTargetVelocityPoint(
     target_point_with_lane_id.point.pose.position.x = target_point.x();
     target_point_with_lane_id.point.pose.position.y = target_point.y();
     if (insert_target_point_idx > 0) {
-      //calculate z-position of the target point (Internal division point of point1/point2)
-      //if insert_target_point_idx is zero, use z-position of target_velocity_point_idx
+      // calculate z-position of the target point (Internal division point of point1/point2)
+      // if insert_target_point_idx is zero, use z-position of target_velocity_point_idx
       const double internal_div_ratio =
         (point1 - target_point).norm() /
         ((point1 - target_point).norm() + (point2 - target_point).norm());

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "scene_module/detection_area/scene.hpp"
 
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
@@ -11,7 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "scene_module/detection_area/manager.hpp"
+
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
 
 #include "tf2/utils.h"
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/scene.cpp
@@ -11,7 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "scene_module/detection_area/scene.hpp"
+
+#include <algorithm>
+#include <utility>
+#include <vector>
 
 #include "tf2_eigen/tf2_eigen.h"
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
@@ -11,6 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include <string>
+#include <vector>
+
 #include "scene_module/intersection/scene_intersection.hpp"
 #include "scene_module/intersection/scene_merge_from_private_road.hpp"
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -11,8 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "scene_module/intersection/manager.hpp"
 
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
 #include "lanelet2_core/primitives/BasicRegulatoryElements.h"
 
 #include "utilization/boost_geometry_helper.hpp"

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -11,7 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "scene_module/intersection/scene_intersection.hpp"
+
+#include <memory>
+#include <vector>
 
 #include "lanelet2_core/geometry/Polygon.h"
 #include "lanelet2_core/primitives/BasicRegulatoryElements.h"
@@ -250,7 +254,7 @@ Polygon2d IntersectionModule::generateEgoIntersectionLanePolygon(
 
   size_t ego_area_start_idx = assigned_lane_start_idx;
   {
-    //decide start idx with considering ignore_dist
+// decide start idx with considering ignore_dist
     double dist_sum = 0.0;
     for (size_t i = assigned_lane_start_idx + 1; i < assigned_lane_end_idx; ++i) {
       dist_sum += planning_utils::calcDist2d(path.points.at(i), path.points.at(i - 1));
@@ -266,7 +270,7 @@ Polygon2d IntersectionModule::generateEgoIntersectionLanePolygon(
 
   size_t ego_area_end_idx = assigned_lane_end_idx;
   {
-    //decide end idx with cosidering extra_dist
+// decide end idx with cosidering extra_dist
     double dist_sum = 0.0;
     for (size_t i = assigned_lane_end_idx + 1; i < path.points.size(); ++i) {
       dist_sum += planning_utils::calcDist2d(path.points.at(i), path.points.at(i - 1));

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
@@ -11,7 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "scene_module/intersection/scene_merge_from_private_road.hpp"
+
+#include <memory>
+#include <vector>
 
 #include "lanelet2_core/geometry/Polygon.h"
 #include "lanelet2_core/primitives/BasicRegulatoryElements.h"

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -11,7 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "rclcpp/rclcpp.hpp"
+
+#include "scene_module/intersection/util.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "lanelet2_core/geometry/Polygon.h"
 #include "lanelet2_core/primitives/BasicRegulatoryElements.h"
@@ -19,7 +25,7 @@
 #include "lanelet2_extension/utility/query.hpp"
 #include "lanelet2_extension/utility/utilities.hpp"
 
-#include "scene_module/intersection/util.hpp"
+#include "rclcpp/rclcpp.hpp"
 #include "utilization/interpolate.hpp"
 #include "utilization/util.hpp"
 
@@ -405,20 +411,20 @@ bool getObjectivePolygons(
   }
 
   std::stringstream ss_c, ss_y, ss_e, ss_o, ss_os;
-  for (const auto l : conflicting_lanelets) {
+  for (const auto & l : conflicting_lanelets) {
     ss_c << l.id() << ", ";
   }
-  for (const auto l : yield_lanelets) {
+  for (const auto & l : yield_lanelets) {
     ss_y << l.id() << ", ";
   }
-  for (const auto l : ego_lanelets) {
+  for (const auto & l : ego_lanelets) {
     ss_e << l.id() << ", ";
   }
-  for (const auto l : objective_lanelets) {
+  for (const auto & l : objective_lanelets) {
     ss_o << l.id() << ", ";
   }
-  for (const auto l : objective_lanelets_sequences) {
-    for (const auto ll : l) {
+  for (const auto & l : objective_lanelets_sequences) {
+    for (const auto & ll : l) {
       ss_os << ll.id() << ", ";
     }
   }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
@@ -13,6 +13,11 @@
 // limitations under the License.
 #include "scene_module/stop_line/manager.hpp"
 
+#include <vector>
+#include <set>
+#include <string>
+#include <memory>
+
 namespace
 {
 std::vector<lanelet::TrafficSignConstPtr> getTrafficSignRegElemsOnPath(

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/scene.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "scene_module/stop_line/scene.hpp"
+
+#include <algorithm>
+#include <vector>
+
 #include "utilization/util.hpp"
 
 namespace bg = boost::geometry;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
@@ -13,6 +13,12 @@
 // limitations under the License.
 #include "scene_module/traffic_light/manager.hpp"
 
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
 #include "tf2/utils.h"
 
 namespace

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
@@ -13,7 +13,11 @@
 // limitations under the License.
 #include "scene_module/traffic_light/scene.hpp"
 
+#include <algorithm>
 #include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "tf2/utils.h"
 #include "tf2_eigen/tf2_eigen.h"
@@ -501,7 +505,7 @@ geometry_msgs::msg::Point TrafficLightModule::getTrafficLightPosition(
   const lanelet::ConstLineStringOrPolygon3d traffic_light)
 {
   geometry_msgs::msg::Point tl_center;
-  for (const auto tl_point : *traffic_light.lineString()) {
+  for (const auto & tl_point : *traffic_light.lineString()) {
     tl_center.x += tl_point.x() / (*traffic_light.lineString()).size();
     tl_center.y += tl_point.y() / (*traffic_light.lineString()).size();
     tl_center.z += tl_point.z() / (*traffic_light.lineString()).size();

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/interpolate.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/interpolate.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "utilization/interpolate.hpp"
+
+#include <vector>
 #include "utilization/util.hpp"
 
 namespace interpolation
@@ -24,7 +26,7 @@ bool LinearInterpolate::interpolate(
   const std::vector<double> & base_index, const std::vector<double> & base_value,
   const std::vector<double> & return_index, std::vector<double> & return_value)
 {
-  if (!isValidInput(base_index, base_value, return_index, return_value)) {
+  if (!isValidInput(base_index, base_value, return_index)) {
     std::cerr << "[interpolate] invalid input. interpolation failed." << std::endl;
     return false;
   }
@@ -72,7 +74,7 @@ bool isIncrease(const std::vector<double> & x)
 
 bool isValidInput(
   const std::vector<double> & base_index, const std::vector<double> & base_value,
-  const std::vector<double> & return_index, std::vector<double> & return_value)
+  const std::vector<double> & return_index)
 {
   if (base_index.empty() || base_value.empty() || return_index.empty()) {
     std::cout << "bad index : some vector is empty. base_index: " << base_index.size() <<

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/path_utilization.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/path_utilization.cpp
@@ -14,6 +14,9 @@
 
 #include "utilization/path_utilization.hpp"
 
+#include <vector>
+#include <algorithm>
+
 #include <memory>
 
 #include "tf2/LinearMath/Quaternion.h"
@@ -111,7 +114,7 @@ autoware_planning_msgs::msg::Path filterLitterPathPoint(
   const double epsilon = 0.01;
   size_t latest_id = 0;
   for (size_t i = 0; i < path.points.size(); ++i) {
-    double dist;
+    double dist = 0.0;
     if (i != 0) {
       const double x =
         path.points.at(i).pose.position.x - path.points.at(latest_id).pose.position.x;
@@ -119,7 +122,7 @@ autoware_planning_msgs::msg::Path filterLitterPathPoint(
         path.points.at(i).pose.position.y - path.points.at(latest_id).pose.position.y;
       dist = std::sqrt(x * x + y * y);
     }
-    if (epsilon < dist || i == 0 /*init*/) {
+    if (i == 0 || epsilon < dist /*init*/) {
       latest_id = i;
       filtered_path.points.push_back(path.points.at(latest_id));
     } else {

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/util.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/util.cpp
@@ -1,22 +1,22 @@
-/*
- * Copyright 2015-2019 Autoware Foundation. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * Author: Robin Karlsson
- */
+// Copyright 2015-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "utilization/util.hpp"
+
+#include <limits>
+#include <string>
+#include <vector>
 
 namespace planning_utils
 {
@@ -177,7 +177,7 @@ std::vector<geometry_msgs::msg::Point> toRosPoints(
   const autoware_perception_msgs::msg::DynamicObjectArray & object)
 {
   std::vector<geometry_msgs::msg::Point> points;
-  for (const auto obj : object.objects) {
+  for (const auto & obj : object.objects) {
     points.emplace_back(obj.state.pose_covariance.pose.position);
   }
   return points;


### PR DESCRIPTION
I only fixed cppcheck lints and missing includes (for which I wrote a script), as well as clang-tidy lints. There was one about the `stop_point` variable in stop_line/scene.cpp being possibly uninitialized.