### PR TITLE
adding linters to autoware_localization_srvs

### DIFF
--- a/localization/util/autoware_localization_srvs/CMakeLists.txt
+++ b/localization/util/autoware_localization_srvs/CMakeLists.txt
@@ -4,6 +4,8 @@ project(autoware_localization_srvs)
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -17,5 +19,10 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/PoseWithCovarianceStamped.srv"
   DEPENDENCIES geometry_msgs
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_package()

--- a/localization/util/autoware_localization_srvs/package.xml
+++ b/localization/util/autoware_localization_srvs/package.xml
@@ -15,6 +15,9 @@
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>


### PR DESCRIPTION
`clang-tidy` giving errors. Not sure if they are relevant.

```
Error while processing /home/nithilan/AutowareArchitectureProposal/src/autoware/pilot.auto/localization/util/autoware_localization_srvs/srv/PoseWithCovarianceStamped.srv.
/home/nithilan/AutowareArchitectureProposal/src/autoware/pilot.auto/localization/util/autoware_localization_srvs/srv/PoseWithCovarianceStamped.srv:1:3: error: invalid preprocessing directive [clang-diagnostic-error]
# A sequence number is included to do primitive error checking
  ^
/home/nithilan/AutowareArchitectureProposal/src/autoware/pilot.auto/localization/util/autoware_localization_srvs/srv/PoseWithCovarianceStamped.srv:2:1: error: unknown type name 'uint32' [clang-diagnostic-error]
uint32 seq
^
/home/nithilan/AutowareArchitectureProposal/src/autoware/pilot.auto/localization/util/autoware_localization_srvs/srv/PoseWithCovarianceStamped.srv:2:11: error: expected ';' after top level declarator [clang-diagnostic-error]
uint32 seq
```
