### PR TITLE
[pacmod_interface] fix vehicle_info parameter loading

### DIFF
--- a/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
+++ b/vehicle/as/include/pacmod_interface/pacmod_interface.hpp
@@ -42,6 +42,7 @@
 #include "autoware_vehicle_msgs/msg/shift_stamped.hpp"
 #include "autoware_vehicle_msgs/msg/steering.hpp"
 #include "autoware_vehicle_msgs/msg/turn_signal.hpp"
+#include "vehicle_info_util/vehicle_info.hpp"
 
 class PacmodInterface : public rclcpp::Node
 {
@@ -116,6 +117,9 @@ private:
   double max_steering_wheel_rate_;     // [rad/s]
   double min_steering_wheel_rate_;     // [rad/s]
   bool enable_steering_rate_control_;  // use steering angle speed for command [rad/s]
+
+  vehicle_info_util::VehicleInfo vehicle_info_;
+
 
   /* input values */
   autoware_vehicle_msgs::msg::RawVehicleCommand::ConstSharedPtr raw_vehicle_cmd_ptr_;

--- a/vehicle/as/launch/pacmod_interface.launch.xml
+++ b/vehicle/as/launch/pacmod_interface.launch.xml
@@ -23,6 +23,8 @@
   <arg name="accel_pedal_offset" default="0.0" />
   <arg name="brake_pedal_offset" default="0.0" />
 
+  <arg name="vehicle_info_param" default="$(find-pkg-share lexus_description)/config/vehicle_info.yaml" />
+
   <!-- pacmod interface -->
   <node pkg="as" exec="pacmod_interface" name="pacmod_interface" output="screen">
     <param name="base_frame_id" value="$(var base_frame_id)" />
@@ -43,5 +45,8 @@
     <param name="vgr_coef_c" value="$(var vgr_coef_c)" />
     <param name="steering_offset" value="$(var steering_offset)" />
     <param name="enable_steering_rate_control" value="$(var enable_steering_rate_control)" />
+
+    <param from="$(var vehicle_info_param)" />
+
   </node>
 </launch>

--- a/vehicle/as/package.xml
+++ b/vehicle/as/package.xml
@@ -19,6 +19,7 @@
   <depend>message_filters</depend>
   <depend>pacmod_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>vehicle_info_util</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
+++ b/vehicle/as/src/pacmod_interface/pacmod_interface.cpp
@@ -21,7 +21,8 @@ PacmodInterface::PacmodInterface()
   is_clear_override_needed_(false),
   prev_override_(true),
   engage_cmd_(false),
-  prev_engage_cmd_(false)
+  prev_engage_cmd_(false),
+  vehicle_info_(vehicle_info_util::VehicleInfo::create(*this))
 {
   /* setup parameters */
   base_frame_id_ = declare_parameter("base_frame_id", "base_link");
@@ -29,8 +30,10 @@ PacmodInterface::PacmodInterface()
   loop_rate_ = declare_parameter("loop_rate", 30.0);
 
   /* parameters for vehicle specifications */
-  tire_radius_ = declare_parameter("vehicle_info.wheel_radius", 0.5);
-  wheel_base_ = declare_parameter("vehicle_info.wheel_base", 4.0);
+  tire_radius_ = vehicle_info_.wheel_radius_m_;
+  wheel_base_ = vehicle_info_.wheel_base_m_;
+
+
   steering_offset_ = declare_parameter("steering_offset", 0.0);
   enable_steering_rate_control_ = declare_parameter("enable_steering_rate_control", false);
 


### PR DESCRIPTION
Fix pacmod interface to use vehicle_info_util::VehicleInfo class instead of accessing to global parameter which is not available in ros2.