### PR TITLE
ROS2 Linting: raw_vehicle_cmd_converter

### DIFF
--- a/vehicle/raw_vehicle_cmd_converter/CMakeLists.txt
+++ b/vehicle/raw_vehicle_cmd_converter/CMakeLists.txt
@@ -5,6 +5,11 @@ project(raw_vehicle_cmd_converter)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
 endif()
 
 find_package(ament_cmake_auto REQUIRED)
@@ -21,8 +26,14 @@ ament_auto_add_executable(raw_vehicle_cmd_converter_node
   src/node.cpp
   src/main.cpp
 )
+
 add_dependencies(raw_vehicle_cmd_converter_node accel_map_converter)
 target_link_libraries(raw_vehicle_cmd_converter_node accel_map_converter)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/vehicle/raw_vehicle_cmd_converter/CMakeLists.txt
+++ b/vehicle/raw_vehicle_cmd_converter/CMakeLists.txt
@@ -20,7 +20,7 @@ ament_auto_add_library(accel_map_converter SHARED
   src/brake_map.cpp
   src/csv_loader.cpp
   src/interpolate.cpp
-) 
+)
 
 ament_auto_add_executable(raw_vehicle_cmd_converter_node
   src/node.cpp
@@ -39,4 +39,3 @@ ament_auto_package(INSTALL_TO_SHARE
   launch
   data
 )
-

--- a/vehicle/raw_vehicle_cmd_converter/include/raw_vehicle_cmd_converter/accel_map.hpp
+++ b/vehicle/raw_vehicle_cmd_converter/include/raw_vehicle_cmd_converter/accel_map.hpp
@@ -12,23 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAW_VEHICLE_CMD_CONVERTER_ACCEL_MAP_H
-#define RAW_VEHICLE_CMD_CONVERTER_ACCEL_MAP_H
-
-#include "raw_vehicle_cmd_converter/csv_loader.hpp"
-#include "raw_vehicle_cmd_converter/interpolate.hpp"
-
-#include "rclcpp/rclcpp.hpp"
+#ifndef RAW_VEHICLE_CMD_CONVERTER__ACCEL_MAP_HPP_
+#define RAW_VEHICLE_CMD_CONVERTER__ACCEL_MAP_HPP_
 
 #include <algorithm>
 #include <iostream>
 #include <string>
 #include <vector>
 
+#include "rclcpp/rclcpp.hpp"
+
+#include "raw_vehicle_cmd_converter/csv_loader.hpp"
+#include "raw_vehicle_cmd_converter/interpolate.hpp"
+
 class AccelMap
 {
 public:
-  AccelMap(const rclcpp::Logger & logger);
+  explicit AccelMap(const rclcpp::Logger & logger);
   ~AccelMap();
 
   bool readAccelMapFromCSV(std::string csv_path);
@@ -44,4 +44,4 @@ private:
   std::vector<std::vector<double>> accel_map_;
 };
 
-#endif
+#endif  // RAW_VEHICLE_CMD_CONVERTER__ACCEL_MAP_HPP_

--- a/vehicle/raw_vehicle_cmd_converter/include/raw_vehicle_cmd_converter/brake_map.hpp
+++ b/vehicle/raw_vehicle_cmd_converter/include/raw_vehicle_cmd_converter/brake_map.hpp
@@ -12,23 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAW_VEHICLE_CMD_CONVERTER_BRAKE_MAP_H
-#define RAW_VEHICLE_CMD_CONVERTER_BRAKE_MAP_H
-
-#include "raw_vehicle_cmd_converter/csv_loader.hpp"
-#include "raw_vehicle_cmd_converter/interpolate.hpp"
-
-#include "rclcpp/rclcpp.hpp"
+#ifndef RAW_VEHICLE_CMD_CONVERTER__BRAKE_MAP_HPP_
+#define RAW_VEHICLE_CMD_CONVERTER__BRAKE_MAP_HPP_
 
 #include <algorithm>
 #include <iostream>
 #include <string>
 #include <vector>
 
+#include "rclcpp/rclcpp.hpp"
+
+#include "raw_vehicle_cmd_converter/csv_loader.hpp"
+#include "raw_vehicle_cmd_converter/interpolate.hpp"
+
 class BrakeMap
 {
 public:
-  BrakeMap(const rclcpp::Logger & logger);
+  explicit BrakeMap(const rclcpp::Logger & logger);
   ~BrakeMap();
 
   bool readBrakeMapFromCSV(std::string csv_path);
@@ -45,4 +45,4 @@ private:
   std::vector<std::vector<double>> brake_map_;
 };
 
-#endif
+#endif  // RAW_VEHICLE_CMD_CONVERTER__BRAKE_MAP_HPP_

--- a/vehicle/raw_vehicle_cmd_converter/include/raw_vehicle_cmd_converter/csv_loader.hpp
+++ b/vehicle/raw_vehicle_cmd_converter/include/raw_vehicle_cmd_converter/csv_loader.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAW_VEHICLE_CMD_CONVERTER_CSV_LOADER_H
-#define RAW_VEHICLE_CMD_CONVERTER_CSV_LOADER_H
+#ifndef RAW_VEHICLE_CMD_CONVERTER__CSV_LOADER_HPP_
+#define RAW_VEHICLE_CMD_CONVERTER__CSV_LOADER_HPP_
 
 #include <fstream>
 #include <iostream>
@@ -24,7 +24,7 @@
 class CSVLoader
 {
 public:
-  CSVLoader(std::string csv_path);
+  explicit CSVLoader(std::string csv_path);
   ~CSVLoader();
 
   bool readCSV(std::vector<std::vector<std::string>> & result, const char delim = ',');
@@ -33,4 +33,4 @@ private:
   std::string csv_path_;
 };
 
-#endif
+#endif  // RAW_VEHICLE_CMD_CONVERTER__CSV_LOADER_HPP_

--- a/vehicle/raw_vehicle_cmd_converter/include/raw_vehicle_cmd_converter/interpolate.hpp
+++ b/vehicle/raw_vehicle_cmd_converter/include/raw_vehicle_cmd_converter/interpolate.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAW_VEHICLE_CMD_CONVERTER_INTERPOLATE_H
-#define RAW_VEHICLE_CMD_CONVERTER_INTERPOLATE_H
+#ifndef RAW_VEHICLE_CMD_CONVERTER__INTERPOLATE_HPP_
+#define RAW_VEHICLE_CMD_CONVERTER__INTERPOLATE_HPP_
 
 #include <cmath>
 #include <iostream>
@@ -29,4 +29,4 @@ public:
     const double & return_index, double & return_value);
 };
 
-#endif
+#endif  // RAW_VEHICLE_CMD_CONVERTER__INTERPOLATE_HPP_

--- a/vehicle/raw_vehicle_cmd_converter/include/raw_vehicle_cmd_converter/node.hpp
+++ b/vehicle/raw_vehicle_cmd_converter/include/raw_vehicle_cmd_converter/node.hpp
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef VEHICLE_RAW_VEHICLE_CMD_CONVERTER_INCLUDE_RAW_VEHICLE_CMD_CONVERTER_NODE_HPP_
-#define VEHICLE_RAW_VEHICLE_CMD_CONVERTER_INCLUDE_RAW_VEHICLE_CMD_CONVERTER_NODE_HPP_
+#ifndef RAW_VEHICLE_CMD_CONVERTER__NODE_HPP_
+#define RAW_VEHICLE_CMD_CONVERTER__NODE_HPP_
+
+#include <memory>
+#include <string>
 
 #include "raw_vehicle_cmd_converter/accel_map.hpp"
 #include "raw_vehicle_cmd_converter/brake_map.hpp"
@@ -25,8 +28,6 @@
 #include "autoware_vehicle_msgs/msg/shift.hpp"
 #include "autoware_vehicle_msgs/msg/vehicle_command.hpp"
 
-#include <memory>
-#include <string>
 
 class AccelMapConverter : public rclcpp::Node
 {
@@ -35,17 +36,23 @@ public:
   ~AccelMapConverter() = default;
 
 private:
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::RawVehicleCommand>::SharedPtr pub_cmd_;        //!< @brief topic publisher for low-level vehicle command
-  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_velocity_;  //!< @brief subscriber for current velocity
-  rclcpp::Subscription<autoware_vehicle_msgs::msg::VehicleCommand>::SharedPtr sub_cmd_;       //!< @brief subscriber for vehicle command
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::RawVehicleCommand>::SharedPtr
+    pub_cmd_;  //!< @brief topic publisher for low-level vehicle command
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr
+    sub_velocity_;  //!< @brief subscriber for current velocity
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::VehicleCommand>::SharedPtr
+    sub_cmd_;  //!< @brief subscriber for vehicle command
 
   std::shared_ptr<double> current_velocity_ptr_;  // [m/s]
 
   AccelMap accel_map_;
   BrakeMap brake_map_;
-  bool acc_map_initialized_;  //!< @brief flag to manage validity of imported accel map files
-  double max_throttle_;  //!< @brief maximum throttle that can be passed to low level controller. In general [0.0, 1.0]
-  double max_brake_;  //!< @brief maximum brake value that can be passed to low level controller. In general [0.0, 1.0]
+  //!< @brief flag to manage validity of imported accel map files
+  bool acc_map_initialized_;
+  //!< @brief maximum throttle that can be passed to low level controller. In general [0.0, 1.0]
+  double max_throttle_;
+  //!< @brief maximum brake value that can be passed to low level controller. In general [0.0, 1.0]
+  double max_brake_;
 
   void callbackVehicleCmd(
     const autoware_vehicle_msgs::msg::VehicleCommand::ConstSharedPtr vehicle_cmd_ptr);
@@ -55,4 +62,4 @@ private:
     double * desired_brake);
 };
 
-#endif  // VEHICLE_RAW_VEHICLE_CMD_CONVERTER_INCLUDE_RAW_VEHICLE_CMD_CONVERTER_NODE_HPP_
+#endif  // RAW_VEHICLE_CMD_CONVERTER__NODE_HPP_

--- a/vehicle/raw_vehicle_cmd_converter/package.xml
+++ b/vehicle/raw_vehicle_cmd_converter/package.xml
@@ -15,6 +15,9 @@
   <depend>autoware_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/vehicle/raw_vehicle_cmd_converter/package.xml
+++ b/vehicle/raw_vehicle_cmd_converter/package.xml
@@ -16,7 +16,7 @@
   <depend>geometry_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/vehicle/raw_vehicle_cmd_converter/src/accel_map.cpp
+++ b/vehicle/raw_vehicle_cmd_converter/src/accel_map.cpp
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "raw_vehicle_cmd_converter/accel_map.hpp"
+#include <algorithm>
 #include <chrono>
+#include <string>
+#include <vector>
+
+#include "raw_vehicle_cmd_converter/accel_map.hpp"
+
 using namespace std::chrono_literals;
 
 AccelMap::AccelMap(const rclcpp::Logger & logger)

--- a/vehicle/raw_vehicle_cmd_converter/src/brake_map.cpp
+++ b/vehicle/raw_vehicle_cmd_converter/src/brake_map.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+#include <string>
+#include <vector>
+
 #include "raw_vehicle_cmd_converter/brake_map.hpp"
 
 BrakeMap::BrakeMap(const rclcpp::Logger & logger)

--- a/vehicle/raw_vehicle_cmd_converter/src/csv_loader.cpp
+++ b/vehicle/raw_vehicle_cmd_converter/src/csv_loader.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+#include <vector>
+
 #include "raw_vehicle_cmd_converter/csv_loader.hpp"
 
 CSVLoader::CSVLoader(std::string csv_path) {csv_path_ = csv_path;}

--- a/vehicle/raw_vehicle_cmd_converter/src/interpolate.cpp
+++ b/vehicle/raw_vehicle_cmd_converter/src/interpolate.cpp
@@ -51,12 +51,12 @@ bool LinearInterpolate::interpolate(
     printf(
       "base_index.size() = %lu, base_value.size() = %lu\n", base_index.size(), base_value.size());
     printf("base_index: [");
-    for (int i = 0; i < base_index.size(); ++i) {
+    for (size_t i = 0; i < base_index.size(); ++i) {
       printf("%f, ", base_index.at(i));
     }
     printf("]\n");
     printf("base_value: [");
-    for (int i = 0; i < base_value.size(); ++i) {
+    for (size_t i = 0; i < base_value.size(); ++i) {
       printf("%f, ", base_value.at(i));
     }
     printf("]\n");

--- a/vehicle/raw_vehicle_cmd_converter/src/interpolate.cpp
+++ b/vehicle/raw_vehicle_cmd_converter/src/interpolate.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <vector>
+
 #include "raw_vehicle_cmd_converter/interpolate.hpp"
 
 /*
@@ -23,7 +25,7 @@ bool LinearInterpolate::interpolate(
   const double & return_index, double & return_value)
 {
   auto isIncrease = [](const std::vector<double> & x) {
-      for (int i = 0; i < (int)x.size() - 1; ++i) {
+      for (size_t i = 0; i < x.size() - 1; ++i) {
         if (x[i] > x[i + 1]) {return false;}
       }
       return true;
@@ -65,7 +67,7 @@ bool LinearInterpolate::interpolate(
   }
 
   // calculate linear interpolation
-  int i = 0;
+  size_t i = 0;
   if (base_index[i] == return_index) {
     return_value = base_value[i];
     return true;
@@ -73,7 +75,7 @@ bool LinearInterpolate::interpolate(
   while (base_index[i] < return_index) {
     ++i;
   }
-  if (i <= 0 || (int)base_index.size() - 1 < i) {
+  if (i <= 0 || base_index.size() - 1 < i) {
     std::cerr << "? something wrong. skip this return_index." << std::endl;
     return false;
   }

--- a/vehicle/raw_vehicle_cmd_converter/src/main.cpp
+++ b/vehicle/raw_vehicle_cmd_converter/src/main.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
 
 #include "raw_vehicle_cmd_converter/node.hpp"
 

--- a/vehicle/raw_vehicle_cmd_converter/src/node.cpp
+++ b/vehicle/raw_vehicle_cmd_converter/src/node.cpp
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <string>
+
 #include "raw_vehicle_cmd_converter/node.hpp"
 
 #include "rclcpp/logging.hpp"
-
-#include <functional>
 
 using std::placeholders::_1;
 


### PR DESCRIPTION
## Summary

Add and process linters for `raw_vehicle_cmd_converter`. This package had no issues with `ament_cmake_cppcheck` so I went ahead and just did the entire `ament_lint_common` linters. It was straightforward.

## Testing

1.  Compile with the correct build flags
```
colcon build --packages-up-to raw_vehicle_cmd_converter --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

2. Run the linter tests
```
colcon test --packages-select raw_vehicle_cmd_converter && colcon test-result --verbose
```

3. Run `clang-tidy` on the the source files from the root `AutowareArchitectureProposal` directory
```
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/vehicle/raw_vehicle_cmd_converter/src/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/vehicle/raw_vehicle_cmd_converter/include/*
```