### PR TITLE
[lane_change_planner] fix clock type when BoolStamped is initialized

### DIFF
--- a/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.hpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/data_manager.hpp
@@ -59,7 +59,8 @@ private:
 struct BoolStamped
 {
   explicit BoolStamped(bool in_data)
-  : data(in_data) {}
+  : data(in_data),
+    stamp(0, 0, RCL_ROS_TIME) {}
   bool data = false;
   rclcpp::Time stamp;
 };


### PR DESCRIPTION
This was already merged in https://github.com/tier4/Pilot.Auto/pull/183/files, but was reverted in https://github.com/tier4/Pilot.Auto/pull/150 when conflict was resolved. 