### PR TITLE
ROS2 Linting: autoware_state_monitor

### DIFF
--- a/system/autoware_state_monitor/CMakeLists.txt
+++ b/system/autoware_state_monitor/CMakeLists.txt
@@ -4,6 +4,8 @@ project(autoware_state_monitor)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
@@ -26,6 +28,11 @@ ament_auto_add_executable(autoware_state_monitor
   src/autoware_state_monitor_node/main.cpp
   ${AUTOWARE_STATE_MONITOR_SRC}
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/system/autoware_state_monitor/package.xml
+++ b/system/autoware_state_monitor/package.xml
@@ -26,6 +26,9 @@
   <exec_depend>autoware_perception_msgs</exec_depend>
   <exec_depend>autoware_control_msgs</exec_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/system/autoware_state_monitor/src/autoware_state_monitor_node/autoware_state_monitor_node.cpp
+++ b/system/autoware_state_monitor/src/autoware_state_monitor_node/autoware_state_monitor_node.cpp
@@ -132,7 +132,7 @@ void AutowareStateMonitorNode::onRoute(const autoware_planning_msgs::msg::Route:
   {
     geometry_msgs::msg::Pose::SharedPtr p = std::make_shared<geometry_msgs::msg::Pose>();
     *p = msg->goal_pose;
-    state_input_.goal_pose = geometry_msgs::msg::Pose::ConstPtr(p);
+    state_input_.goal_pose = geometry_msgs::msg::Pose::ConstSharedPtr(p);
   }
 
   if (disengage_on_route_) {


### PR DESCRIPTION
## Summary 

Add linter tests to `autoware_state_monitor` package. I ended up fixing one of the warning as it was using the deprecated `ConstPtr` type.

## Testing
1. Compile with the correct build flags
```
colcon build --packages-up-to autoware_state_monitor --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```
2. Run the linter tests
```
colcon test --packages-select autoware_state_monitor && colcon test-result --verbose
```
3. Run clang-tidy on the the source files from the root AutowareArchitectureProposal directory
```
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/autoware_state_monitor/src/autoware_state_monitor_node/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/autoware_state_monitor/include/autoware_state_monitor/
```