### PR TITLE
adding linters to lidar_apollo_instance_segmentation

### DIFF
--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/CMakeLists.txt
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/CMakeLists.txt
@@ -96,6 +96,8 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
   
   if(NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
   endif()
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
@@ -142,6 +144,10 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     tensorrt_apollo_cnn_lib
   )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
   ament_auto_package(INSTALL_TO_SHARE
     launch
@@ -152,6 +158,11 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
 else()
   find_package(ament_cmake_auto REQUIRED)
   ament_auto_find_build_dependencies()
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
   # to avoid launch file missing without a gpu
   ament_auto_package(INSTALL_TO_SHARE

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/cluster2d.hpp
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/cluster2d.hpp
@@ -43,8 +43,8 @@
  * limitations under the License.
  *****************************************************************************/
 
-#ifndef CLUSTER2D_H
-#define CLUSTER2D_H
+#ifndef LIDAR_APOLLO_INSTANCE_SEGMENTATION__CLUSTER2D_HPP_
+#define LIDAR_APOLLO_INSTANCE_SEGMENTATION__CLUSTER2D_HPP_
 
 #include "pcl/point_types.h"
 #include "pcl/point_cloud.h"
@@ -161,4 +161,4 @@ private:
   void traverse(Node * x);
 };
 
-#endif  // CLUSTER_2D_H
+#endif  // LIDAR_APOLLO_INSTANCE_SEGMENTATION__CLUSTER2D_HPP_

--- a/perception/object_recognition/detection/lidar_apollo_instance_segmentation/package.xml
+++ b/perception/object_recognition/detection/lidar_apollo_instance_segmentation/package.xml
@@ -20,6 +20,10 @@
     <depend>tf2_geometry_msgs</depend>
     <depend>tf2_eigen</depend>
     <depend>tf2_ros</depend>
+
+    <test_depend>ament_lint_auto</test_depend>
+    <test_depend>ament_cmake_cppcheck</test_depend>
+
     <export>
         <build_type>ament_cmake</build_type>
     </export>


### PR DESCRIPTION
Getting errors in headers while running `clang-tidy `

```
lidar_apollo_instance_segmentation/src/cluster2d.cpp:47:10: error: 'lidar_apollo_instance_segmentation/cluster2d.hpp' file not found [clang-diagnostic-error]
#include "lidar_apollo_instance_segmentation/cluster2d.hpp"
```

Even though the headers are available.