### PR TITLE
ROS2 Linting: as

### DIFF
--- a/vehicle/as/CMakeLists.txt
+++ b/vehicle/as/CMakeLists.txt
@@ -6,6 +6,8 @@ ament_auto_find_build_dependencies()
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
@@ -20,6 +22,11 @@ ament_auto_add_executable(pacmod_interface
   src/pacmod_interface/pacmod_interface.cpp
   src/pacmod_interface/pacmod_interface_node.cpp
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE

--- a/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
+++ b/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef VEHICLE_AS_PACMOD_INTERFACE_H
-#define VEHICLE_AS_PACMOD_INTERFACE_H
-
-#include "message_filters/subscriber.h"
-#include "message_filters/sync_policies/approximate_time.h"
-#include "message_filters/synchronizer.h"
+#ifndef PACMOD_INTERFACE__PACMOD_INTERFACE_HPP_
+#define PACMOD_INTERFACE__PACMOD_INTERFACE_HPP_
 
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <memory>
 #include <string>
+
+#include "message_filters/subscriber.h"
+#include "message_filters/sync_policies/approximate_time.h"
+#include "message_filters/synchronizer.h"
 
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -157,4 +157,4 @@ private:
   int32_t toAutowareTurnSignal(const pacmod_msgs::msg::SystemRptInt & turn);
 };
 
-#endif
+#endif  // PACMOD_INTERFACE__PACMOD_INTERFACE_HPP_

--- a/vehicle/as/include/ssc_interface/ssc_interface.hpp
+++ b/vehicle/as/include/ssc_interface/ssc_interface.hpp
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SSC_INTERFACE_H
-#define SSC_INTERFACE_H
+#ifndef SSC_INTERFACE__SSC_INTERFACE_HPP_
+#define SSC_INTERFACE__SSC_INTERFACE_HPP_
+
+#include <memory>
+#include <string>
 
 #include "message_filters/subscriber.h"
 #include "message_filters/sync_policies/approximate_time.h"
 #include "message_filters/synchronizer.h"
-
-#include <memory>
-#include <string>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -171,4 +171,4 @@ private:
   int32_t toAutowareTurnSignal(const pacmod_msgs::msg::SystemRptInt & turn) const;
 };
 
-#endif  // SSC_INTERFACE_H
+#endif  // SSC_INTERFACE__SSC_INTERFACE_HPP_

--- a/vehicle/as/package.xml
+++ b/vehicle/as/package.xml
@@ -5,10 +5,11 @@
   <version>0.1.0</version>
   <description>AutonomouStuff vehicle interface as a ROS 2 node</description>
   <maintainer email="aohsato@gmail.com">Akihito Ohsato</maintainer>
+  <license>Apache License 2.0</license>
+  
   <author email="aohsato@gmail.com">Akihito Ohsato</author>
   <author email="antm678@ertl.jp">T.Ando</author>
   <author email="horibe.takamasa@gmail.com">Horibe Takamasa</author>
-  <license>Apache License 2.0</license>
 
   <depend>rclcpp</depend>
   <depend>automotive_navigation_msgs</depend>
@@ -19,6 +20,9 @@
   <depend>message_filters</depend>
   <depend>pacmod_msgs</depend>
   <depend>std_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
+++ b/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+#include <memory>
+#include <utility>
+
 #include "pacmod_interface/pacmod_interface.hpp"
 
 PacmodInterface::PacmodInterface()

--- a/vehicle/as/src/pacmod_interface/pacmod_interface_node.cpp
+++ b/vehicle/as/src/pacmod_interface/pacmod_interface_node.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+
 #include "rclcpp/rclcpp.hpp"
 
 #include "pacmod_interface/pacmod_interface.hpp"

--- a/vehicle/as/src/ssc_interface/ssc_interface.cpp
+++ b/vehicle/as/src/ssc_interface/ssc_interface.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "ssc_interface/ssc_interface.hpp"
 
 SSCInterface::SSCInterface()
@@ -190,7 +194,8 @@ void SSCInterface::callbackFromSSCFeedbacks(
   const double steering_angle = std::atan(curvature * wheel_base_);
   // constexpr double tread = 1.64;  // spec sheet 1.63
   // double omega =
-  //   (-msg_wheel_speed->rear_right_wheel_speed + msg_wheel_speed->rear_left_wheel_speed) * tire_radius_ / tread;
+  //   (-msg_wheel_speed->rear_right_wheel_speed + msg_wheel_speed->rear_left_wheel_speed) *
+  //   tire_radius_ / tread;
 
   // as_current_velocity (geometry_msgs::msg::TwistStamped)
   geometry_msgs::msg::TwistStamped twist;

--- a/vehicle/as/src/ssc_interface/ssc_interface_node.cpp
+++ b/vehicle/as/src/ssc_interface/ssc_interface_node.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+
 #include "ssc_interface/ssc_interface.hpp"
 
 #include "rclcpp/rclcpp.hpp"


### PR DESCRIPTION
## Summary

Small and straightforward lint of the `as` package.

## Testing

1.  Compile with the correct build flags
```
colcon build --packages-up-to as --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

2. Run the linter tests
```
colcon test --packages-select as && colcon test-result --verbose
```

3. Run `clang-tidy` on the the source files from the root `AutowareArchitectureProposal` directory
```
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/vehicle/as/src/pacmod_interface/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/vehicle/as/src/ssc_interface/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/vehicle/as/include/pacmod_interface/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/vehicle/as/include/ssc_interface/*
```

Note: warning will be generated - but no errors