### PR TITLE
ROS2 Linting: system_monitor

### DIFF
--- a/system/system_monitor/CMakeLists.txt
+++ b/system/system_monitor/CMakeLists.txt
@@ -4,6 +4,8 @@ project(system_monitor)
 ## Compile as C++14, supported in ROS Melodic and newer
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
@@ -151,8 +153,11 @@ target_link_libraries(gpu_monitor ${GPU_LIBRARY})
 target_link_libraries(msr_reader ${Boost_LIBRARIES})
 target_link_libraries(hdd_reader ${Boost_LIBRARIES})
 
-
-# TODO(yunus.caliskan): Port the tests to ROS2, robustify the tests, fix linter issues.
+# TODO(yunus.caliskan): Port the tests to ROS2, robustify the tests.
+if(BUILD_TESTING)                                                                                                                                                                                                  
+  find_package(ament_lint_auto REQUIRED)                                                                                                                                                                           
+  ament_lint_auto_find_test_dependencies()                                                                                                                                                                         
+endif()  
 
 #############
 ## Install ##

--- a/system/system_monitor/include/system_monitor/utils.hpp
+++ b/system/system_monitor/include/system_monitor/utils.hpp
@@ -21,6 +21,12 @@
 /// \tparam MonitorT Monitor type
 /// \param monitor_ptr Shared pointer of a monitor node to be spinned.
 /// \param period Spin period.
+
+#include <memory>
+#include <chrono>
+
+#include "rclcpp/rclcpp.hpp"
+
 template<typename MonitorT>
 void spin_and_update(const std::shared_ptr<MonitorT> & monitor_ptr, std::chrono::seconds period)
 {

--- a/system/system_monitor/package.xml
+++ b/system/system_monitor/package.xml
@@ -17,6 +17,10 @@
 
   <exec_depend>sysstat</exec_depend>
   <exec_depend>ntpdate</exec_depend>
+  
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
## Summary 

Add linter tests to `system_monitor` package. 

## Testing
1. Compile with the correct build flags
```
colcon build --packages-up-to system_monitor --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```
2. Run the linter tests
```
colcon test --packages-select system_monitor && colcon test-result --verbose
```
3. Run clang-tidy on the the source files from the root AutowareArchitectureProposal directory
```
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/system_monitor/src/cpu_monitor/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/system_monitor/src/gpu_monitor/* (error finding nvml.h)
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/system_monitor/src/hdd_monitor/* 
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/system_monitor/src/net_monitor/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/system_monitor/src/mem_monitor/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/system_monitor/src/ntp_monitor/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/system_monitor/src/process_monitor/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/system_monitor/include/hdd_reader/hdd_reader.hpp
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/system_monitor/include/msr_reader/msr_reader.hpp
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/system_monitor/include/system_monitor/system_monitor_utility.hpp
```

Note: gpu_monitor fails to find nvml headers. This might just be because my computer doesn't have a GPU.