### PR TITLE
[freespace_planner] add missing declaration of parameter

### DIFF
--- a/planning/scenario_planning/parking/freespace_planner/src/freespace_planner/freespace_planner_node.cpp
+++ b/planning/scenario_planning/parking/freespace_planner/src/freespace_planner/freespace_planner_node.cpp
@@ -255,6 +255,7 @@ AstarNavi::AstarNavi()
     node_param_.th_course_out_distance_m = declare_parameter("th_course_out_distance_m", 3.0);
     node_param_.replan_when_obstacle_found = declare_parameter("replan_when_obstacle_found", true);
     node_param_.replan_when_course_out = declare_parameter("replan_when_course_out", true);
+    declare_parameter("is_completed");
   }
 
   // AstarParam


### PR DESCRIPTION
Adds missing declaration of `is_completed` parameter in freespace_planner.
Without this declaration, the node dies when it tries to set the undeclared parameter.