### PR TITLE
Add strict C++14 features to CMake

### DIFF
--- a/control/latlon_muxer/CMakeLists.txt
+++ b/control/latlon_muxer/CMakeLists.txt
@@ -7,6 +7,8 @@ ament_auto_find_build_dependencies()
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter -Werror)


### PR DESCRIPTION
This package already had all the linters, I only added the stricter C++ options to CMake