### PR TITLE
ROS2 Linting: spline_interpolation

### DIFF
--- a/common/math/spline_interpolation/CMakeLists.txt
+++ b/common/math/spline_interpolation/CMakeLists.txt
@@ -1,14 +1,24 @@
 cmake_minimum_required(VERSION 3.5)
 project(spline_interpolation)
 
+### Compile options
 if(NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
 endif()
 
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-
 ament_auto_add_library(spline_interpolation src/spline_interpolation.cpp)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package()

--- a/common/math/spline_interpolation/package.xml
+++ b/common/math/spline_interpolation/package.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-    <name>spline_interpolation</name>
-    <version>0.1.0</version>
-    <description>The spline interpolation package</description>
-    <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
-    <author email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</author>
+  <name>spline_interpolation</name>
+  <version>0.1.0</version>
+  <description>The spline interpolation package</description>
+  <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
+  <author email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</author>
   <license>Apache License 2.0</license>
-    <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-    <depend>rclcpp</depend>
+  <depend>rclcpp</depend>
 
-    <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>
 
-    <export>
-      <build_type>ament_cmake</build_type>
-    </export>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/common/math/spline_interpolation/package.xml
+++ b/common/math/spline_interpolation/package.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-<name>spline_interpolation</name>
-<version>0.1.0</version>
-<description>The spline interpolation package</description>
-<maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
-<author email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</author>
-  <license>Apache 2</license>
-<buildtool_depend>ament_cmake_auto</buildtool_depend>
+	<name>spline_interpolation</name>
+	<version>0.1.0</version>
+	<description>The spline interpolation package</description>
+	<maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
+	<author email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</author>
+  <license>Apache License 2.0</license>
+	<buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-<depend>rclcpp</depend>
+	<depend>rclcpp</depend>
 
-<export>
-  <build_type>ament_cmake</build_type>
-</export>
+	<test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
+	<export>
+	  <build_type>ament_cmake</build_type>
+	</export>
 </package>

--- a/common/math/spline_interpolation/package.xml
+++ b/common/math/spline_interpolation/package.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-	<name>spline_interpolation</name>
-	<version>0.1.0</version>
-	<description>The spline interpolation package</description>
-	<maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
-	<author email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</author>
+    <name>spline_interpolation</name>
+    <version>0.1.0</version>
+    <description>The spline interpolation package</description>
+    <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
+    <author email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</author>
   <license>Apache License 2.0</license>
-	<buildtool_depend>ament_cmake_auto</buildtool_depend>
+    <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-	<depend>rclcpp</depend>
+    <depend>rclcpp</depend>
 
-	<test_depend>ament_lint_auto</test_depend>
+    <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>
 
-	<export>
-	  <build_type>ament_cmake</build_type>
-	</export>
+    <export>
+      <build_type>ament_cmake</build_type>
+    </export>
 </package>


### PR DESCRIPTION
## Summary

Simple lint of the `spline_interpolation` package. Only changes were in package.xml where I fixed the indentation.

## Testing
1. Compile with the correct build flags
```
colcon build --packages-up-to spline_interpolation --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```
2. Run the linter tests
```
colcon test --packages-select spline_interpolation && colcon test-result --verbose
```
3. Run clang-tidy on the the source files from the root AutowareArchitectureProposal directory
```
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/common/math/spline_interpolation/src/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/common/math/spline_interpolation/include/spline_interpolation/*
```