### PR TITLE
adding linters to dummy_perception_publisher

### DIFF
--- a/simulator/util/dummy_perception_publisher/CMakeLists.txt
+++ b/simulator/util/dummy_perception_publisher/CMakeLists.txt
@@ -4,6 +4,8 @@ project(dummy_perception_publisher)
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)

--- a/simulator/util/dummy_perception_publisher/package.xml
+++ b/simulator/util/dummy_perception_publisher/package.xml
@@ -28,6 +28,7 @@
   <depend>unique_identifier_msgs</depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
Ignored `clang-tidy` warnings in rclcpp headers.

Also there was a warning about using `double` type variable as loop counter in for loop.