### PR TITLE
Add linters ndt scan matcher

### DIFF
--- a/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/CMakeLists.txt
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/CMakeLists.txt
@@ -3,6 +3,8 @@ project(ndt_scan_matcher)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -16,5 +18,10 @@ ament_auto_add_executable(ndt_scan_matcher
   src/ndt_scan_matcher_node.cpp
   src/ndt_scan_matcher_core.cpp
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_auto_package(INSTALL_TO_SHARE launch)

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
-
+#include <deque>
 #include <algorithm>
 #include <cmath>
 #include <random>
 
 #include "tf2_eigen/tf2_eigen.h"
-
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include "geometry_msgs/msg/pose_array.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"

--- a/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/package.xml
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/package.xml
@@ -25,6 +25,9 @@
     <depend>tf2_sensor_msgs</depend>
     <depend>visualization_msgs</depend>
 
+    <test_depend>ament_lint_auto</test_depend>
+    <test_depend>ament_cmake_cppcheck</test_depend>
+
     <export>
       <build_type>ament_cmake</build_type>
     </export>


### PR DESCRIPTION
fixed `clang-tidy` errors