### PR TITLE
ROS2 Linting: osqp_interface

### DIFF
--- a/common/math/osqp_interface/CMakeLists.txt
+++ b/common/math/osqp_interface/CMakeLists.txt
@@ -3,6 +3,8 @@ project(osqp_interface)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -35,5 +37,10 @@ ament_target_dependencies(osqp_interface osqp_vendor)
 ament_export_include_directories("${OSQP_INCLUDE_DIR}")
 # crucial so the linking order is correct in a downstream package: libosqp_interface.a should come before libosqp.a
 ament_export_libraries(osqp::osqpstatic)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package()

--- a/common/math/osqp_interface/include/osqp_interface/csc_matrix_conv.hpp
+++ b/common/math/osqp_interface/include/osqp_interface/csc_matrix_conv.hpp
@@ -14,6 +14,8 @@
 #ifndef CSC_MATRIX_CONV_H
 #define CSC_MATRIX_CONV_H
 
+#include <vector>
+
 #include "eigen3/Eigen/Core"
 #include "types.h"  // for 'c_int' type ('long' or 'long long')
 

--- a/common/math/osqp_interface/package.xml
+++ b/common/math/osqp_interface/package.xml
@@ -14,6 +14,9 @@
 
   <depend>osqp_vendor</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
## Summary

Simple lint of the `osqp_interface` package. 

## Testing
1. Compile with the correct build flags
```
colcon build --packages-up-to osqp_interface --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```
2. Run the linter tests
```
colcon test --packages-select osqp_interface && colcon test-result --verbose
```
3. Run clang-tidy on the the source files from the root AutowareArchitectureProposal directory
```
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/common/math/osqp_interface/src/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/common/math/osqp_interface/include/osqp_interface/*
```