### PR TITLE
adding linters to ndt_omp

### DIFF
--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/CMakeLists.txt
@@ -3,6 +3,8 @@ project(ndt_omp)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -109,5 +111,9 @@ install(
   INCLUDES DESTINATION include
 )
 
-ament_package()
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
+ament_package()

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/include/ndt_omp/ndt_omp_impl.hpp
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/include/ndt_omp/ndt_omp_impl.hpp
@@ -266,7 +266,7 @@ double ndt_omp::NormalDistributionsTransform<PointSource, PointTarget>::computeD
 
   // Update gradient and hessian for each point, line 17 in Algorithm 2 [Magnusson 2009]
 #pragma omp parallel for num_threads(num_threads_) schedule(guided, 8)
-  for (int idx = 0; idx < input_->points.size(); idx++) {
+  for (unsigned long idx = 0; idx < input_->points.size(); idx++) {
     int thread_n = omp_get_thread_num();
 
     // Original Point and Transformed Point
@@ -987,7 +987,7 @@ double ndt_omp::NormalDistributionsTransform<PointSource, PointTarget>::calculat
 {
   double score = 0;
 
-  for (int idx = 0; idx < trans_cloud.points.size(); idx++) {
+  for (unsigned long idx = 0; idx < trans_cloud.points.size(); idx++) {
     PointSource x_trans_pt = trans_cloud.points[idx];
 
     // Find nieghbors (Radius search has been experimentally faster than direct neighbor checking.

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/include/ndt_omp/voxel_grid_covariance_omp_impl.hpp
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/include/ndt_omp/voxel_grid_covariance_omp_impl.hpp
@@ -136,8 +136,8 @@ void ndt_omp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
       if (!input_->is_dense) {
         // Check if the point is invalid
         if (
-          !pcl_isfinite(input_->points[cp].x) || !pcl_isfinite(input_->points[cp].y) ||
-          !pcl_isfinite(input_->points[cp].z))
+          !std::isfinite(input_->points[cp].x) || !std::isfinite(input_->points[cp].y) ||
+          !std::isfinite(input_->points[cp].z))
         {
           continue;
         }
@@ -213,8 +213,8 @@ void ndt_omp::VoxelGridCovariance<PointT>::applyFilter(PointCloud & output)
       if (!input_->is_dense) {
         // Check if the point is invalid
         if (
-          !pcl_isfinite(input_->points[cp].x) || !pcl_isfinite(input_->points[cp].y) ||
-          !pcl_isfinite(input_->points[cp].z))
+          !std::isfinite(input_->points[cp].x) || !std::isfinite(input_->points[cp].y) ||
+          !std::isfinite(input_->points[cp].z))
         {
           continue;
         }

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_omp/package.xml
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_omp/package.xml
@@ -15,6 +15,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>libpcl-all-dev</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
Warnings generated at multiple places by clang-tidy for this function:

```
warning: 'getFieldIndex<pcl::PointXYZ>' is deprecated: use getFieldIndex<PointT> (field_name, fields) instead [clang-diagnostic-deprecated-declarations]
rgba_index = pcl::getFieldIndex(*input_, "rgb", fields);
```
