### PR TITLE
ROS2 Linting: emergency_handler

### DIFF
--- a/system/emergency_handler/CMakeLists.txt
+++ b/system/emergency_handler/CMakeLists.txt
@@ -4,6 +4,8 @@ project(emergency_handler)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
@@ -25,6 +27,11 @@ ament_auto_add_executable(${PROJECT_NAME}
   ${EMERGENCY_HANDLER_SRC}
   ${EMERGENCY_HANDLER_HEADERS}
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/system/emergency_handler/package.xml
+++ b/system/emergency_handler/package.xml
@@ -15,6 +15,9 @@
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
## Summary 

Add linter tests to `emergency_handler` package. 

## Testing
1. Compile with the correct build flags
```
colcon build --packages-up-to emergency_handler --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```
2. Run the linter tests
```
colcon test --packages-select emergency_handler && colcon test-result --verbose
```
3. Run clang-tidy on the the source files from the root AutowareArchitectureProposal directory
```
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/emergency_handler/src/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/emergency_handler/include/emergency_handler/*
```