### PR TITLE
ROS2 Linting: autoware_error_monitor

### DIFF
--- a/system/autoware_error_monitor/CMakeLists.txt
+++ b/system/autoware_error_monitor/CMakeLists.txt
@@ -4,6 +4,8 @@ project(autoware_error_monitor)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
@@ -23,6 +25,11 @@ ament_auto_add_executable(${PROJECT_NAME}
   src/autoware_error_monitor_node.cpp
   ${AUTOWARE_ERROR_MONITOR_SRC}
  )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 # Install
 ## executables and libraries

--- a/system/autoware_error_monitor/package.xml
+++ b/system/autoware_error_monitor/package.xml
@@ -17,6 +17,9 @@
   <exec_depend>diagnostic_aggregator</exec_depend>
   <exec_depend>rqt_robot_monitor</exec_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
## Summary 

Add linter tests to `autoware_error_monitor` package. 

## Testing
1. Compile with the correct build flags
```
colcon build --packages-up-to autoware_error_monitor --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```
2. Run the linter tests
```
colcon test --packages-select autoware_error_monitor && colcon test-result --verbose
```
3. Run clang-tidy on the the source files from the root AutowareArchitectureProposal directory
```
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/autoware_error_monitor/src/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/autoware_error_monitor/include/autoware_error_monitor/autoware_error_monitor_core.hpp
```