### PR TITLE
Fix perception launches

### DIFF
--- a/perception/object_recognition/detection/euclidean_cluster/launch/euclidean_cluster.launch.xml
+++ b/perception/object_recognition/detection/euclidean_cluster/launch/euclidean_cluster.launch.xml
@@ -1,3 +1,5 @@
+----- NOT PORTED TO ROS2 YET: SHOULD USE CONTAINER IN PYTHON -----
+
 <?xml version="1.0"?>
 
 <launch>

--- a/perception/object_recognition/detection/euclidean_cluster/launch/voxel_grid_based_euclidean_cluster.launch.xml
+++ b/perception/object_recognition/detection/euclidean_cluster/launch/voxel_grid_based_euclidean_cluster.launch.xml
@@ -1,3 +1,5 @@
+----- NOT PORTED TO ROS2 YET: SHOULD USE CONTAINER IN PYTHON -----
+
 <?xml version="1.0"?>
 
 <launch>

--- a/perception/object_recognition/detection/roi_cluster_fusion/launch/roi_cluster_fusion.launch.xml
+++ b/perception/object_recognition/detection/roi_cluster_fusion/launch/roi_cluster_fusion.launch.xml
@@ -22,19 +22,12 @@
 
 
   <node pkg="roi_cluster_fusion" exec="roi_cluster_fusion_node" name="roi_cluster_fusion">
-    <rosparam>
-            use_iou: true
-            use_iou_x: false
-            use_iou_y: false
-            iou_threshold: 0.35
-    </rosparam>
-    <!-- <rosparam>
-            use_iou: false
-            use_iou_x: true
-            use_iou_y: false
-            iou_threshold: 0.7
-        </rosparam> -->
+    <param name="use_iou" value="true"/>
+    <param name="use_iou_x" value="false"/>
+    <param name="use_iou_y" value="false"/>
+    <param name="iou_threshold" value="0.35"/>
     <remap from="clusters" to="$(var input_clusters)"/>
+
     <remap if="$(eval input_rois_number >= 1)" from="rois0" to="$(var input_rois0)"/>
     <remap if="$(eval input_rois_number >= 1)" from="camera_info0" to="$(var input_camera_info0)"/>
     <remap if="$(eval input_rois_number >= 2)" from="rois1" to="$(var input_rois1)"/>


### PR DESCRIPTION
 - Fix for `roi_cluster_fusion` launch
 - Add comment on `euclidean_cluster` launch which is not ported to ros2. Since this launch file uses a nodelet and the priority is low, I just leave a comment and create an issue for this launch file.