### PR TITLE
Enable lints in velocity_controller

### DIFF
--- a/control/velocity_controller/CMakeLists.txt
+++ b/control/velocity_controller/CMakeLists.txt
@@ -6,6 +6,11 @@ ament_auto_find_build_dependencies()
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang") 
+  add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic) 
 endif()
 
 set(velocity_controller_SRC
@@ -26,6 +31,11 @@ ament_auto_add_executable(velocity_controller
   ${velocity_controller_HEADER}
   ${velocity_controller_SRC}
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE

--- a/control/velocity_controller/include/velocity_controller/velocity_controller.hpp
+++ b/control/velocity_controller/include/velocity_controller/velocity_controller.hpp
@@ -192,7 +192,7 @@ private:
   /* check condition */
   bool checkIsStopped(double current_vel, double target_vel, int closest) const;
   bool checkSmoothStop(const int closest, const double target_vel) const;
-  bool checkEmergency(int closest, double target_vel) const;
+  bool checkEmergency(int closest) const;
 
   /* reset flags */
   void resetHandling(ControlMode control_mode);

--- a/control/velocity_controller/package.xml
+++ b/control/velocity_controller/package.xml
@@ -18,6 +18,9 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
In `velocity_controller_core.cpp`, I deleted two function calls whose return value was unused, plus some minor fixes. 