### PR TITLE
ROS2 Linting: remote_cmd_converter

### DIFF
--- a/vehicle/remote_cmd_converter/CMakeLists.txt
+++ b/vehicle/remote_cmd_converter/CMakeLists.txt
@@ -4,6 +4,8 @@ project(remote_cmd_converter)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -17,6 +19,11 @@ ament_auto_add_executable(remote_cmd_converter_node
   src/node.cpp
   src/main.cpp
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/vehicle/remote_cmd_converter/include/remote_cmd_converter/node.hpp
+++ b/vehicle/remote_cmd_converter/include/remote_cmd_converter/node.hpp
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
+#ifndef REMOTE_CMD_CONVERTER__NODE_HPP_
+#define REMOTE_CMD_CONVERTER__NODE_HPP_
 
 #include <memory>
 #include <string>
@@ -21,8 +22,8 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include "autoware_control_msgs/msg/control_command_stamped.hpp"
-#include "autoware_control_msgs/msg/gate_mode.hpp"
 #include "autoware_control_msgs/msg/emergency_mode.hpp"
+#include "autoware_control_msgs/msg/gate_mode.hpp"
 #include "autoware_vehicle_msgs/msg/raw_control_command.hpp"
 #include "autoware_vehicle_msgs/msg/raw_control_command_stamped.hpp"
 #include "autoware_vehicle_msgs/msg/shift_stamped.hpp"
@@ -87,3 +88,5 @@ private:
   double calculateAcc(const autoware_vehicle_msgs::msg::RawControlCommand & cmd, const double vel);
   double getShiftVelocitySign(const autoware_vehicle_msgs::msg::ShiftStamped & cmd);
 };
+
+#endif  // REMOTE_CMD_CONVERTER__NODE_HPP_

--- a/vehicle/remote_cmd_converter/package.xml
+++ b/vehicle/remote_cmd_converter/package.xml
@@ -17,6 +17,9 @@
   <depend>raw_vehicle_cmd_converter</depend>
   <depend>diagnostic_updater</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/vehicle/remote_cmd_converter/src/main.cpp
+++ b/vehicle/remote_cmd_converter/src/main.cpp
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+
 #include "rclcpp/rclcpp.hpp"
+
 #include "remote_cmd_converter/node.hpp"
 
 int main(int argc, char ** argv)

--- a/vehicle/remote_cmd_converter/src/node.cpp
+++ b/vehicle/remote_cmd_converter/src/node.cpp
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "remote_cmd_converter/node.hpp"
 
 using std::placeholders::_1;


### PR DESCRIPTION
## Summary

Relatively straightforward linter addition as this is a small packages.

## Testing

1.  Compile with the correct build flags
```
colcon build --packages-up-to remote_cmd_converter --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

2. Run the linter tests
```
colcon test --packages-select remote_cmd_converter && colcon test-result --verbose
```

3. Run `clang-tidy` on the the source files from the root `AutowareArchitectureProposal` directory
```
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/vehicle/remote_cmd_converter/src/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/vehicle/remote_cmd_converter/include/*
```