### PR TITLE
Fix rviz plugins

### DIFF
--- a/common/util/rviz_plugins/autoware_perception_rviz_plugin/CMakeLists.txt
+++ b/common/util/rviz_plugins/autoware_perception_rviz_plugin/CMakeLists.txt
@@ -26,7 +26,7 @@ ament_auto_add_library(autoware_perception_rviz_plugin
   src/tools/delete_all_objects.cpp
 )
 
-target_link_libraries(autoware_perception_rviz_plugin 
+target_link_libraries(autoware_perception_rviz_plugin SHARED
   ${QT_LIBRARIES})
 
 # Export the plugin to be imported by rviz2

--- a/common/util/rviz_plugins/autoware_perception_rviz_plugin/plugins/plugin_description.xml
+++ b/common/util/rviz_plugins/autoware_perception_rviz_plugin/plugins/plugin_description.xml
@@ -1,4 +1,4 @@
-<library path="lib/libautoware_perception_rviz_plugin">
+<library path="autoware_perception_rviz_plugin">
   <class name="rviz_plugins/PedestrianInitialPoseTool"
          type="rviz_plugins::PedestrianInitialPoseTool"
          base_class_type="rviz_common::Tool">

--- a/common/util/rviz_plugins/autoware_planning_rviz_plugin/CMakeLists.txt
+++ b/common/util/rviz_plugins/autoware_planning_rviz_plugin/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_definitions(-DQT_NO_KEYWORDS)
 find_package(Eigen3 REQUIRED)
 
-ament_auto_add_library(autoware_planning_rviz_plugin
+ament_auto_add_library(autoware_planning_rviz_plugin SHARED
   include/path/display.hpp
   src/path/display.cpp
   include/trajectory/display.hpp

--- a/common/util/rviz_plugins/autoware_planning_rviz_plugin/plugins/plugin_description.xml
+++ b/common/util/rviz_plugins/autoware_planning_rviz_plugin/plugins/plugin_description.xml
@@ -1,11 +1,11 @@
-<library path="lib/libautoware_planning_rviz_plugin">
-  <class name="rviz_plugins/Path" 
-    type="rviz_plugins::AutowarePathDisplay" 
+<library path="autoware_planning_rviz_plugin">
+  <class name="rviz_plugins/Path"
+    type="rviz_plugins::AutowarePathDisplay"
     base_class_type="rviz_common::Display">
     <description>Display autoware_planning_msg::Path</description>
   </class>
-  <class name="rviz_plugins/Trajectory" 
-    type="rviz_plugins::AutowareTrajectoryDisplay" 
+  <class name="rviz_plugins/Trajectory"
+    type="rviz_plugins::AutowareTrajectoryDisplay"
     base_class_type="rviz_common::Display">
     <description>Display autoware_planning_msg::Trajectory</description>
   </class>


### PR DESCRIPTION
There is a bug in rviz_plugins where it fails to load in RVIZ2.
For example when you add "Path" tools in display panel by clicking "Add" -> "By Display Type" -> "autoware_rviz_plugin/Path", it outputs error that it cannot find library.
This PR fixes the error.