### PR TITLE
ROS2 Linting: gnss_poser

### DIFF
--- a/sensing/preprocessor/gnss/gnss_poser/CMakeLists.txt
+++ b/sensing/preprocessor/gnss/gnss_poser/CMakeLists.txt
@@ -4,6 +4,8 @@ project(gnss_poser)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
@@ -16,17 +18,22 @@ set(GNSS_POSER_HEADERS
   include/gnss_poser/convert.hpp
   include/gnss_poser/gnss_poser_core.hpp
   include/gnss_poser/gnss_stat.hpp
- )
+)
 
 ament_auto_add_library(gnss_poser_node SHARED
-	src/gnss_poser_core.cpp
-	${GNSS_POSER_HEADERS}
+  src/gnss_poser_core.cpp
+  ${GNSS_POSER_HEADERS}
 )
 
 rclcpp_components_register_node(gnss_poser_node
   PLUGIN "GNSSPoser"
   EXECUTABLE gnss_poser
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/sensing/preprocessor/gnss/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/preprocessor/gnss/gnss_poser/include/gnss_poser/convert.hpp
@@ -101,7 +101,7 @@ GNSSStat UTM2MGRS(
       std::pow(
       10, static_cast<int>(MGRSPrecision::_1_METER) -
       static_cast<int>(precision));                 // set unit as [m]
-    mgrs.z = utm.z;                                 // TODO(user)
+    mgrs.z = utm.z;                                 // TODO(ryo.watanabe)
   } catch (const GeographicLib::GeographicErr & err) {
     RCLCPP_ERROR_STREAM(logger, "Failed to convert from UTM to MGRS" << err.what());
   }

--- a/sensing/preprocessor/gnss/gnss_poser/include/gnss_poser/convert.hpp
+++ b/sensing/preprocessor/gnss/gnss_poser/include/gnss_poser/convert.hpp
@@ -11,8 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef GNSS_POSER_CONVERT_HPP_
-#define GNSS_POSER_CONVERT_HPP_
+#ifndef GNSS_POSER__CONVERT_HPP_
+#define GNSS_POSER__CONVERT_HPP_
+
+#include <string>
 
 #include "gnss_poser/gnss_stat.hpp"
 #include "geo_pos_conv/geo_pos_conv.hpp"
@@ -99,7 +101,7 @@ GNSSStat UTM2MGRS(
       std::pow(
       10, static_cast<int>(MGRSPrecision::_1_METER) -
       static_cast<int>(precision));                 // set unit as [m]
-    mgrs.z = utm.z;                                 // TODO
+    mgrs.z = utm.z;                                 // TODO(user)
   } catch (const GeographicLib::GeographicErr & err) {
     RCLCPP_ERROR_STREAM(logger, "Failed to convert from UTM to MGRS" << err.what());
   }
@@ -131,4 +133,4 @@ GNSSStat NavSatFix2PLANE(
 }
 }  // namespace GNSSPoser
 
-#endif
+#endif  // GNSS_POSER__CONVERT_HPP_

--- a/sensing/preprocessor/gnss/gnss_poser/include/gnss_poser/gnss_poser_core.hpp
+++ b/sensing/preprocessor/gnss/gnss_poser/include/gnss_poser/gnss_poser_core.hpp
@@ -11,8 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef GNSS_POSER_GNSS_POSER_CORE_HPP_
-#define GNSS_POSER_GNSS_POSER_CORE_HPP_
+#ifndef GNSS_POSER__GNSS_POSER_CORE_HPP_
+#define GNSS_POSER__GNSS_POSER_CORE_HPP_
+
+#include <string>
 
 #include "gnss_poser/convert.hpp"
 #include "gnss_poser/gnss_stat.hpp"
@@ -89,4 +91,4 @@ private:
 };
 }  // namespace GNSSPoser
 
-#endif
+#endif  // GNSS_POSER__GNSS_POSER_CORE_HPP_

--- a/sensing/preprocessor/gnss/gnss_poser/include/gnss_poser/gnss_stat.hpp
+++ b/sensing/preprocessor/gnss/gnss_poser/include/gnss_poser/gnss_stat.hpp
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef GNSS_POSER_GNSS_STAT_HPP_
-#define GNSS_POSER_GNSS_STAT_HPP_
+#ifndef GNSS_POSER__GNSS_STAT_HPP_
+#define GNSS_POSER__GNSS_STAT_HPP_
 
 namespace GNSSPoser
 {
@@ -50,4 +50,4 @@ struct GNSSStat
 };
 }  // namespace GNSSPoser
 
-#endif
+#endif  // GNSS_POSER__GNSS_STAT_HPP_

--- a/sensing/preprocessor/gnss/gnss_poser/package.xml
+++ b/sensing/preprocessor/gnss/gnss_poser/package.xml
@@ -5,8 +5,6 @@
   <version>1.0.0</version>
   <description>The ROS2 gnss_poser package</description>
   <maintainer email="ryo.watanabe@tier4.jp">Ryo Watanabe</maintainer>
-  <!-- ROS2 -->
-  <maintainer email="jilada.eccleston@tier4.jp">Jilada ECCLESTON</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>

--- a/sensing/preprocessor/gnss/gnss_poser/package.xml
+++ b/sensing/preprocessor/gnss/gnss_poser/package.xml
@@ -24,6 +24,9 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/sensing/preprocessor/gnss/gnss_poser/src/gnss_poser_core.cpp
+++ b/sensing/preprocessor/gnss/gnss_poser/src/gnss_poser_core.cpp
@@ -11,11 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "gnss_poser/gnss_poser_core.hpp"
-#include "rclcpp_components/register_node_macro.hpp"
 
 #include <algorithm>
+#include <memory>
 #include <string>
+#include <vector>
+
+#include "gnss_poser/gnss_poser_core.hpp"
 
 namespace GNSSPoser
 {
@@ -105,7 +107,7 @@ void GNSSPoser::callbackNavSatFix(
 
   // transform pose from gnss_antenna to base_link
   geometry_msgs::msg::PoseStamped gnss_base_pose_msg;
-  //remove rotation
+  // remove rotation
   tf_base_to_gnss_ptr->transform.rotation.x = 0.0;
   tf_base_to_gnss_ptr->transform.rotation.y = 0.0;
   tf_base_to_gnss_ptr->transform.rotation.z = 0.0;
@@ -343,6 +345,7 @@ void GNSSPoser::publishTF(
   tf2_broadcaster_.sendTransform(transform_stamped);
 }
 
-RCLCPP_COMPONENTS_REGISTER_NODE(GNSSPoser)
+#include "rclcpp_components/register_node_macro.hpp"
 
+RCLCPP_COMPONENTS_REGISTER_NODE(GNSSPoser)
 }  // namespace GNSSPoser


### PR DESCRIPTION
## Summary

Small and straightforward lint of the `gnss_poser` package. There is a TODO with no description - should this be removed? I added "user" so the linter would not complain.

## Testing

1.  Compile with the correct build flags
```
colcon build --packages-up-to gnss_poser --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

2. Run the linter tests
```
colcon test --packages-select gnss_poser && colcon test-result --verbose
```

3. Run `clang-tidy` on the the source files from the root `AutowareArchitectureProposal` directory
```
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/sensing/preprocessor/gnss/gnss_poser/include/gnss_poser/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/sensing/preprocessor/gnss/gnss_poser/src/gnss_poser_core.cpp
```