### PR TITLE
ROS2 Linting: vehicle_info_util

### DIFF
--- a/vehicle/util/vehicle_info_util/CMakeLists.txt
+++ b/vehicle/util/vehicle_info_util/CMakeLists.txt
@@ -4,6 +4,8 @@ project(vehicle_info_util)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
@@ -16,5 +18,10 @@ ament_auto_find_build_dependencies()
 ament_auto_add_library(vehicle_info SHARED
   src/vehicle_info.cpp
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package()

--- a/vehicle/util/vehicle_info_util/include/vehicle_info_util/vehicle_info.hpp
+++ b/vehicle/util/vehicle_info_util/include/vehicle_info_util/vehicle_info.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef VEHICLE_INFO_UTIL_VEHICLE_INFO_CORE_HPP_
-#define VEHICLE_INFO_UTIL_VEHICLE_INFO_CORE_HPP_
+#ifndef VEHICLE_INFO_UTIL__VEHICLE_INFO_HPP_
+#define VEHICLE_INFO_UTIL__VEHICLE_INFO_HPP_
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -76,4 +76,4 @@ private:
 
 }  // namespace vehicle_info_util
 
-#endif
+#endif  // VEHICLE_INFO_UTIL__VEHICLE_INFO_HPP_

--- a/vehicle/util/vehicle_info_util/package.xml
+++ b/vehicle/util/vehicle_info_util/package.xml
@@ -11,6 +11,10 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>rclcpp</depend>
+  
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/vehicle/util/vehicle_info_util/src/vehicle_info.cpp
+++ b/vehicle/util/vehicle_info_util/src/vehicle_info.cpp
@@ -86,7 +86,6 @@ VehicleInfo VehicleInfo::create(rclcpp::Node & node)
       wheel_radius_m, wheel_width_m, wheel_base_m, wheel_tread_m, front_overhang_m, rear_overhang_m,
       left_overhang_m, right_overhang_m, vehicle_height_m);
   }
-
 }
 
 }  // namespace vehicle_info_util


### PR DESCRIPTION
## Summary

Small and straightforward lint of the `vehicle_info_util` package.

## Testing

1.  Compile with the correct build flags
```
colcon build --packages-up-to vehicle_info_util --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

2. Run the linter tests
```
colcon test --packages-select vehicle_info_util && colcon test-result --verbose
```

3. Run `clang-tidy` on the the source files from the root `AutowareArchitectureProposal` directory
```
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/vehicle/util/vehicle_info_util/src/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/vehicle/util/vehicle_info_util/include/*
```