### PR TITLE
ROS2 Linting: awapi_awiv_adapter

### DIFF
--- a/awapi/awapi_awiv_adapter/CMakeLists.txt
+++ b/awapi/awapi_awiv_adapter/CMakeLists.txt
@@ -3,6 +3,8 @@ project(awapi_awiv_adapter)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic -Werror)
@@ -21,5 +23,10 @@ ament_auto_add_executable(awapi_awiv_adapter
   src/awapi_obstacle_avoidance_state_publisher.cpp
   src/awapi_autoware_util.cpp
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(INSTALL_TO_SHARE launch)

--- a/awapi/awapi_awiv_adapter/package.xml
+++ b/awapi/awapi_awiv_adapter/package.xml
@@ -26,6 +26,8 @@
   <exec_depend>autoware_perception_msgs</exec_depend>
   <exec_depend>topic_tools</exec_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Summary

Simple lint of the `awapi_awiv_adapter` package, not changes needed apart from adding the linter tests

## Testing
1. Compile with the correct build flags
```
colcon build --packages-up-to awapi_awiv_adapter --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```
2. Run the linter tests
```
colcon test --packages-select awapi_awiv_adapter && colcon test-result --verbose
```
3. Run clang-tidy on the the source files from the root AutowareArchitectureProposal directory (this will generate warnings
```
clang-tidy -p build/compile_commands.json src/autoware/autoware.iv/awapi/awapi_awiv_adapter/src/*
```