### PR TITLE
adding linters to shape_estimation

### DIFF
--- a/perception/object_recognition/detection/shape_estimation/CMakeLists.txt
+++ b/perception/object_recognition/detection/shape_estimation/CMakeLists.txt
@@ -3,6 +3,8 @@ project(shape_estimation)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -84,6 +86,11 @@ target_include_directories(shape_estimation
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/perception/object_recognition/detection/shape_estimation/package.xml
+++ b/perception/object_recognition/detection/shape_estimation/package.xml
@@ -20,6 +20,8 @@
   <depend>libpcl-all-dev</depend>
   <depend>eigen</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/perception/object_recognition/detection/shape_estimation/src/corrector/normal/bus_corrector.cpp
+++ b/perception/object_recognition/detection/shape_estimation/src/corrector/normal/bus_corrector.cpp
@@ -59,7 +59,7 @@ bool BusCorrector::correct(
   v_point.push_back(Eigen::Vector2d(-shape_output.dimensions.x / 2.0, 0.0));
   v_point.push_back(Eigen::Vector2d(0.0, -shape_output.dimensions.y / 2.0));
 
-  size_t first_most_distant_index;
+  size_t first_most_distant_index = 0;
   {
     double distance = 0.0;
     for (size_t i = 0; i < v_point.size(); ++i) {
@@ -69,7 +69,7 @@ bool BusCorrector::correct(
       }
     }
   }
-  size_t second_most_distant_index;
+  size_t second_most_distant_index = 0;
   {
     double distance = 0.0;
     for (size_t i = 0; i < v_point.size(); ++i) {
@@ -79,7 +79,7 @@ bool BusCorrector::correct(
       }
     }
   }
-  size_t third_most_distant_index;
+  size_t third_most_distant_index = 0;
   {
     double distance = 0.0;
     for (size_t i = 0; i < v_point.size(); ++i) {

--- a/perception/object_recognition/detection/shape_estimation/src/filter/bus_filter.cpp
+++ b/perception/object_recognition/detection/shape_estimation/src/filter/bus_filter.cpp
@@ -27,7 +27,6 @@ bool BusFilter::filter(
   double s = x * y;
   constexpr double min_width = 2.0;
   constexpr double max_width = 2.9;
-  constexpr double min_length = 5.0;
   constexpr double max_length = 17.0;
 
   if (x < min_width && y < min_width) {

--- a/perception/object_recognition/detection/shape_estimation/src/filter/car_filter.cpp
+++ b/perception/object_recognition/detection/shape_estimation/src/filter/car_filter.cpp
@@ -27,7 +27,6 @@ bool CarFilter::filter(
   double s = x * y;
   constexpr double min_width = 1.2;
   constexpr double max_width = 2.2;
-  constexpr double min_length = 3.0;
   constexpr double max_length = 5.0;
 
   if (x < min_width && y < min_width) {

--- a/perception/object_recognition/detection/shape_estimation/src/filter/truck_filter.cpp
+++ b/perception/object_recognition/detection/shape_estimation/src/filter/truck_filter.cpp
@@ -27,7 +27,6 @@ bool TruckFilter::filter(
   double s = x * y;
   constexpr double min_width = 1.5;
   constexpr double max_width = 2.9;
-  constexpr double min_length = 4.0;
   constexpr double max_length = 7.9;
 
   if (x < min_width && y < min_width) {

--- a/perception/object_recognition/detection/shape_estimation/src/model/yaw_fixed/bounding_box.cpp
+++ b/perception/object_recognition/detection/shape_estimation/src/model/yaw_fixed/bounding_box.cpp
@@ -111,7 +111,7 @@ bool BoundingBoxModel::estimate(
     Q.push_back(std::make_pair(theta, q));        // col.8, Algo.2
   }
 
-  double theta_star;  // col.10, Algo.2
+  double theta_star = 0.0;  // col.10, Algo.2
   double max_q = 0.0;
   for (size_t i = 0; i < Q.size(); ++i) {
     if (max_q < Q.at(i).second || i == 0) {


### PR DESCRIPTION
Some variables where uninitialized and were giving warnings. Initialized them to zero.
Not sure if it is correct. 

Also removed variables that were not used.