### PR TITLE
adding linters to multi_object_tracker

### DIFF
--- a/perception/object_recognition/tracking/multi_object_tracker/CMakeLists.txt
+++ b/perception/object_recognition/tracking/multi_object_tracker/CMakeLists.txt
@@ -4,6 +4,8 @@ project(multi_object_tracker)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
@@ -54,6 +56,11 @@ rclcpp_components_register_node(multi_object_tracker_node
   PLUGIN "MultiObjectTracker"
   EXECUTABLE multi_object_tracker
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/perception/object_recognition/tracking/multi_object_tracker/package.xml
+++ b/perception/object_recognition/tracking/multi_object_tracker/package.xml
@@ -20,6 +20,9 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/perception/object_recognition/tracking/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/object_recognition/tracking/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -85,7 +85,7 @@ void MultiObjectTracker::measurementCallback(
     if (status != std::future_status::ready) {
       RCLCPP_WARN_THROTTLE(
         this->get_logger(), *(this->get_clock()), std::chrono::milliseconds(1000).count(),
-        "cannot transform to world frame form %s", input_transformed_objects.header.frame_id);
+        "cannot transform to world frame form %s", input_transformed_objects.header.frame_id.c_str());
       return;
     }
 


### PR DESCRIPTION
`clang-tidy` flags an error in `multi_object_tracker_core.cpp`. But it is a false positive, so ignored it.