### PR TITLE
adding linters to autoware_perception_rviz_plugin

### DIFF
--- a/common/util/rviz_plugins/autoware_perception_rviz_plugin/CMakeLists.txt
+++ b/common/util/rviz_plugins/autoware_perception_rviz_plugin/CMakeLists.txt
@@ -3,6 +3,8 @@ project(autoware_perception_rviz_plugin)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -31,6 +33,11 @@ target_link_libraries(autoware_perception_rviz_plugin SHARED
 
 # Export the plugin to be imported by rviz2
 pluginlib_export_plugin_description_file(rviz_common plugins/plugin_description.xml)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE

--- a/common/util/rviz_plugins/autoware_perception_rviz_plugin/package.xml
+++ b/common/util/rviz_plugins/autoware_perception_rviz_plugin/package.xml
@@ -19,6 +19,9 @@
   <depend>libqt5-widgets</depend>
   <depend>dummy_perception_publisher</depend>
   
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
     <rviz plugin="${prefix}/plugins/plugin_description.xml"/>


### PR DESCRIPTION
`clang-tidy` giving warnings in some rclcpp header files.