### PR TITLE
fix parameter in autoware_state_monitor.planning_simulation.yaml

### DIFF
--- a/system/autoware_state_monitor/config/autoware_state_monitor.planning_simulation.yaml
+++ b/system/autoware_state_monitor/config/autoware_state_monitor.planning_simulation.yaml
@@ -24,9 +24,6 @@
       names: [
         "/map/vector_map",
         "/map/pointcloud_map",
-        "/sensing/lidar/pointcloud",
-        "/sensing/lidar/no_ground/pointcloud",
-        "/localization/pose_twist_fusion_filter/pose",
         "/perception/object_recognition/detection/objects",
         "/perception/object_recognition/tracking/objects",
         "/perception/object_recognition/objects",
@@ -43,56 +40,67 @@
           module: "map"
           timeout: 0.0
           warn_rate: 0.0
+          type: "autoware_lanelet2_msgs/msg/MapBin"
 
         /map/pointcloud_map:
           module: "map"
           timeout: 0.0
           warn_rate: 0.0
+          type: "sensor_msgs/msg/PointCloud2"
 
         /perception/object_recognition/detection/objects:
           module: "perception"
           timeout: 1.0
           warn_rate: 5.0
+          type: "autoware_perception_msgs/msg/DynamicObjectWithFeatureArray"
 
         /perception/object_recognition/tracking/objects:
           module: "perception"
           timeout: 1.0
           warn_rate: 5.0
+          type: "autoware_perception_msgs/msg/DynamicObjectArray"
 
         /perception/object_recognition/objects:
           module: "perception"
           timeout: 1.0
           warn_rate: 5.0
+          type: "autoware_perception_msgs/msg/DynamicObjectArray"
 
         /planning/mission_planning/route:
           module: "planning"
           timeout: 0.0
           warn_rate: 0.0
+          type: "autoware_planning_msgs/msg/Route"
 
         /planning/scenario_planning/trajectory:
           module: "planning"
           timeout: 1.0
           warn_rate: 5.0
+          type: "autoware_planning_msgs/msg/Trajectory"
 
         /control/vehicle_cmd:
           module: "control"
           timeout: 1.0
           warn_rate: 5.0
+          type: "autoware_vehicle_msgs/msg/VehicleCommand"
 
         /vehicle/status/twist:
           module: "vehicle"
           timeout: 1.0
           warn_rate: 5.0
+          type: "geometry_msgs/msg/TwistStamped"
 
         /vehicle/status/steering:
           module: "vehicle"
           timeout: 1.0
           warn_rate: 5.0
+          type: "autoware_vehicle_msgs/msg/Steering"
 
         /system/emergency/control_cmd:
           module: "emergency_system"
           timeout: 1.0
           warn_rate: 5.0
+          type: "autoware_control_msgs/msg/ControlCommandStamped"
 
     # Param Config
     ## names: string array


### PR DESCRIPTION
This fixes parameter for planning simulator.

How to test:
`ros2 launch autoware_state_monitor autoware_state_monitor.launch.xml config_file:=<path/to/autoware_state_monitor.planning_simulation.yaml>`