### PR TITLE
ROS2 Linting: autoware_api_msgs

### DIFF
--- a/awapi/autoware_api_msgs/CMakeLists.txt
+++ b/awapi/autoware_api_msgs/CMakeLists.txt
@@ -3,6 +3,8 @@ project(autoware_api_msgs)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -21,5 +23,10 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/ObstacleAvoidanceStatus.msg"
   DEPENDENCIES std_msgs geometry_msgs diagnostic_msgs autoware_planning_msgs
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_package()

--- a/awapi/autoware_api_msgs/package.xml
+++ b/awapi/autoware_api_msgs/package.xml
@@ -5,21 +5,23 @@
   <version>0.1.0</version>
   <description>The autoware_api_msgs package</description>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
+  <license>Apache License 2.0</license>
+
   <author email="tomoya.kimura@tier4.jp">Tomoya Kimura</author>
-  <license>BSD</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
-  <exec_depend>rosidl_default_runtime</exec_depend>
-  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>autoware_planning_msgs</depend>
-  
+
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/awapi/autoware_api_msgs/package.xml
+++ b/awapi/autoware_api_msgs/package.xml
@@ -17,6 +17,10 @@
   <depend>geometry_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>autoware_planning_msgs</depend>
+  
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
## Summary

Simple lint of the `autoware_api_msgs` package.

## Testing
1. Compile with the correct build flags
```
colcon build --packages-up-to autoware_api_msgs --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```
2. Run the linter tests
```
colcon test --packages-select autoware_api_msgs && colcon test-result --verbose
```
3. No C++ so no clang-tidy needed