### PR TITLE
ROS2 Linting: dummy_diag_publisher

### DIFF
--- a/system/util/dummy_diag_publisher/CMakeLists.txt
+++ b/system/util/dummy_diag_publisher/CMakeLists.txt
@@ -4,6 +4,8 @@ project(dummy_diag_publisher)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
@@ -21,6 +23,11 @@ ament_auto_add_executable(${PROJECT_NAME}
   src/dummy_diag_publisher_node/main.cpp
   ${DUMMY_DIAG_PUBLISHER_SRC}
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/system/util/dummy_diag_publisher/package.xml
+++ b/system/util/dummy_diag_publisher/package.xml
@@ -14,6 +14,9 @@
 
   <exec_depend>rqt_reconfigure</exec_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
## Summary 

Add linter tests to `dummy_diag_publisher` package. 

## Testing
1. Compile with the correct build flags
```
colcon build --packages-up-to dummy_diag_publisher --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```
2. Run the linter tests
```
colcon test --packages-select dummy_diag_publisher && colcon test-result --verbose
```
3. Run clang-tidy on the the source files from the root AutowareArchitectureProposal directory
```
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/util/dummy_diag_publisher/src/dummy_diag_publisher_node/*
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/system/util/dummy_diag_publisher/include/dummy_diag_publisher/*
```