### PR TITLE
fixing clang-tidy errors in ndt_scan_matcher

### DIFF
--- a/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
+++ b/localization/pose_estimator/ndt_scan_matcher/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
-
 #include <algorithm>
 #include <cmath>
+#include <deque>
 #include <random>
 
 #include "tf2_eigen/tf2_eigen.h"
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include "geometry_msgs/msg/pose_array.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"


### PR DESCRIPTION
fixed `clang-tidy` errors in headers