### PR TITLE
[scenario_selector_node] fix timer frequency

### DIFF
--- a/planning/scenario_planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
+++ b/planning/scenario_planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
@@ -336,7 +336,7 @@ ScenarioSelectorNode::ScenarioSelectorNode()
   // Timer Callback
   auto timer_callback = std::bind(&ScenarioSelectorNode::onTimer, this);
   auto period = std::chrono::duration_cast<std::chrono::nanoseconds>(
-    std::chrono::duration<double>(update_rate_));
+    std::chrono::duration<double>(1.0 / static_cast<double>(update_rate_)));
 
   timer_ = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
     this->get_clock(), period, std::move(timer_callback),


### PR DESCRIPTION
This fixes timer frequency of scenario_selector.
The parameter "rate" is wrongly used as "period" when configuring timer.