### PR TITLE
add remapping option for the launch file in map_based_prediction

### DIFF
--- a/perception/object_recognition/prediction/map_based_prediction/launch/map_based_prediction.launch.xml
+++ b/perception/object_recognition/prediction/map_based_prediction/launch/map_based_prediction.launch.xml
@@ -4,9 +4,11 @@
   <arg name="prediction_time_horizon" default="10.0" />
   <arg name="prediction_sampling_delta_time" default="0.5" />
   <arg name="vector_map_topic" default="/map/vector_map" />
+  <arg name="output_topic" default="objects"/>
   <node pkg="map_based_prediction" exec="map_based_prediction" name="map_based_prediction" output="screen">
     <param name="perception_time_horizon" value="$(var prediction_time_horizon)" />
     <param name="prediction_sampling_delta_time" value="$(var prediction_sampling_delta_time)" />
     <remap from="/vector_map" to="$(var vector_map_topic)"/>
+    <remap from="objects" to="$(var output_topic)"/>
   </node>
 </launch>


### PR DESCRIPTION
This adds remapping arguments for output topic so that the topic can be remapped when it is called from another launch file.