### PR TITLE
[multi_object_tracker] fix bug in calculating timer period

### DIFF
--- a/perception/object_recognition/tracking/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/object_recognition/tracking/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -54,7 +54,7 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
   // Create ROS time based timer
   auto timer_callback = std::bind(&MultiObjectTracker::publishTimerCallback, this);
   auto period = std::chrono::duration_cast<std::chrono::nanoseconds>(
-    std::chrono::duration<double>(publish_rate));
+    std::chrono::duration<double>(1.0 / publish_rate));
 
   publish_timer_ = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
     this->get_clock(), period, std::move(timer_callback),


### PR DESCRIPTION
This fixes the bug in setting timer period.
Original code is using publish_rate directly as period instead of taking inverse.