### PR TITLE
[lane_change_planner] [obstacle_avoidance_planner] fix clock type

### DIFF
--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.hpp
@@ -57,7 +57,8 @@ private:
 struct BoolStamped
 {
   explicit BoolStamped(bool in_data)
-  : data(in_data) {}
+  : data(in_data), 
+    stamp(0, 0, RCL_ROS_TIME) {}
   bool data = false;
   rclcpp::Time stamp;
 };

--- a/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/src/node.cpp
@@ -368,7 +368,7 @@ ObstacleAvoidancePlanner::generateOptimizedTrajectory(
     return getPrevTrajectory(path.points);
   }
   prev_ego_pose_ptr_ = std::make_unique<geometry_msgs::msg::Pose>(ego_pose);
-  prev_replanned_time_ptr_ = std::make_unique<rclcpp::Time>(rclcpp::Clock().now());
+  prev_replanned_time_ptr_ = std::make_unique<rclcpp::Time>(this->now());
 
   DebugData debug_data;
   const auto optional_trajs = eb_path_optimizer_ptr_->generateOptimizedTrajectory(


### PR DESCRIPTION
Some of the nodes had comparison of rclcpp::Time with difference clock source, which outputs error when it tries to do comparison or subtraction operations.