### PR TITLE
[autoware_perception_rviz_plugin] make plugin library SHARED

### DIFF
--- a/common/util/rviz_plugins/autoware_perception_rviz_plugin/CMakeLists.txt
+++ b/common/util/rviz_plugins/autoware_perception_rviz_plugin/CMakeLists.txt
@@ -22,13 +22,13 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_definitions(-DQT_NO_KEYWORDS)
 
 ## Declare a C++ library
-ament_auto_add_library(autoware_perception_rviz_plugin
+ament_auto_add_library(autoware_perception_rviz_plugin SHARED
   src/tools/pedestrian_pose.cpp
   src/tools/car_pose.cpp
   src/tools/delete_all_objects.cpp
 )
 
-target_link_libraries(autoware_perception_rviz_plugin SHARED
+target_link_libraries(autoware_perception_rviz_plugin
   ${QT_LIBRARIES})
 
 # Export the plugin to be imported by rviz2

--- a/common/util/rviz_plugins/autoware_perception_rviz_plugin/package.xml
+++ b/common/util/rviz_plugins/autoware_perception_rviz_plugin/package.xml
@@ -18,7 +18,7 @@
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>
   <depend>dummy_perception_publisher</depend>
-  
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>
 


### PR DESCRIPTION
Fix library declaration in CMakeLists.txt.

How to review:
Make sure that you can load autoware_perception_rviz_plugin tools(e.g. CarInitialPoseTool) in rviz without error.