### PR TITLE
Enable lints in mpc_follower

### DIFF
--- a/control/mpc_follower/CMakeLists.txt
+++ b/control/mpc_follower/CMakeLists.txt
@@ -44,6 +44,11 @@ set(MPC_FOLLOWER_HDR
 
 ament_auto_add_executable(mpc_follower ${MPC_FOLLOWER_SRC} ${MPC_FOLLOWER_HDR})
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_auto_package(
   INSTALL_TO_SHARE
     launch

--- a/control/mpc_follower/include/mpc_follower/qp_solver/qp_solver_interface.hpp
+++ b/control/mpc_follower/include/mpc_follower/qp_solver/qp_solver_interface.hpp
@@ -30,6 +30,11 @@ class QPSolverInterface
 {
 public:
   /**
+   * @brief destructor
+   */
+  virtual ~QPSolverInterface() = default;
+
+  /**
    * @brief solve QP problem : minimize J = U' * Hmat * U + fvec' * U without constraint
    * @param [in] Hmat parameter matrix in object function
    * @param [in] fvec parameter matrix in object function

--- a/control/mpc_follower/include/mpc_follower/vehicle_model/vehicle_model_interface.hpp
+++ b/control/mpc_follower/include/mpc_follower/vehicle_model/vehicle_model_interface.hpp
@@ -46,6 +46,11 @@ public:
   VehicleModelInterface(int dim_x, int dim_u, int dim_y);
 
   /**
+   * @brief destructor
+   */
+  virtual ~VehicleModelInterface() = default;
+
+  /**
    * @brief get state x dimension
    * @return state dimension
    */

--- a/control/mpc_follower/package.xml
+++ b/control/mpc_follower/package.xml
@@ -9,6 +9,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
clang-tidy again found missing virtual destructors.